### PR TITLE
feat(chat): implement attach image functionality in chat screens

### DIFF
--- a/app/booking/chat/[orderId].tsx
+++ b/app/booking/chat/[orderId].tsx
@@ -3,6 +3,8 @@ import { ApiError, fetchMessages, Message, sendMessage } from '@/services/messag
 import { fetchOrderDetail } from '@/services/orders';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
     ActivityIndicator,
@@ -191,6 +193,98 @@ export default function ChatScreen() {
     );
   };
 
+  const handleAttachImage = async () => {
+    console.log('[Booking Chat] handleAttachImage called', { orderId, sending });
+    
+    if (sending) {
+      console.log('[Booking Chat] Already sending, ignoring attach request');
+      return;
+    }
+    
+    try {
+      console.log('[Booking Chat] Requesting media library permissions...');
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      console.log('[Booking Chat] Permission status:', status);
+      if (status !== 'granted') {
+        Alert.alert(
+          t('common.error'),
+          t('chat.imagePermissionDenied')
+        );
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        quality: 0.8,
+      });
+
+      if (!result.canceled && result.assets[0]) {
+        const uri = result.assets[0].uri;
+        
+        try {
+          let imageDataUri: string;
+          
+          if (Platform.OS === 'web' && uri.startsWith('blob:')) {
+            const response = await fetch(uri);
+            const blob = await response.blob();
+            const reader = new FileReader();
+            const base64Promise = new Promise<string>((resolve, reject) => {
+              reader.onloadend = () => {
+                const base64 = reader.result as string;
+                const base64Data = base64.split(',')[1] || base64;
+                resolve(base64Data);
+              };
+              reader.onerror = reject;
+            });
+            reader.readAsDataURL(blob);
+            const base64Data = await base64Promise;
+            imageDataUri = `data:image/jpeg;base64,${base64Data}`;
+          } else if (uri.startsWith('data:')) {
+            imageDataUri = uri;
+          } else {
+            if (typeof FileSystem === 'undefined') {
+              throw new Error('FileSystem is not available');
+            }
+            const base64 = await FileSystem.readAsStringAsync(uri, {
+              encoding: 'base64',
+            } as { encoding: 'base64' });
+            imageDataUri = `data:image/jpeg;base64,${base64}`;
+          }
+          
+          // Send image as message
+          if (!orderId || sending) return;
+          
+          setSending(true);
+          try {
+            // Send image data URI as content (backend may need to be updated to handle this)
+            const newMessage = await sendMessage(orderId, { content: imageDataUri });
+            setMessages((prev) => [...prev, newMessage]);
+            
+            // Scroll to bottom
+            setTimeout(() => {
+              flatListRef.current?.scrollToEnd({ animated: true });
+            }, 100);
+          } catch (err) {
+            console.error('Error sending image:', err);
+            Alert.alert(
+              t('common.error'),
+              t('chat.imageSelectionFailed')
+            );
+          } finally {
+            setSending(false);
+          }
+        } catch (error) {
+          console.error('Error converting image to base64:', error);
+          Alert.alert(t('common.error'), t('chat.imageSelectionFailed'));
+        }
+      }
+    } catch (error) {
+      console.error('Error picking image:', error);
+      Alert.alert(t('common.error'), t('chat.imageSelectionFailed'));
+    }
+  };
+
   const renderMessage = ({ item, index }: { item: Message; index: number }) => {
     const isMine = isMyMessage(item);
     const showDate = index === 0 || 
@@ -293,7 +387,13 @@ export default function ChatScreen() {
 
         {/* Input Area - Exact match to JSX */}
         <View style={[styles.inputContainer, { paddingBottom: insets.bottom + 16 }]}>
-          <TouchableOpacity style={styles.attachButton}>
+          <TouchableOpacity 
+            style={styles.attachButton}
+            onPress={handleAttachImage}
+            disabled={sending}
+            activeOpacity={0.7}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
             <Ionicons name="attach-outline" size={20} color="#FFFFFF" />
           </TouchableOpacity>
           <TextInput

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -8,6 +8,8 @@ import {
 } from '@/services/conversations';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
     ActivityIndicator,
@@ -193,6 +195,98 @@ export default function ChatScreen() {
     });
   };
 
+  const handleAttachImage = async () => {
+    console.log('[Chat] handleAttachImage called', { conversationId, sending });
+    
+    if (sending) {
+      console.log('[Chat] Already sending, ignoring attach request');
+      return;
+    }
+    
+    try {
+      console.log('[Chat] Requesting media library permissions...');
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      console.log('[Chat] Permission status:', status);
+      if (status !== 'granted') {
+        Alert.alert(
+          t('common.error'),
+          t('chat.imagePermissionDenied')
+        );
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        quality: 0.8,
+      });
+
+      if (!result.canceled && result.assets[0]) {
+        const uri = result.assets[0].uri;
+        
+        try {
+          let imageDataUri: string;
+          
+          if (Platform.OS === 'web' && uri.startsWith('blob:')) {
+            const response = await fetch(uri);
+            const blob = await response.blob();
+            const reader = new FileReader();
+            const base64Promise = new Promise<string>((resolve, reject) => {
+              reader.onloadend = () => {
+                const base64 = reader.result as string;
+                const base64Data = base64.split(',')[1] || base64;
+                resolve(base64Data);
+              };
+              reader.onerror = reject;
+            });
+            reader.readAsDataURL(blob);
+            const base64Data = await base64Promise;
+            imageDataUri = `data:image/jpeg;base64,${base64Data}`;
+          } else if (uri.startsWith('data:')) {
+            imageDataUri = uri;
+          } else {
+            if (typeof FileSystem === 'undefined') {
+              throw new Error('FileSystem is not available');
+            }
+            const base64 = await FileSystem.readAsStringAsync(uri, {
+              encoding: 'base64',
+            } as { encoding: 'base64' });
+            imageDataUri = `data:image/jpeg;base64,${base64}`;
+          }
+          
+          // Send image as message
+          if (!conversationId || sending) return;
+          
+          setSending(true);
+          try {
+            // Send image data URI as content (backend may need to be updated to handle this)
+            const newMessage = await sendConversationMessage(conversationId, imageDataUri);
+            setMessages((prev) => [...prev, newMessage]);
+            
+            // Scroll to bottom
+            setTimeout(() => {
+              flatListRef.current?.scrollToEnd({ animated: true });
+            }, 100);
+          } catch (err) {
+            console.error('Error sending image:', err);
+            Alert.alert(
+              t('common.error'),
+              t('chat.imageSelectionFailed')
+            );
+          } finally {
+            setSending(false);
+          }
+        } catch (error) {
+          console.error('Error converting image to base64:', error);
+          Alert.alert(t('common.error'), t('chat.imageSelectionFailed'));
+        }
+      }
+    } catch (error) {
+      console.error('Error picking image:', error);
+      Alert.alert(t('common.error'), t('chat.imageSelectionFailed'));
+    }
+  };
+
   const renderMessage = ({ item, index }: { item: Message; index: number }) => {
     const isMine = isMyMessage(item);
     const showDate = index === 0 || 
@@ -303,7 +397,13 @@ export default function ChatScreen() {
 
         {/* Input Area - Exact match to JSX */}
         <View style={[styles.inputContainer, { paddingBottom: insets.bottom + 16 }]}>
-          <TouchableOpacity style={styles.attachButton}>
+          <TouchableOpacity 
+            style={styles.attachButton}
+            onPress={handleAttachImage}
+            disabled={sending}
+            activeOpacity={0.7}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
             <Ionicons name="attach-outline" size={20} color="#FFFFFF" />
           </TouchableOpacity>
           <TextInput

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -297,6 +297,9 @@ export default {
     callProviderMessage: 'Do you want to call the provider?',
     phoneNumberNotAvailable: 'Provider phone number is not available',
     couldNotOpenDialer: 'Could not open phone dialer',
+    imagePermissionDenied: 'Permission to access photos is required to send images',
+    imageSelectionFailed: 'Failed to select image. Please try again.',
+    sendingImage: 'Sending image...',
   },
   quote: {
     title: 'Review & Approve',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -297,6 +297,9 @@ export default {
     callProviderMessage: '¿Deseas llamar al proveedor?',
     phoneNumberNotAvailable: 'El número de teléfono del proveedor no está disponible',
     couldNotOpenDialer: 'No se pudo abrir el marcador telefónico',
+    imagePermissionDenied: 'Se requiere permiso para acceder a las fotos para enviar imágenes',
+    imageSelectionFailed: 'Error al seleccionar imagen. Por favor intenta de nuevo.',
+    sendingImage: 'Enviando imagen...',
   },
   quote: {
     title: 'Revisar y aprobar',


### PR DESCRIPTION
- Add handleAttachImage function to both chat screens
- Request media library permissions before opening image picker
- Convert selected images to base64 format
- Send images as messages (base64 data URI)
- Add translations for image-related messages (en/es)
- Add activeOpacity and hitSlop to improve button responsiveness
- Add debug logging for troubleshooting

Fixes: Attach image button was unresponsive