### PR TITLE
fix(profile): validate contact phone and limit length (MDB-214)

### DIFF
--- a/app/(provider-tabs)/profile/edit.tsx
+++ b/app/(provider-tabs)/profile/edit.tsx
@@ -7,6 +7,7 @@ import {
     uploadProviderAvatar,
     type UpdateProviderProfilePayload,
 } from "@/services/providers";
+import { normalizePhoneInput, validatePhone } from "@/utils/phoneValidation";
 import { Ionicons } from "@expo/vector-icons";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -47,7 +48,9 @@ const schema = z.object({
   categoryId: z.string().nullable(),
   specialties: z.array(z.string()),
   bio: z.string().max(BIO_MAX_LENGTH),
-  phoneNumber: z.string(),
+  phoneNumber: z.string().refine((val) => validatePhone(val).isValid, {
+    message: t("providerDashboard.providerEditProfile.invalidPhone"),
+  }),
   yearsExperience: z.union([z.string(), z.number()]).transform((v) => {
     const n = typeof v === "string" ? parseInt(v, 10) : v;
     return Number.isNaN(n) ? null : n;
@@ -153,7 +156,7 @@ export default function ProviderEditProfileScreen() {
       categoryId: resolvedCategoryId,
       specialties: (profile as { specialties?: string[] }).specialties ?? [],
       bio: profile.bio || "",
-      phoneNumber: profile.phoneNumber || "",
+      phoneNumber: normalizePhoneInput(profile.phoneNumber || ""),
       yearsExperience: profile.yearsExperience ?? null,
     });
     if (profile.avatarUrl) setAvatarUri(profile.avatarUrl);
@@ -524,11 +527,12 @@ export default function ProviderEditProfileScreen() {
                   <TextInput
                     style={[styles.input, errors.phoneNumber && styles.inputError]}
                     onBlur={onBlur}
-                    onChangeText={onChange}
+                    onChangeText={(text) => onChange(normalizePhoneInput(text))}
                     value={value}
                     placeholder="+52 55 1234 5678"
                     placeholderTextColor="rgba(255,255,255,0.3)"
                     keyboardType="phone-pad"
+                    maxLength={15}
                   />
                 )}
               />

--- a/components/PhoneInput.tsx
+++ b/components/PhoneInput.tsx
@@ -2,14 +2,14 @@ import { t } from '@/i18n';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  FlatList,
-  Modal,
-  Platform,
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
+    FlatList,
+    Modal,
+    Platform,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
 } from 'react-native';
 import { type Country, COUNTRIES } from './CountryPicker';
 
@@ -87,9 +87,9 @@ export function PhoneInput({
     );
   }, [extensionSearchQuery]);
 
-  // Format phone number (numbers only)
+  // Format phone number (numbers only, max 15 digits per E.164)
   const handlePhoneNumberChange = (text: string) => {
-    const digitsOnly = text.replace(/\D/g, '');
+    const digitsOnly = text.replace(/\D/g, '').slice(0, 15);
     onPhoneNumberChange(digitsOnly);
   };
 

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1212,6 +1212,7 @@ export default {
       bio: "Biography",
       bioCharCount: "{{current}}/{{max}}",
       contactPhone: "Contact phone",
+      invalidPhone: "Invalid phone number. Use 6 to 15 digits.",
       yearsExperience: "Years of experience",
       saveSuccess: "Profile updated successfully",
       unsavedChanges: "Discard changes?",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -1214,6 +1214,7 @@ export default {
       bio: "Biografía",
       bioCharCount: "{{current}}/{{max}}",
       contactPhone: "Teléfono de contacto",
+      invalidPhone: "Número de teléfono inválido. Use entre 6 y 15 dígitos.",
       yearsExperience: "Años de experiencia",
       saveSuccess: "Perfil actualizado correctamente",
       unsavedChanges: "¿Descartar cambios?",

--- a/utils/phoneValidation.ts
+++ b/utils/phoneValidation.ts
@@ -1,0 +1,35 @@
+/**
+ * Phone number validation for contact/profile fields.
+ * Accepts digits only (optional + and spaces); length 6–15 (E.164 without +).
+ */
+
+const MIN_DIGITS = 6;
+const MAX_DIGITS = 15;
+
+export interface PhoneValidationResult {
+  isValid: boolean;
+  normalized?: string;
+}
+
+/**
+ * Normalizes input to digits only (strips + and spaces) and enforces max length.
+ */
+export function normalizePhoneInput(input: string): string {
+  const digits = input.replace(/\D/g, '');
+  return digits.slice(0, MAX_DIGITS);
+}
+
+/**
+ * Validates phone: empty is valid (optional field); otherwise 6–15 digits.
+ */
+export function validatePhone(phone: string): PhoneValidationResult {
+  const trimmed = phone.trim();
+  if (!trimmed) {
+    return { isValid: true, normalized: '' };
+  }
+  const digits = trimmed.replace(/\D/g, '');
+  if (digits.length < MIN_DIGITS || digits.length > MAX_DIGITS) {
+    return { isValid: false };
+  }
+  return { isValid: true, normalized: digits };
+}


### PR DESCRIPTION
- Add phone validation util (6-15 digits, normalize input)
- Validate phone in provider edit profile with Zod, show i18n error
- Normalize phone on load and on change to prevent invalid data
- Limit PhoneInput to 15 digits; maxLength on provider contact field