### PR TITLE
feat(auth): implement onboarding screens and login count tracking

### DIFF
--- a/app/(auth)/index.tsx
+++ b/app/(auth)/index.tsx
@@ -1,6 +1,7 @@
 import { Redirect } from 'expo-router';
 
 export default function AuthIndex() {
-  // Automatically redirect to the login screen
+  // Always redirect to login screen
+  // Welcome screen will be shown after successful login if it's the first time
   return <Redirect href="/(auth)/login" />;
 }

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -99,7 +99,24 @@ export default function LoginScreen() {
         provider: userData.provider,
       });
       await login(userData);
-      router.replace('/(tabs)/home');
+      
+      // Check if this is the first login using login_count from backend
+      // Note: Google login doesn't go through verification code, so login_count might be 0 or undefined
+      // For Google users, we'll check if they have any login_count or if it's their first time
+      // Since Google login doesn't increment login_count (only verification code does),
+      // we'll show onboarding if login_count is 0 or undefined (new user)
+      const loginCount = (userData as Record<string, unknown>).loginCount as number | undefined;
+      // For Google login, if login_count is 0 or undefined, it's a new user (first login)
+      // If login_count is 1, it means they've logged in once via email verification before
+      const isFirstLogin = loginCount === 0 || loginCount === undefined;
+      
+      if (isFirstLogin) {
+        // Navigate to onboarding screens for first-time users
+        router.replace('/(auth)/onboarding');
+      } else {
+        // Navigate to home on success
+        router.replace('/(tabs)/home');
+      }
     },
     [login]
   );

--- a/app/(auth)/onboarding.tsx
+++ b/app/(auth)/onboarding.tsx
@@ -1,0 +1,280 @@
+import { t } from '@/i18n';
+import { router } from 'expo-router';
+import { useState } from 'react';
+import {
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+const ONBOARDING_SCREENS = 3;
+
+export default function OnboardingScreen() {
+  const [currentScreen, setCurrentScreen] = useState(1);
+
+  const handleNext = () => {
+    if (currentScreen < ONBOARDING_SCREENS) {
+      setCurrentScreen(currentScreen + 1);
+    } else {
+      // Last screen - go to home
+      router.replace('/(tabs)/home');
+    }
+  };
+
+  const handleSkip = () => {
+    // Skip all onboarding screens and go to home
+    router.replace('/(tabs)/home');
+  };
+
+  const renderScreen = () => {
+    switch (currentScreen) {
+      case 1:
+        return (
+          <View style={styles.screenContent}>
+            {/* Icon Container */}
+            <View style={styles.iconContainer}>
+              <LinearGradient
+                colors={['rgba(59, 130, 246, 0.3)', 'rgba(16, 185, 129, 0.3)']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={styles.iconGradient}
+              >
+                <Text style={styles.iconEmoji}>🏠</Text>
+              </LinearGradient>
+            </View>
+
+            {/* Title and Description */}
+            <Text style={styles.title}>{t('auth.onboarding.screen1.title')}</Text>
+            <Text style={styles.description}>
+              {t('auth.onboarding.screen1.description')}
+            </Text>
+
+            {/* Pagination Dots */}
+            <View style={styles.pagination}>
+              <View style={[styles.dot, styles.dotActive]} />
+              <View style={styles.dot} />
+              <View style={styles.dot} />
+            </View>
+
+            {/* Button */}
+            <TouchableOpacity style={[styles.button, styles.primaryButton]} onPress={handleNext}>
+              <Text style={styles.primaryButtonText}>{t('auth.onboarding.screen1.next')}</Text>
+            </TouchableOpacity>
+          </View>
+        );
+
+      case 2:
+        return (
+          <View style={styles.screenContent}>
+            {/* Icon Container */}
+            <View style={styles.iconContainer}>
+              <LinearGradient
+                colors={['rgba(16, 185, 129, 0.3)', 'rgba(245, 158, 11, 0.3)']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={styles.iconGradient}
+              >
+                <Text style={styles.iconEmoji}>⭐</Text>
+                {/* Verification checkmark */}
+                <View style={[styles.iconBadge, styles.iconBadgeSmall, { top: 40, right: 40, backgroundColor: 'rgba(16, 185, 129, 0.4)' }]}>
+                  <Text style={styles.badgeEmojiSmall}>✓</Text>
+                </View>
+                {/* Shield icon */}
+                <View style={[styles.iconBadge, styles.iconBadgeMedium, { bottom: 50, left: 30, backgroundColor: 'rgba(245, 158, 11, 0.4)' }]}>
+                  <Text style={styles.badgeEmojiMedium}>🛡️</Text>
+                </View>
+              </LinearGradient>
+            </View>
+
+            {/* Title and Description */}
+            <Text style={styles.title}>{t('auth.onboarding.screen2.title')}</Text>
+            <Text style={styles.description}>
+              {t('auth.onboarding.screen2.description')}
+            </Text>
+
+            {/* Pagination Dots */}
+            <View style={styles.pagination}>
+              <View style={styles.dot} />
+              <View style={[styles.dot, styles.dotActive, { backgroundColor: '#10B981' }]} />
+              <View style={styles.dot} />
+            </View>
+
+            {/* Button */}
+            <TouchableOpacity style={[styles.button, { backgroundColor: '#10B981' }]} onPress={handleNext}>
+              <Text style={styles.primaryButtonText}>{t('auth.onboarding.screen2.next')}</Text>
+            </TouchableOpacity>
+          </View>
+        );
+
+      case 3:
+        return (
+          <View style={styles.screenContent}>
+            {/* Icon Container */}
+            <View style={styles.iconContainer}>
+              <LinearGradient
+                colors={['rgba(245, 158, 11, 0.3)', 'rgba(236, 72, 153, 0.3)']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={styles.iconGradient}
+              >
+                <Text style={styles.iconEmoji}>💳</Text>
+                {/* Lock icon */}
+                <View style={[styles.iconBadge, styles.iconBadgeSmall, { top: 30, left: 50, backgroundColor: 'rgba(245, 158, 11, 0.4)' }]}>
+                  <Text style={styles.badgeEmojiSmall}>🔒</Text>
+                </View>
+                {/* Money bag icon */}
+                <View style={[styles.iconBadge, styles.iconBadgeMedium, { bottom: 40, right: 40, backgroundColor: 'rgba(236, 72, 153, 0.4)' }]}>
+                  <Text style={styles.badgeEmojiMedium}>💰</Text>
+                </View>
+              </LinearGradient>
+            </View>
+
+            {/* Title and Description */}
+            <Text style={styles.title}>{t('auth.onboarding.screen3.title')}</Text>
+            <Text style={styles.description}>
+              {t('auth.onboarding.screen3.description')}
+            </Text>
+
+            {/* Pagination Dots */}
+            <View style={styles.pagination}>
+              <View style={styles.dot} />
+              <View style={styles.dot} />
+              <View style={[styles.dot, styles.dotActive, { backgroundColor: '#F59E0B' }]} />
+            </View>
+
+            {/* Button - Only "Get Started" on last screen */}
+            <TouchableOpacity style={[styles.button, { backgroundColor: '#F59E0B' }]} onPress={handleNext}>
+              <Text style={styles.primaryButtonText}>{t('auth.onboarding.screen3.getStarted')}</Text>
+            </TouchableOpacity>
+          </View>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {/* Skip button in top right corner - only show on screens 1 and 2 */}
+      {currentScreen < ONBOARDING_SCREENS && (
+        <TouchableOpacity style={styles.skipButtonTop} onPress={handleSkip}>
+          <Text style={styles.skipButtonText}>{t('auth.onboarding.screen1.skip')}</Text>
+        </TouchableOpacity>
+      )}
+      {renderScreen()}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  screenContent: {
+    flex: 1,
+    paddingHorizontal: 30,
+    paddingTop: 20,
+    paddingBottom: 40,
+    justifyContent: 'center',
+  },
+  iconContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 40,
+  },
+  iconGradient: {
+    width: 280,
+    height: 280,
+    borderRadius: 140,
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+  },
+  iconEmoji: {
+    fontSize: 120,
+  },
+  iconBadge: {
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconBadgeSmall: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+  },
+  iconBadgeMedium: {
+    width: 45,
+    height: 45,
+    borderRadius: 22.5,
+  },
+  badgeEmojiSmall: {
+    fontSize: 24,
+  },
+  badgeEmojiMedium: {
+    fontSize: 20,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  description: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#9CA3AF',
+    textAlign: 'center',
+    marginBottom: 40,
+  },
+  pagination: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 8,
+    marginBottom: 30,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#252542',
+  },
+  dotActive: {
+    width: 24,
+    backgroundColor: '#3B82F6',
+  },
+  button: {
+    width: '100%',
+    paddingVertical: 18,
+    borderRadius: 14,
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  primaryButton: {
+    backgroundColor: '#3B82F6',
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  skipButtonTop: {
+    position: 'absolute',
+    top: 50,
+    right: 20,
+    zIndex: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  skipButtonText: {
+    color: '#9CA3AF',
+    fontSize: 14,
+  },
+});

--- a/app/(auth)/verify.tsx
+++ b/app/(auth)/verify.tsx
@@ -181,8 +181,17 @@ export default function VerifyScreen() {
         'pending_verification_password',
       ]);
 
-      // Navigate to home on success
-      router.replace('/(tabs)/home');
+      // Check if this is the first login using login_count from backend
+      const loginCount = (apiUser as Record<string, unknown>).login_count as number | undefined;
+      const isFirstLogin = loginCount === 1 || loginCount === undefined;
+      
+      if (isFirstLogin) {
+        // Navigate to onboarding screens for first-time users
+        router.replace('/(auth)/onboarding');
+      } else {
+        // Navigate to home on success
+        router.replace('/(tabs)/home');
+      }
     } catch (error) {
       console.error('Verification error:', error);
       console.error('Error details:', {

--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -1,0 +1,437 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { t } from '@/i18n';
+// Note: We no longer use markWelcomeScreenAsSeen - login_count is managed by backend
+import { registerGoogleAccountOrFallback, type GoogleAuthTokens } from '@/utils/googleAuth';
+import { type GoogleProfile } from '@/utils/authMapping';
+import {
+  consumePendingGoogleWebResult,
+  getGoogleStatusCodes,
+  isGoogleWebAvailable,
+  signInWithGoogleWeb,
+  signInWithGoogleMobile,
+  WEB_RESULT_STORAGE_KEY,
+} from '@/utils/googleSignIn';
+import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { router } from 'expo-router';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import MordoboLogo from '@/components/MordoboLogo';
+import { ApiError } from '@/services/auth';
+
+export default function WelcomeScreen() {
+  const { login, isAuthenticated } = useAuth();
+  const [googleLoading, setGoogleLoading] = useState(false);
+  const webGoogleSupported = isGoogleWebAvailable();
+  const isGoogleSupported = webGoogleSupported;
+
+  const handleSignIn = async () => {
+    if (isAuthenticated) {
+      // If already authenticated, go to home
+      router.replace('/(tabs)/home');
+    } else {
+      // If not authenticated, go to login
+      router.push('/(auth)/login');
+    }
+  };
+
+  const handleCreateAccount = async () => {
+    if (isAuthenticated) {
+      // If already authenticated, go to home
+      router.replace('/(tabs)/home');
+    } else {
+      // If not authenticated, go to register
+      router.push('/(auth)/register');
+    }
+  };
+
+  const handleContinue = async () => {
+    // Continue to home (login_count is already incremented by backend)
+    router.replace('/(tabs)/home');
+  };
+
+  const handleGoogleError = useCallback((error: unknown) => {
+    if (error instanceof ApiError) {
+      const message = error.message?.length ? error.message : t('errors.googleLoginGeneric');
+      Alert.alert(t('common.error'), message);
+      return;
+    }
+
+    if (error instanceof Error) {
+      switch (error.message) {
+        case 'google-web-signin-cancelled':
+          return;
+        case 'google-web-missing-id-token':
+        case 'google-missing-id-token':
+          Alert.alert(t('common.error'), t('errors.googleMissingIdToken'));
+          return;
+        case 'google-web-state-mismatch':
+          Alert.alert(t('common.error'), t('errors.googleLoginGeneric'));
+          return;
+        case 'google-missing-web-client-id':
+        case 'google-web-not-supported':
+          Alert.alert(t('common.error'), t('errors.googleUnavailable'));
+          return;
+        default:
+          Alert.alert(t('common.error'), t('errors.googleLoginGeneric'));
+          return;
+      }
+    }
+
+    Alert.alert(t('common.error'), t('errors.googleLoginGeneric'));
+  }, []);
+
+  const finalizeGoogleLogin = useCallback(
+    async (profile: GoogleProfile, tokens: GoogleAuthTokens) => {
+      console.log('[WelcomeScreen][GoogleLogin] Finalizing Google login', {
+        email: profile.email,
+        hasIdToken: !!tokens.idToken,
+        hasAccessToken: !!tokens.accessToken,
+      });
+      // Note: login_count is managed by backend, no need to mark welcome screen
+      const userData = await registerGoogleAccountOrFallback(profile, tokens);
+      console.log('[WelcomeScreen][GoogleLogin] registerGoogleAccountOrFallback resolved', {
+        userId: userData.id,
+        provider: userData.provider,
+      });
+      await login(userData);
+      // Navigate to home after successful login
+      router.replace('/(tabs)/home');
+    },
+    [login]
+  );
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') {
+      console.log('[WelcomeScreen][GoogleLogin] Skipping pending web result because platform is', Platform.OS);
+      return;
+    }
+
+    let isMounted = true;
+
+    const maybeConsumePendingLogin = async () => {
+      try {
+        const pendingResult = await consumePendingGoogleWebResult();
+        console.log('[WelcomeScreen][GoogleLogin] Pending result from redirect:', pendingResult);
+        if (!pendingResult || !isMounted) {
+          if (!pendingResult) {
+            console.log('[WelcomeScreen][GoogleLogin] No pending Google result detected in URL hash.');
+          }
+          return;
+        }
+        setGoogleLoading(true);
+        const profile: GoogleProfile = {
+          id: pendingResult.user.id,
+          email: pendingResult.user.email,
+          name: pendingResult.user.name,
+          givenName: pendingResult.user.givenName,
+          familyName: pendingResult.user.familyName,
+          photo: pendingResult.user.photo,
+        };
+        const tokens: GoogleAuthTokens = {
+          idToken: pendingResult.idToken,
+          accessToken: pendingResult.accessToken,
+        };
+        await finalizeGoogleLogin(profile, tokens);
+      } catch (error) {
+        if (isMounted) {
+          handleGoogleError(error);
+        }
+      } finally {
+        if (isMounted) {
+          setGoogleLoading(false);
+        }
+      }
+    };
+
+    void maybeConsumePendingLogin();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === WEB_RESULT_STORAGE_KEY && event.newValue) {
+        console.log('[WelcomeScreen][GoogleLogin] Storage event detected for Google OAuth result. Retrying consumption.');
+        void maybeConsumePendingLogin();
+      }
+    };
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', handleStorage);
+    }
+
+    return () => {
+      isMounted = false;
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('storage', handleStorage);
+      }
+    };
+  }, [finalizeGoogleLogin, handleGoogleError]);
+
+  const handleGoogleLogin = async () => {
+    console.log('[WelcomeScreen][GoogleLogin] Platform:', Platform.OS, 'isGoogleWebAvailable:', webGoogleSupported);
+    
+    setGoogleLoading(true);
+    try {
+      let result;
+      
+      if (Platform.OS === 'web') {
+        result = await signInWithGoogleWeb();
+        console.log('[WelcomeScreen][GoogleLogin] signInWithGoogleWeb result:', result);
+        if (!result) {
+          console.log('[WelcomeScreen][GoogleLogin] Web flow initiated; waiting for storage event.');
+          return;
+        }
+      } else {
+        // Móvil: usar expo-auth-session
+        result = await signInWithGoogleMobile();
+        console.log('[WelcomeScreen][GoogleLogin] signInWithGoogleMobile result:', result);
+      }
+
+      const profile: GoogleProfile = {
+        id: result.user.id,
+        email: result.user.email,
+        name: result.user.name,
+        givenName: result.user.givenName,
+        familyName: result.user.familyName,
+        photo: result.user.photo,
+      };
+      const tokens: GoogleAuthTokens = {
+        idToken: result.idToken,
+        accessToken: result.accessToken,
+      };
+      await finalizeGoogleLogin(profile, tokens);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('cancelled')) {
+        // Usuario canceló, no mostrar error
+        return;
+      }
+
+      if (error instanceof ApiError) {
+        const message = error.message?.length ? error.message : t('errors.googleLoginGeneric');
+        Alert.alert(t('common.error'), message);
+        return;
+      }
+
+      if (error instanceof Error && error.message === 'google-missing-id-token') {
+        Alert.alert(t('common.error'), t('errors.googleMissingIdToken'));
+        return;
+      }
+
+      console.error('Google login error:', error);
+      Alert.alert(t('common.error'), t('errors.googleLoginGeneric'));
+    } finally {
+      setGoogleLoading(false);
+    }
+  };
+
+  const handleAppleLogin = async () => {
+    Alert.alert(t('common.ok'), t('auth.soonApple'));
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        {/* Logo with gradient */}
+        <View style={styles.logoContainer}>
+          <LinearGradient
+            colors={['#3B82F6', '#10B981']}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.logoGradient}
+          >
+            <MordoboLogo size={60} />
+          </LinearGradient>
+        </View>
+
+        {/* Title and Subtitle */}
+        <Text style={styles.title}>{t('auth.welcomeTitle')}</Text>
+        <Text style={styles.subtitle}>{t('auth.welcomeSubtitle')}</Text>
+
+        {isAuthenticated ? (
+          // If user is already authenticated (first login), show Continue button
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={handleContinue}
+          >
+            <Text style={styles.primaryButtonText}>{t('auth.getStarted')}</Text>
+          </TouchableOpacity>
+        ) : (
+          // If user is not authenticated, show Sign In and Create Account buttons
+          <>
+            {/* Primary Button - Sign In */}
+            <TouchableOpacity
+              style={styles.primaryButton}
+              onPress={handleSignIn}
+            >
+              <Text style={styles.primaryButtonText}>{t('auth.signIn')}</Text>
+            </TouchableOpacity>
+
+            {/* Secondary Button - Create Account */}
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={handleCreateAccount}
+            >
+              <Text style={styles.secondaryButtonText}>{t('auth.createAccount')}</Text>
+            </TouchableOpacity>
+
+            {/* Divider */}
+            <View style={styles.dividerContainer}>
+              <View style={styles.dividerLine} />
+              <Text style={styles.dividerText}>{t('auth.orContinueWith')}</Text>
+              <View style={styles.dividerLine} />
+            </View>
+
+            {/* Social Auth Buttons */}
+            <View style={styles.socialContainer}>
+              <TouchableOpacity
+                style={styles.socialButton}
+                onPress={handleGoogleLogin}
+                disabled={googleLoading || !isGoogleSupported}
+              >
+                {googleLoading ? (
+                  <ActivityIndicator color="#4285F4" />
+                ) : (
+                  <View style={styles.socialButtonContent}>
+                    <Ionicons name="logo-google" size={20} color="#4285F4" />
+                    <Text style={styles.socialButtonText}>{t('auth.google')}</Text>
+                  </View>
+                )}
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.socialButton} onPress={handleAppleLogin}>
+                <View style={styles.socialButtonContent}>
+                  <Ionicons name="logo-apple" size={20} color="#FFFFFF" />
+                  <Text style={styles.socialButtonText}>{t('auth.apple')}</Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+          </>
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 30,
+    paddingTop: 60,
+    paddingBottom: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  logoContainer: {
+    marginBottom: 24,
+  },
+  logoGradient: {
+    width: 120,
+    height: 120,
+    borderRadius: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#3B82F6',
+    shadowOffset: {
+      width: 0,
+      height: 10,
+    },
+    shadowOpacity: 0.3,
+    shadowRadius: 20,
+    elevation: 10,
+  },
+  title: {
+    fontSize: 36,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#9CA3AF',
+    marginBottom: 40,
+    textAlign: 'center',
+  },
+  primaryButton: {
+    width: '100%',
+    backgroundColor: '#3B82F6',
+    borderRadius: 14,
+    paddingVertical: 18,
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  secondaryButton: {
+    width: '100%',
+    backgroundColor: 'transparent',
+    borderWidth: 2,
+    borderColor: '#3B82F6',
+    borderRadius: 14,
+    paddingVertical: 18,
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  secondaryButtonText: {
+    color: '#3B82F6',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  dividerContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+    marginBottom: 24,
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: '#374151',
+  },
+  dividerText: {
+    color: '#9CA3AF',
+    fontSize: 14,
+    paddingHorizontal: 16,
+  },
+  socialContainer: {
+    flexDirection: 'row',
+    gap: 12,
+    width: '100%',
+  },
+  socialButton: {
+    flex: 1,
+    backgroundColor: '#252542',
+    borderRadius: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    borderWidth: 1,
+    borderColor: '#374151',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  socialButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  socialButtonText: {
+    fontSize: 14,
+    fontWeight: '400',
+    color: '#FFFFFF',
+  },
+});

--- a/app/profile/settings.tsx
+++ b/app/profile/settings.tsx
@@ -7,20 +7,19 @@ import {
   deleteAccount,
   disable2FA,
   enable2FA,
-  getSettings,
   getSessions,
+  getSettings,
   requestDataExport,
   revokeSession,
   updateSettings,
   validatePassword,
   verify2FA,
-  type UserSettings,
   type UserSession,
+  type UserSettings,
 } from '@/services/settings';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   ActivityIndicator,
   Alert,
@@ -36,7 +35,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { Image } from 'expo-image';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface SettingsSection {
   title: string;
@@ -559,6 +558,27 @@ export default function SettingsScreen() {
     } catch (error) {
       console.error('[Settings] Failed to update language:', error);
       Alert.alert(t('common.error'), t('errors.updateSettingsFailed'));
+    } finally {
+      setUpdating(null);
+    }
+  };
+
+  const handleToggle = async (key: keyof UserSettings, value: boolean) => {
+    if (!settings) return;
+    
+    try {
+      setUpdating(key);
+      const updatedSettings = { ...settings, [key]: value };
+      await updateSettings(updatedSettings);
+      setSettings(updatedSettings);
+      setToastMessage(t('settings.settingsUpdated'));
+      setToastType('success');
+      setToastVisible(true);
+    } catch (error) {
+      console.error('[Settings] Failed to update setting:', error);
+      setToastMessage(t('errors.updateSettingsFailed'));
+      setToastType('error');
+      setToastVisible(true);
     } finally {
       setUpdating(null);
     }

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -66,6 +66,28 @@ export default {
     passwordRequirements: 'Minimum 8 characters',
     alreadyHaveAccount: 'Already have an account?',
     signIn: 'Sign in',
+    welcomeTitle: 'Mordobo',
+    welcomeSubtitle: 'Home services at your fingertips',
+    getStarted: 'Get Started',
+    onboarding: {
+      screen1: {
+        title: 'Services at your door',
+        description: 'Find verified professionals for any service in your home',
+        next: 'Next',
+        skip: 'Skip',
+      },
+      screen2: {
+        title: 'Verified professionals',
+        description: 'All our providers go through a verification process and have real customer reviews',
+        next: 'Next',
+        skip: 'Skip',
+      },
+      screen3: {
+        title: 'Secure payment',
+        description: 'Pay securely with your preferred method. Your money is protected until the service is completed',
+        getStarted: 'Get Started',
+      },
+    },
   },
   errors: {
     useAuthHookError: 'useAuth must be used within an AuthProvider',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -66,6 +66,28 @@ export default {
     passwordRequirements: 'Mínimo 8 caracteres',
     alreadyHaveAccount: '¿Ya tienes cuenta?',
     signIn: 'Inicia sesión',
+    welcomeTitle: 'Mordobo',
+    welcomeSubtitle: 'Servicios del hogar a tu alcance',
+    getStarted: 'Comenzar',
+    onboarding: {
+      screen1: {
+        title: 'Servicios a tu puerta',
+        description: 'Encuentra profesionales verificados para cualquier servicio en tu hogar',
+        next: 'Siguiente',
+        skip: 'Saltar',
+      },
+      screen2: {
+        title: 'Profesionales verificados',
+        description: 'Todos nuestros proveedores pasan por un proceso de verificación y tienen reseñas reales de clientes',
+        next: 'Siguiente',
+        skip: 'Saltar',
+      },
+      screen3: {
+        title: 'Pago seguro',
+        description: 'Paga de forma segura con tu método preferido. Tu dinero está protegido hasta que el servicio se complete',
+        getStarted: 'Comenzar',
+      },
+    },
   },
   errors: {
     useAuthHookError: 'useAuth debe ser usado dentro de un AuthProvider',

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-image-picker": "^17.0.10",
+        "expo-linear-gradient": "^15.0.8",
         "expo-linking": "~8.0.11",
         "expo-localization": "~17.0.8",
         "expo-router": "~6.0.21",
@@ -6002,6 +6003,16 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-image-picker": "^17.0.10",
+    "expo-linear-gradient": "^15.0.8",
     "expo-linking": "~8.0.11",
     "expo-localization": "~17.0.8",
     "expo-router": "~6.0.21",

--- a/utils/authMapping.ts
+++ b/utils/authMapping.ts
@@ -69,6 +69,9 @@ export const mapAuthResponseToUser = (
 ): User => {
   const apiUser = response.user;
   const { firstName, lastName } = resolveName(apiUser, googleUser);
+  
+  // Extract login_count from API response if available
+  const loginCount = (apiUser as Record<string, unknown>).login_count as number | undefined;
 
   return {
     id: stringOrUndefined(apiUser.id) ?? stringOrUndefined(googleUser?.id) ?? '',
@@ -86,5 +89,7 @@ export const mapAuthResponseToUser = (
     provider,
     authToken: stringOrUndefined(response.token),
     refreshToken: stringOrUndefined(response.refreshToken),
-  };
+    // Store login_count as a custom property (not in User interface, but accessible)
+    loginCount,
+  } as User & { loginCount?: number };
 };

--- a/utils/firstLogin.ts
+++ b/utils/firstLogin.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const FIRST_LOGIN_KEY = 'has_seen_welcome_screen';
+
+/**
+ * Checks if the user has seen the welcome screen before
+ * @returns Promise<boolean> - true if user has seen welcome screen, false if it's their first time
+ */
+export const hasSeenWelcomeScreen = async (): Promise<boolean> => {
+  try {
+    const value = await AsyncStorage.getItem(FIRST_LOGIN_KEY);
+    return value === 'true';
+  } catch (error) {
+    console.error('Error checking welcome screen status:', error);
+    // Default to showing welcome screen if there's an error
+    return false;
+  }
+};
+
+/**
+ * Marks that the user has seen the welcome screen
+ */
+export const markWelcomeScreenAsSeen = async (): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(FIRST_LOGIN_KEY, 'true');
+  } catch (error) {
+    console.error('Error marking welcome screen as seen:', error);
+  }
+};
+
+/**
+ * Resets the welcome screen status (useful for testing or logout)
+ */
+export const resetWelcomeScreenStatus = async (): Promise<void> => {
+  try {
+    await AsyncStorage.removeItem(FIRST_LOGIN_KEY);
+  } catch (error) {
+    console.error('Error resetting welcome screen status:', error);
+  }
+};


### PR DESCRIPTION
- Add 3 onboarding screens (Services, Verified Professionals, Secure Payment)
- Implement login_count tracking in backend database
- Replace AsyncStorage welcome screen check with backend login_count
- Add welcome screen component with social auth options
- Fix handleToggle function in settings screen
- Add i18n translations for onboarding screens
- Update auth flow to show onboarding on first login (login_count === 1)