### PR TITLE
feat(auth): add SMTP fallback workaround with verification code modal

### DIFF
--- a/components/VerificationCodeModal.tsx
+++ b/components/VerificationCodeModal.tsx
@@ -1,0 +1,205 @@
+import { t } from '@/i18n';
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import {
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+interface VerificationCodeModalProps {
+  visible: boolean;
+  code: string | null;
+  onClose: () => void;
+}
+
+export function VerificationCodeModal({
+  visible,
+  code,
+  onClose,
+}: VerificationCodeModalProps) {
+  if (!code) {
+    return null;
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.modalContainer}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View style={styles.iconContainer}>
+              <Ionicons name="mail-outline" size={32} color="#3B82F6" />
+            </View>
+            <TouchableOpacity
+              style={styles.closeButton}
+              onPress={onClose}
+              accessibilityLabel={t('common.close')}
+            >
+              <Ionicons name="close" size={24} color="#6B7280" />
+            </TouchableOpacity>
+          </View>
+
+          {/* Content */}
+          <View style={styles.content}>
+            <Text style={styles.title}>
+              {t('auth.smtpFailedTitle')}
+            </Text>
+            <Text style={styles.message}>
+              {t('auth.smtpFailedMessage')}
+            </Text>
+
+            {/* Code Display */}
+            <View style={styles.codeContainer}>
+              <Text style={styles.codeLabel}>
+                {t('auth.verificationCode')}
+              </Text>
+              <View style={styles.codeBox}>
+                <Text style={styles.codeText}>{code}</Text>
+              </View>
+            </View>
+
+            <Text style={styles.note}>
+              {t('auth.smtpFailedNote')}
+            </Text>
+          </View>
+
+          {/* Footer */}
+          <View style={styles.footer}>
+            <TouchableOpacity
+              style={styles.button}
+              onPress={onClose}
+            >
+              <Text style={styles.buttonText}>
+                {t('common.ok')}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  modalContainer: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    width: '100%',
+    maxWidth: 400,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.3,
+        shadowRadius: 8,
+      },
+      android: {
+        elevation: 8,
+      },
+    }),
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  iconContainer: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: '#EFF6FF',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeButton: {
+    padding: 4,
+  },
+  content: {
+    padding: 20,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#1F2937',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  message: {
+    fontSize: 16,
+    color: '#6B7280',
+    marginBottom: 24,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  codeContainer: {
+    marginBottom: 20,
+  },
+  codeLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#374151',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  codeBox: {
+    backgroundColor: '#F3F4F6',
+    borderRadius: 12,
+    padding: 20,
+    borderWidth: 2,
+    borderColor: '#3B82F6',
+    borderStyle: 'dashed',
+  },
+  codeText: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: '#3B82F6',
+    textAlign: 'center',
+    letterSpacing: 8,
+  },
+  note: {
+    fontSize: 14,
+    color: '#9CA3AF',
+    textAlign: 'center',
+    fontStyle: 'italic',
+    lineHeight: 20,
+  },
+  footer: {
+    padding: 20,
+    paddingTop: 0,
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+  },
+  button: {
+    backgroundColor: '#3B82F6',
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -3,6 +3,7 @@ export default {
     ok: 'OK',
     cancel: 'Cancel',
     error: 'Error',
+    close: 'Close',
   },
   auth: {
     firstName: 'First Name',
@@ -49,6 +50,10 @@ export default {
     verifyAccount: 'Verify Account',
     resendCode: 'Resend code',
     resendIn: 'Resend in',
+    smtpFailedTitle: 'Email Service Unavailable',
+    smtpFailedMessage: 'We couldn\'t send the verification code to your email, but here is your code:',
+    verificationCode: 'Verification Code',
+    smtpFailedNote: 'This is a temporary workaround. Please configure SMTP to enable email delivery.',
   },
   errors: {
     useAuthHookError: 'useAuth must be used within an AuthProvider',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -3,6 +3,7 @@ export default {
     ok: 'Aceptar',
     cancel: 'Cancelar',
     error: 'Error',
+    close: 'Cerrar',
   },
   auth: {
     firstName: 'Nombre',
@@ -49,6 +50,10 @@ export default {
     verifyAccount: 'Verificar cuenta',
     resendCode: 'Reenviar código',
     resendIn: 'Reenviar en',
+    smtpFailedTitle: 'Servicio de Correo No Disponible',
+    smtpFailedMessage: 'No pudimos enviar el código de verificación a tu correo, pero aquí está tu código:',
+    verificationCode: 'Código de Verificación',
+    smtpFailedNote: 'Esta es una solución temporal. Por favor configura SMTP para habilitar el envío de correos.',
   },
   errors: {
     useAuthHookError: 'useAuth debe ser usado dentro de un AuthProvider',


### PR DESCRIPTION
- Add VerificationCodeModal component to display code when SMTP fails
- Update register, login, and verify screens to show modal on SMTP errors
- Add translations for SMTP failure modal (en/es)
- Backend now returns verificationCode in error response when SMTP fails
- This allows users to continue verification flow even when email service is unavailable