### PR TITLE
fix(auth): corregir error de referencia apiUser en verificación de có…

### DIFF
--- a/app/(auth)/verify.tsx
+++ b/app/(auth)/verify.tsx
@@ -211,7 +211,7 @@ export default function VerifyScreen() {
       ]);
 
       // Check if this is the first login using login_count from backend
-      const loginCount = (apiUser as Record<string, unknown>).login_count as number | undefined;
+      const loginCount = (apiResponse.user as Record<string, unknown>).login_count as number | undefined;
       const isFirstLogin = loginCount === 1 || loginCount === undefined;
       
       if (isFirstLogin) {


### PR DESCRIPTION
…digo

- Cambiar apiUser por apiResponse.user en línea 214
- Resuelve bug MDB-151 donde se mostraba error 'Verificación fallida' incorrectamente después de ingresar código correcto
- El login se completaba exitosamente pero se mostraba error por variable no definida