### PR TITLE
fix(onboarding): reset Continue button loading state on focus (MDB-211)

### DIFF
--- a/app/provider-onboarding/availability.tsx
+++ b/app/provider-onboarding/availability.tsx
@@ -4,7 +4,7 @@ import { submitOnboardingStep } from "@/services/providers";
 import { Ionicons } from "@expo/vector-icons";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { LinearGradient } from "expo-linear-gradient";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
 import { ActivityIndicator, Platform, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -94,6 +94,12 @@ export default function ProviderOnboardingAvailabilityScreen() {
   };
 
   const [saving, setSaving] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      setSaving(false);
+    }, []),
+  );
 
   const handleBack = () => {
     router.back();

--- a/app/provider-onboarding/bank.tsx
+++ b/app/provider-onboarding/bank.tsx
@@ -4,7 +4,7 @@ import { submitOnboardingStep } from "@/services/providers";
 import { formatClabeDisplay, normalizeClabe, validateClabe } from "@/utils/clabeValidation";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
 import { ActivityIndicator, FlatList, Modal, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -83,6 +83,12 @@ export default function ProviderOnboardingBankScreen() {
   };
 
   const [saving, setSaving] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      setSaving(false);
+    }, []),
+  );
 
   const handleContinue = async () => {
     setSaving(true);

--- a/app/provider-onboarding/business.tsx
+++ b/app/provider-onboarding/business.tsx
@@ -5,8 +5,8 @@ import { submitOnboardingStep } from "@/services/providers";
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery } from "@tanstack/react-query";
 import { LinearGradient } from "expo-linear-gradient";
-import { useRouter } from "expo-router";
-import React, { useMemo, useState } from "react";
+import { useFocusEffect, useRouter } from "expo-router";
+import React, { useCallback, useMemo, useState } from "react";
 import { ActivityIndicator, FlatList, Modal, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -82,6 +82,12 @@ export default function ProviderOnboardingBusinessScreen() {
   const canContinue = businessName.trim().length > 0 && selectedCategory !== null && description.trim().length >= MIN_DESCRIPTION_LENGTH;
 
   const [saving, setSaving] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      setSaving(false);
+    }, []),
+  );
 
   const handleContinue = async () => {
     if (!canContinue) return;

--- a/app/provider-onboarding/documents.tsx
+++ b/app/provider-onboarding/documents.tsx
@@ -5,7 +5,7 @@ import { Ionicons } from "@expo/vector-icons";
 import * as FileSystem from "expo-file-system";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
 import { ActivityIndicator, Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -107,6 +107,12 @@ export default function ProviderOnboardingDocumentsScreen() {
   };
 
   const [saving, setSaving] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      setSaving(false);
+    }, []),
+  );
 
   const handleBack = () => {
     router.back();

--- a/app/provider-onboarding/services.tsx
+++ b/app/provider-onboarding/services.tsx
@@ -3,7 +3,7 @@ import { t } from "@/i18n";
 import { submitOnboardingStep } from "@/services/providers";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
 import { ActivityIndicator, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -83,6 +83,12 @@ export default function ProviderOnboardingServicesScreen() {
   }, []);
 
   const [saving, setSaving] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      setSaving(false);
+    }, []),
+  );
 
   const handleBack = () => {
     router.back();

--- a/app/provider-onboarding/terms.tsx
+++ b/app/provider-onboarding/terms.tsx
@@ -3,8 +3,8 @@ import { t } from "@/i18n";
 import { submitOnboardingStep } from "@/services/providers";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
-import { useRouter } from "expo-router";
-import React, { useState } from "react";
+import { useFocusEffect, useRouter } from "expo-router";
+import React, { useCallback, useState } from "react";
 import { ActivityIndicator, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -31,6 +31,12 @@ export default function ProviderOnboardingTermsScreen() {
 
   const [saving, setSaving] = useState(false);
   const canContinue = terms[0].checked && terms[1].checked;
+
+  useFocusEffect(
+    useCallback(() => {
+      setSaving(false);
+    }, []),
+  );
 
   const handleBack = () => {
     router.back();


### PR DESCRIPTION
- Add useFocusEffect to all provider onboarding steps to set saving=false when screen gains focus
- Fixes infinite loading spinner when user navigates Back and then Continue again