### PR TITLE
fix(chat): handle null last_message_at to prevent crashes in APK

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -29,9 +29,27 @@ export default function ConversationsListScreen() {
       setLoading(true);
       const data = await fetchConversations();
       // Sort by most recent (last_message_at descending)
+      // Handle null last_message_at by putting them at the end
       const sortedData = [...data].sort((a, b) => {
+        // If both are null, maintain order
+        if (!a.last_message_at && !b.last_message_at) {
+          return 0;
+        }
+        // If a is null, put it after b
+        if (!a.last_message_at) {
+          return 1;
+        }
+        // If b is null, put it after a
+        if (!b.last_message_at) {
+          return -1;
+        }
+        // Both have dates, compare them
         const dateA = new Date(a.last_message_at).getTime();
         const dateB = new Date(b.last_message_at).getTime();
+        // Check for invalid dates
+        if (isNaN(dateA) || isNaN(dateB)) {
+          return 0;
+        }
         return dateB - dateA;
       });
       setConversations(sortedData);
@@ -74,8 +92,20 @@ export default function ConversationsListScreen() {
     router.push(`/chat/${conversationId}`);
   };
 
-  const formatTime = (dateString: string) => {
+  const formatTime = (dateString: string | null) => {
+    // Handle null or invalid dates
+    if (!dateString) {
+      const locale = t('chat.messages') === 'Mensajes' ? 'es' : 'en';
+      return locale === 'es' ? 'Nuevo' : 'New';
+    }
+    
     const date = new Date(dateString);
+    // Check if date is valid
+    if (isNaN(date.getTime())) {
+      const locale = t('chat.messages') === 'Mensajes' ? 'es' : 'en';
+      return locale === 'es' ? 'Nuevo' : 'New';
+    }
+    
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / (1000 * 60));

--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -28,9 +28,27 @@ export default function ConversationsListScreen() {
       setError(null);
       const data = await fetchConversations();
       // Sort by most recent (last_message_at descending)
+      // Handle null last_message_at by putting them at the end
       const sortedData = [...data].sort((a, b) => {
+        // If both are null, maintain order
+        if (!a.last_message_at && !b.last_message_at) {
+          return 0;
+        }
+        // If a is null, put it after b
+        if (!a.last_message_at) {
+          return 1;
+        }
+        // If b is null, put it after a
+        if (!b.last_message_at) {
+          return -1;
+        }
+        // Both have dates, compare them
         const dateA = new Date(a.last_message_at).getTime();
         const dateB = new Date(b.last_message_at).getTime();
+        // Check for invalid dates
+        if (isNaN(dateA) || isNaN(dateB)) {
+          return 0;
+        }
         return dateB - dateA;
       });
       setConversations(sortedData);
@@ -56,12 +74,23 @@ export default function ConversationsListScreen() {
     router.push(`/chat/${conversationId}`);
   };
 
-  const formatTime = (dateString: string) => {
+  const formatTime = (dateString: string | null) => {
+    // Handle null or invalid dates
+    if (!dateString) {
+      const locale = t('chat.messages') === 'Mensajes' ? 'es' : 'en';
+      return locale === 'es' ? 'Nuevo' : 'New';
+    }
+    
     const date = new Date(dateString);
+    // Check if date is valid
+    if (isNaN(date.getTime())) {
+      const locale = t('chat.messages') === 'Mensajes' ? 'es' : 'en';
+      return locale === 'es' ? 'Nuevo' : 'New';
+    }
+    
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / (1000 * 60));
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
     if (diffMins < 60) {

--- a/services/conversations.ts
+++ b/services/conversations.ts
@@ -19,7 +19,7 @@ export interface Conversation {
   client_id: string;
   supplier_id: string;
   order_id: string | null;
-  last_message_at: string;
+  last_message_at: string | null; // Can be null if conversation has no messages yet
   created_at: string;
   other_user_name: string;
   other_user_image: string | null;
@@ -68,7 +68,16 @@ export const fetchConversations = async (): Promise<Conversation[]> => {
     if (!data.conversations) {
       throw new ApiError('Invalid response format: missing conversations', 500);
     }
-    return data.conversations;
+    // Validate and sanitize data to prevent crashes
+    return data.conversations.map((conv) => ({
+      ...conv,
+      // Ensure last_message_at is either a valid string or null
+      last_message_at: conv.last_message_at || null,
+      // Ensure other fields have defaults
+      last_message: conv.last_message || null,
+      other_user_image: conv.other_user_image || null,
+      unread_count: typeof conv.unread_count === 'number' ? conv.unread_count : 0,
+    }));
   } catch (error) {
     if (error instanceof ApiError) {
       throw error;


### PR DESCRIPTION
- Update Conversation interface to allow last_message_at as null
- Add defensive validation in fetchConversations to sanitize data
- Fix sort logic to handle null dates (put them at end)
- Fix formatTime to handle null/invalid dates gracefully
- Apply fixes to both app/chat/index.tsx and app/(tabs)/chat.tsx

Fixes crash when opening chat list in APK when conversations have no messages yet.