### PR TITLE
MDB-15: Integrate frontend register flow and surface login success toast

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -5,6 +5,8 @@ export default {
     error: 'Error',
   },
   auth: {
+    firstName: 'First Name',
+    lastName: 'Last Name',
     appName: 'Mordobo',
     welcomeBack: 'Welcome back!',
     signInToContinue: 'Sign in to continue',
@@ -32,6 +34,7 @@ export default {
     soonApple: 'Apple Sign-In will be available soon. Please use email login for now.',
     successLogin: 'Login successful!',
     successRegister: 'Account created successfully! You can now sign in.',
+    registrationSuccessLogin: 'You are all set! Sign in with your new account.',
   },
   errors: {
     fillAllFields: 'Please complete all fields',
@@ -39,6 +42,7 @@ export default {
     passwordMin: 'Password must be at least 8 characters',
     invalidEmail: 'Please enter a valid email address',
     emailExists: 'An account with this email already exists',
+    phoneExists: 'An account with this phone number already exists',
     loginFailed: 'Incorrect email/phone or password',
     loginGeneric: 'Error while signing in',
     registerGeneric: 'Error while creating the account',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -5,6 +5,8 @@ export default {
     error: 'Error',
   },
   auth: {
+    firstName: 'Nombre',
+    lastName: 'Apellido',
     appName: 'Mordobo',
     welcomeBack: '¡Bienvenido de vuelta!',
     signInToContinue: 'Inicia sesión para continuar',
@@ -32,6 +34,7 @@ export default {
     soonApple: 'Apple Sign-In estará disponible pronto. Por ahora usa el login con email.',
     successLogin: '¡Inicio de sesión exitoso!',
     successRegister: '¡Cuenta creada exitosamente! Ahora puedes iniciar sesión.',
+    registrationSuccessLogin: '¡Listo! Inicia sesión con tu nueva cuenta.',
   },
   errors: {
     fillAllFields: 'Por favor completa todos los campos',
@@ -39,6 +42,7 @@ export default {
     passwordMin: 'La contraseña debe tener al menos 8 caracteres',
     invalidEmail: 'Por favor ingresa un email válido',
     emailExists: 'Ya existe una cuenta con este email',
+    phoneExists: 'Ya existe una cuenta con este número de teléfono',
     loginFailed: 'Email, teléfono o contraseña incorrectos',
     loginGeneric: 'Error al iniciar sesión',
     registerGeneric: 'Error al crear la cuenta',

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -1,0 +1,106 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:3000';
+
+const getBaseUrl = () => {
+  const envUrl = process.env.EXPO_PUBLIC_API_URL;
+  if (envUrl && envUrl.trim().length > 0) {
+    return envUrl.trim();
+  }
+  return DEFAULT_API_BASE_URL;
+};
+
+const buildUrl = (path: string) => {
+  const base = getBaseUrl().replace(/\/+$/, '');
+  const sanitizedPath = path.replace(/^\/+/, '');
+  return `${base}/${sanitizedPath}`;
+};
+
+export interface RegisterPayload {
+  fullName: string;
+  email: string;
+  phoneNumber: string;
+  password: string;
+}
+
+export interface RegisterResponseUser {
+  id: string;
+  full_name: string;
+  email: string;
+  phone_number: string;
+  status?: string;
+  created_at?: string;
+  [key: string]: unknown;
+}
+
+export interface RegisterResponse {
+  userType: string;
+  user: RegisterResponseUser;
+  [key: string]: unknown;
+}
+
+export class ApiError extends Error {
+  status: number;
+  data?: unknown;
+
+  constructor(message: string, status: number, data?: unknown) {
+    super(message);
+    this.status = status;
+    this.data = data;
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+}
+
+export const registerUser = async (
+  payload: RegisterPayload
+): Promise<RegisterResponse> => {
+  const body = {
+    full_name: payload.fullName,
+    email: payload.email,
+    phone_number: payload.phoneNumber,
+    password: payload.password,
+  };
+
+  try {
+    const response = await fetch(buildUrl('/auth/register'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const responseText = await response.text();
+    let responseData: unknown = undefined;
+    if (responseText) {
+      try {
+        responseData = JSON.parse(responseText);
+      } catch (parseError) {
+        responseData = responseText;
+      }
+    }
+
+    if (!response.ok) {
+      const message =
+        typeof responseData === 'object' && responseData && 'message' in responseData
+          ? String((responseData as { message: unknown }).message)
+          : `Request failed with status ${response.status}`;
+      throw new ApiError(message, response.status, responseData);
+    }
+
+    if (!responseData || typeof responseData !== 'object') {
+      throw new ApiError('Unexpected response from server.', response.status, responseData);
+    }
+
+    return responseData as RegisterResponse;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    const message =
+      error instanceof Error
+        ? error.message || 'Unable to register user. Please try again.'
+        : 'Unable to register user. Please try again.';
+
+    throw new ApiError(message, 0, error);
+  }
+};


### PR DESCRIPTION
Summary

connect register screen with services/auth to hit /auth/register and normalize backend errors (email/phone duplicados)
surface inline API errors + redirect back CTA to login when registration succeeds
show green toast on login when registered=1 arriving from register and localize new copy (EN/ES)

Testing

npm run lint

## Summary
- connect register screen with services/auth to hit /auth/register and normalize backend errors (email/phone duplicados)
- surface inline API errors + redirect back CTA to login when registration succeeds
- show green toast on login when registered=1 arriving from register and localize new copy (EN/ES)

## Testing
- [x] Register with email that exist
- [x] Register with phone number already exist
- [x] Register with password do not match
- [x] Register with password less than 8 characteres
- [x] Register succesffully (using the API )
- [x] use back button 
