### PR TITLE
fix(chat): resolve keyboard elevation issue after hiding keyboard

### DIFF
--- a/app/booking/chat/[orderId].tsx
+++ b/app/booking/chat/[orderId].tsx
@@ -50,6 +50,7 @@ export default function ChatScreen() {
   const [error, setError] = useState<string | null>(null);
   const [providerName, setProviderName] = useState<string>('Provider');
   const [providerImage, setProviderImage] = useState<string | null>(null);
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
   
   const flatListRef = useRef<FlatList>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -114,19 +115,32 @@ export default function ChatScreen() {
     }
   }, [orderId, loadMessages]);
 
-  // Handle keyboard show/hide to scroll to bottom
+  // Handle keyboard show/hide to scroll to bottom and reset position
   useEffect(() => {
     const keyboardWillShow = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
       () => {
+        setKeyboardVisible(true);
         setTimeout(() => {
           flatListRef.current?.scrollToEnd({ animated: true });
         }, 100);
       }
     );
 
+    const keyboardWillHide = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
+      () => {
+        setKeyboardVisible(false);
+        // Force layout update when keyboard hides to reset position
+        setTimeout(() => {
+          flatListRef.current?.scrollToEnd({ animated: false });
+        }, 100);
+      }
+    );
+
     return () => {
       keyboardWillShow.remove();
+      keyboardWillHide.remove();
     };
   }, []);
 
@@ -355,8 +369,9 @@ export default function ChatScreen() {
       {/* Messages */}
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? insets.top + 80 : 0}
+        enabled={Platform.OS === 'ios'}
       >
         {error ? (
           <View style={styles.centerContainer}>
@@ -381,7 +396,11 @@ export default function ChatScreen() {
             keyboardShouldPersistTaps="handled"
             keyboardDismissMode="interactive"
             onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: false })}
-            onLayout={() => flatListRef.current?.scrollToEnd({ animated: false })}
+            onLayout={() => {
+              if (!keyboardVisible) {
+                flatListRef.current?.scrollToEnd({ animated: false });
+              }
+            }}
           />
         )}
 

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -54,6 +54,7 @@ export default function ChatScreen() {
   const [sending, setSending] = useState(false);
   const [messageText, setMessageText] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
   
   const flatListRef = useRef<FlatList>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -104,19 +105,32 @@ export default function ChatScreen() {
     };
   }, [loadConversation, loadMessages]);
 
-  // Handle keyboard show/hide to scroll to bottom
+  // Handle keyboard show/hide to scroll to bottom and reset position
   useEffect(() => {
     const keyboardWillShow = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
       () => {
+        setKeyboardVisible(true);
         setTimeout(() => {
           flatListRef.current?.scrollToEnd({ animated: true });
         }, 100);
       }
     );
 
+    const keyboardWillHide = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
+      () => {
+        setKeyboardVisible(false);
+        // Force layout update when keyboard hides to reset position
+        setTimeout(() => {
+          flatListRef.current?.scrollToEnd({ animated: false });
+        }, 100);
+      }
+    );
+
     return () => {
       keyboardWillShow.remove();
+      keyboardWillHide.remove();
     };
   }, []);
 
@@ -365,8 +379,9 @@ export default function ChatScreen() {
       {/* Messages */}
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? insets.top + 80 : 0}
+        enabled={Platform.OS === 'ios'}
       >
         {error ? (
           <View style={styles.centerContainer}>
@@ -391,7 +406,11 @@ export default function ChatScreen() {
             keyboardShouldPersistTaps="handled"
             keyboardDismissMode="interactive"
             onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: false })}
-            onLayout={() => flatListRef.current?.scrollToEnd({ animated: false })}
+            onLayout={() => {
+              if (!keyboardVisible) {
+                flatListRef.current?.scrollToEnd({ animated: false });
+              }
+            }}
           />
         )}
 


### PR DESCRIPTION
- Disable KeyboardAvoidingView on Android to prevent persistent elevation
- Add keyboard hide listener to force layout reset when keyboard closes
- Apply fix to both conversation and booking chat screens
- Fixes MDB-150: Chat interface remains elevated after hiding keyboard