### PR TITLE
fix(profile): persist gender and dateOfBirth after logout/login

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -2,6 +2,7 @@ import { VerificationCodeModal } from '@/components/VerificationCodeModal';
 import { useAuth } from '@/contexts/AuthContext';
 import { t } from '@/i18n';
 import { ApiError, loginWithCredentials, validateEmail } from '@/services/auth';
+import { mapApiUserToUser } from '@/utils/authMapping';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -112,12 +113,16 @@ export default function LoginScreen() {
           password,
         });
 
-        // Login with the user data and tokens
-        await login(
+        // Map API response to user data using helper function
+        const userData = mapApiUserToUser(
           loginResponse.user,
-          loginResponse.accessToken || loginResponse.token || '',
-          loginResponse.refreshToken || ''
+          'email',
+          loginResponse.accessToken || loginResponse.token,
+          loginResponse.refreshToken
         );
+
+        // Login with the user data
+        await login(userData);
         setErrorMessage(null);
       }
     } catch (error) {

--- a/app/(auth)/verify.tsx
+++ b/app/(auth)/verify.tsx
@@ -2,6 +2,7 @@ import { VerificationCodeModal } from '@/components/VerificationCodeModal';
 import { useAuth } from '@/contexts/AuthContext';
 import { t } from '@/i18n';
 import { ApiError, resendCode, verifyCode } from '@/services/auth';
+import { mapApiUserToUser } from '@/utils/authMapping';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -192,25 +193,13 @@ export default function VerifyScreen() {
       });
 
 
-      // Map API response to user data
-      const apiUser = apiResponse.user;
-      const fullName = apiUser.full_name || '';
-      const nameParts = fullName.split(/\s+/).filter(Boolean);
-      const firstName = nameParts[0] || '';
-      const lastName = nameParts.slice(1).join(' ') || '';
-
-      const userData = {
-        id: apiUser.id,
-        email: apiUser.email,
-        firstName,
-        lastName,
-        phone: (apiUser as Record<string, unknown>).phone_number as string | undefined,
-        avatar: (apiUser as Record<string, unknown>).profile_image as string | undefined,
-        country: (apiUser as Record<string, unknown>).country as string | undefined,
-        provider: 'email' as const,
-        authToken: apiResponse.accessToken || apiResponse.token,
-        refreshToken: apiResponse.refreshToken,
-      };
+      // Map API response to user data using helper function
+      const userData = mapApiUserToUser(
+        apiResponse.user,
+        'email',
+        apiResponse.accessToken || apiResponse.token,
+        apiResponse.refreshToken
+      );
 
       // Login user
       await login(userData);

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -111,6 +111,19 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             const apiCountry = (apiUser as Record<string, unknown>).country as string | undefined;
             const apiPhone = (apiUser as Record<string, unknown>).phone_number as string | undefined;
             const apiAvatar = (apiUser as Record<string, unknown>).profile_image as string | undefined;
+            const apiGender = (apiUser as Record<string, unknown>).gender;
+            const apiDateOfBirth = (apiUser as Record<string, unknown>).date_of_birth as string | undefined;
+            
+            // Map gender: only accept 'male' or 'female', otherwise use existing or undefined
+            const gender = apiGender === 'male' || apiGender === 'female' 
+              ? apiGender 
+              : (parsedUser.gender || undefined);
+            
+            // Map dateOfBirth: use API value if present, otherwise keep existing
+            const dateOfBirth = apiDateOfBirth !== undefined && apiDateOfBirth.trim() !== ''
+              ? apiDateOfBirth.trim()
+              : (parsedUser.dateOfBirth || undefined);
+            
             const syncedUser: User = {
               ...parsedUser,
               firstName,
@@ -119,6 +132,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
               phone: apiPhone !== undefined ? apiPhone : parsedUser.phone,
               avatar: apiAvatar !== undefined ? apiAvatar : parsedUser.avatar,
               country: apiCountry !== undefined ? apiCountry : parsedUser.country,
+              gender,
+              dateOfBirth,
             };
             
             console.log('AuthContext - Syncing user from backend - apiCountry:', apiCountry, 'syncedUser.country:', syncedUser.country);

--- a/utils/authMapping.ts
+++ b/utils/authMapping.ts
@@ -62,6 +62,55 @@ const resolveName = (
   };
 };
 
+/**
+ * Map RegisterResponseUser to User (without Google profile)
+ * Used for email/phone login flows
+ */
+export const mapApiUserToUser = (
+  apiUser: RegisterResponseUser,
+  provider: User['provider'],
+  authToken?: string,
+  refreshToken?: string
+): User => {
+  const { firstName: splitFirst, lastName: splitLast } = extractNameParts(
+    stringOrUndefined(apiUser.full_name)
+  );
+  const apiFirst = stringOrUndefined((apiUser as Record<string, unknown>).first_name);
+  const apiLast = stringOrUndefined((apiUser as Record<string, unknown>).last_name);
+  
+  const firstName = apiFirst ?? splitFirst ?? '';
+  const lastName = apiLast ?? splitLast ?? '';
+  
+  // Extract gender and dateOfBirth from API response
+  const apiGender = (apiUser as Record<string, unknown>).gender;
+  const gender = apiGender === 'male' || apiGender === 'female' ? apiGender : undefined;
+  const dateOfBirth = stringOrUndefined((apiUser as Record<string, unknown>).date_of_birth);
+  
+  // Extract login_count from API response if available
+  const loginCount = (apiUser as Record<string, unknown>).login_count as number | undefined;
+
+  return {
+    id: stringOrUndefined(apiUser.id) ?? '',
+    email: stringOrUndefined(apiUser.email) ?? '',
+    firstName,
+    lastName,
+    phone:
+      stringOrUndefined((apiUser as Record<string, unknown>).phone_number) ??
+      stringOrUndefined((apiUser as Record<string, unknown>).phone),
+    avatar:
+      stringOrUndefined((apiUser as Record<string, unknown>).profile_image) ??
+      stringOrUndefined((apiUser as Record<string, unknown>).avatar),
+    country: stringOrUndefined((apiUser as Record<string, unknown>).country),
+    gender,
+    dateOfBirth,
+    provider,
+    authToken: authToken ? stringOrUndefined(authToken) : undefined,
+    refreshToken: refreshToken ? stringOrUndefined(refreshToken) : undefined,
+    // Store login_count as a custom property (not in User interface, but accessible)
+    loginCount,
+  } as User & { loginCount?: number };
+};
+
 export const mapAuthResponseToUser = (
   response: AuthSuccessResponse,
   googleUser: GoogleProfile,


### PR DESCRIPTION
- Fix AuthContext to include gender and dateOfBirth when syncing profile from backend
- Add mapApiUserToUser helper function to properly map RegisterResponseUser to User
- Update verify.tsx and login.tsx to use mapApiUserToUser for complete user data mapping
- Ensures gender and dateOfBirth are preserved after logout and re-login

Fixes MDB-138