### PR TITLE
fix(chat): evitar que el teclado tape el input en Android

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -34,6 +34,7 @@ export default {
     },
     android: {
       package: "com.mordobo.client",
+      softwareKeyboardLayoutMode: "resize",
       adaptiveIcon: {
         backgroundColor: "#E6F4FE",
         foregroundImage: "./assets/images/android-icon-foreground.png",

--- a/app/booking/chat/[orderId].tsx
+++ b/app/booking/chat/[orderId].tsx
@@ -1,10 +1,11 @@
 import { useAuth } from '@/contexts/AuthContext';
+import { t } from '@/i18n';
 import { ApiError, fetchMessages, Message, sendMessage } from '@/services/messages';
 import { fetchOrderDetail } from '@/services/orders';
 import { Ionicons } from '@expo/vector-icons';
-import { useLocalSearchParams, useRouter } from 'expo-router';
-import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
+import * as ImagePicker from 'expo-image-picker';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
     ActivityIndicator,
@@ -13,16 +14,14 @@ import {
     Image,
     Keyboard,
     KeyboardAvoidingView,
-    Linking,
     Platform,
     StyleSheet,
     Text,
     TextInput,
     TouchableOpacity,
-    View,
+    View
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { t } from '@/i18n';
 
 const POLLING_INTERVAL = 5000; // 5 seconds
 
@@ -51,7 +50,8 @@ export default function ChatScreen() {
   const [providerName, setProviderName] = useState<string>('Provider');
   const [providerImage, setProviderImage] = useState<string | null>(null);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
-  
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
   const flatListRef = useRef<FlatList>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -119,8 +119,11 @@ export default function ChatScreen() {
   useEffect(() => {
     const keyboardWillShow = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
-      () => {
+      (e) => {
         setKeyboardVisible(true);
+        if (Platform.OS === 'android') {
+          setKeyboardHeight(e.endCoordinates.height);
+        }
         setTimeout(() => {
           flatListRef.current?.scrollToEnd({ animated: true });
         }, 100);
@@ -131,6 +134,9 @@ export default function ChatScreen() {
       Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
       () => {
         setKeyboardVisible(false);
+        if (Platform.OS === 'android') {
+          setKeyboardHeight(0);
+        }
         // Force layout update when keyboard hides to reset position
         setTimeout(() => {
           flatListRef.current?.scrollToEnd({ animated: false });
@@ -373,6 +379,12 @@ export default function ChatScreen() {
         keyboardVerticalOffset={Platform.OS === 'ios' ? insets.top + 80 : 0}
         enabled={Platform.OS === 'ios'}
       >
+        <View
+          style={[
+            styles.flex,
+            Platform.OS === 'android' && keyboardHeight > 0 && { paddingBottom: keyboardHeight },
+          ]}
+        >
         {error ? (
           <View style={styles.centerContainer}>
             <Text style={styles.errorText}>{error}</Text>
@@ -440,6 +452,7 @@ export default function ChatScreen() {
               <Ionicons name="arrow-forward" size={18} color="#FFFFFF" />
             )}
           </TouchableOpacity>
+        </View>
         </View>
       </KeyboardAvoidingView>
     </View>

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -1,36 +1,36 @@
 import { useAuth } from '@/contexts/AuthContext';
 import { useMode } from '@/contexts/ModeContext';
+import { t } from '@/i18n';
 import {
-  ConversationDetail,
-  fetchConversation,
-  fetchConversationMessages,
-  Message,
-  sendConversationMessage,
+    ConversationDetail,
+    fetchConversation,
+    fetchConversationMessages,
+    Message,
+    sendConversationMessage,
 } from '@/services/conversations';
 import { fetchOrderDetail, Order, OrderStatus } from '@/services/orders';
 import { Ionicons } from '@expo/vector-icons';
-import { useLocalSearchParams, useRouter } from 'expo-router';
-import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system';
+import * as ImagePicker from 'expo-image-picker';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  ActivityIndicator,
-  Alert,
-  FlatList,
-  Image,
-  Keyboard,
-  KeyboardAvoidingView,
-  Linking,
-  Modal,
-  Platform,
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
+    ActivityIndicator,
+    Alert,
+    FlatList,
+    Image,
+    Keyboard,
+    KeyboardAvoidingView,
+    Linking,
+    Modal,
+    Platform,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { t } from '@/i18n';
 
 // Client UI colors (original design)
 const clientColors = {
@@ -86,6 +86,7 @@ export default function ChatScreen() {
   const [messageText, setMessageText] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [expandedImageUri, setExpandedImageUri] = useState<string | null>(null);
 
   const flatListRef = useRef<FlatList>(null);
@@ -151,8 +152,11 @@ export default function ChatScreen() {
   useEffect(() => {
     const showSub = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
-      () => {
+      (e) => {
         setKeyboardVisible(true);
+        if (Platform.OS === 'android') {
+          setKeyboardHeight(e.endCoordinates.height);
+        }
         setTimeout(() => flatListRef.current?.scrollToEnd({ animated: true }), 100);
       }
     );
@@ -160,6 +164,9 @@ export default function ChatScreen() {
       Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
       () => {
         setKeyboardVisible(false);
+        if (Platform.OS === 'android') {
+          setKeyboardHeight(0);
+        }
         setTimeout(() => flatListRef.current?.scrollToEnd({ animated: false }), 100);
       }
     );
@@ -492,6 +499,12 @@ export default function ChatScreen() {
           keyboardVerticalOffset={Platform.OS === 'ios' ? insets.top + 80 : 0}
           enabled={Platform.OS === 'ios'}
         >
+          <View
+            style={[
+              clientStyles.flex,
+              Platform.OS === 'android' && keyboardHeight > 0 && { paddingBottom: keyboardHeight },
+            ]}
+          >
           {error ? (
             <View style={[clientStyles.centerContainer, clientStyles.flex]}>
               <Text style={clientStyles.errorText}>{error}</Text>
@@ -550,6 +563,7 @@ export default function ChatScreen() {
                 <Ionicons name="arrow-forward" size={18} color="#FFFFFF" />
               )}
             </TouchableOpacity>
+          </View>
           </View>
         </KeyboardAvoidingView>
         <Modal visible={!!expandedImageUri} transparent animationType="fade">
@@ -630,6 +644,12 @@ export default function ChatScreen() {
         keyboardVerticalOffset={Platform.OS === 'ios' ? insets.top + 120 : 0}
         enabled={Platform.OS === 'ios'}
       >
+        <View
+          style={[
+            styles.flex,
+            Platform.OS === 'android' && keyboardHeight > 0 && { paddingBottom: keyboardHeight },
+          ]}
+        >
         {error ? (
           <View style={[styles.centerContainer, styles.flex]}>
             <Text style={styles.errorText}>{error}</Text>
@@ -706,6 +726,7 @@ export default function ChatScreen() {
               <Ionicons name="arrow-forward" size={18} color={colors.textPrimary} />
             )}
           </TouchableOpacity>
+        </View>
         </View>
       </KeyboardAvoidingView>
 


### PR DESCRIPTION
- Añadir softwareKeyboardLayoutMode: resize en app.config.js (Android)
- Usar altura del teclado en chat para paddingBottom en Android
- Aplicar en app/chat/[conversationId] y app/booking/chat/[orderId]