### PR TITLE
feat(MDB-220): client onboarding flag + provider routing by status

### DIFF
--- a/app/(auth)/onboarding.tsx
+++ b/app/(auth)/onboarding.tsx
@@ -1,4 +1,5 @@
 import { t } from '@/i18n';
+import { completeClientOnboarding } from '@/services/auth';
 import { router } from 'expo-router';
 import { useState } from 'react';
 import {
@@ -15,18 +16,25 @@ const ONBOARDING_SCREENS = 3;
 export default function OnboardingScreen() {
   const [currentScreen, setCurrentScreen] = useState(1);
 
+  const finishOnboarding = async () => {
+    try {
+      await completeClientOnboarding();
+    } catch (e) {
+      console.warn('[Onboarding] Could not mark client onboarding complete:', e);
+    }
+    router.replace('/(tabs)/home');
+  };
+
   const handleNext = () => {
     if (currentScreen < ONBOARDING_SCREENS) {
       setCurrentScreen(currentScreen + 1);
     } else {
-      // Last screen - go to home
-      router.replace('/(tabs)/home');
+      finishOnboarding();
     }
   };
 
   const handleSkip = () => {
-    // Skip all onboarding screens and go to home
-    router.replace('/(tabs)/home');
+    finishOnboarding();
   };
 
   const renderScreen = () => {

--- a/app/(auth)/verify.tsx
+++ b/app/(auth)/verify.tsx
@@ -218,16 +218,12 @@ export default function VerifyScreen() {
         'pending_verification_password',
       ]);
 
-      // Check if this is the first login using login_count from backend
-      const loginCount = (apiResponse.user as Record<string, unknown>).login_count as number | undefined;
-      const isFirstLogin = loginCount === 1 || loginCount === undefined;
-      
-      if (isFirstLogin) {
-        // Navigate to onboarding screens for first-time users
-        router.replace('/(auth)/onboarding');
-      } else {
-        // Navigate to home on success
+      // Use DB flag: show client onboarding only if not yet completed
+      const clientOnboardingCompleted = (apiResponse.user as Record<string, unknown>).client_onboarding_completed === true;
+      if (clientOnboardingCompleted) {
         router.replace('/(tabs)/home');
+      } else {
+        router.replace('/(auth)/onboarding');
       }
     } catch (error) {
       

--- a/app/switch-mode.tsx
+++ b/app/switch-mode.tsx
@@ -48,13 +48,19 @@ export default function SwitchModeScreen() {
     try {
       setSwitching(true);
       const result = await setMode("provider");
-      if (result.needsOnboarding) {
-        router.replace("/provider-onboarding");
+      const status = await checkProviderStatus();
+      // Not yet a provider or onboarding not completed → full onboarding from step 1
+      if (result.needsOnboarding || !status.onboardingCompleted) {
+        if (status.onboardingCompleted && !status.isVerified) {
+          router.replace("/provider-onboarding/verification");
+        } else {
+          router.replace("/provider-onboarding");
+        }
         return;
       }
-      const status = await checkProviderStatus();
-      if (!status.onboardingCompleted) {
-        router.replace("/provider-onboarding");
+      // Onboarding done but not approved → final (verification) screen
+      if (!status.isVerified) {
+        router.replace("/provider-onboarding/verification");
         return;
       }
       router.replace("/(provider-tabs)");

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -671,6 +671,18 @@ export interface VerifyCodeResponse extends AuthSuccessResponse {
   refreshToken?: string;
 }
 
+/** Mark client onboarding as completed so it is not shown again. Requires authenticated client. */
+export const completeClientOnboarding = async (): Promise<void> => {
+  await request<{ message: string }>(
+    '/api/users/me/complete-client-onboarding',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    },
+    t('errors.requestFailed')
+  );
+};
+
 export const verifyCode = async (
   payload: VerifyCodePayload
 ): Promise<VerifyCodeResponse> => {


### PR DESCRIPTION
- Use client_onboarding_completed from API to skip client onboarding on next login
- Call completeClientOnboarding() when user finishes or skips onboarding
- Provider: route to verification screen when done but not approved, home when approved, full onboarding when not done