### PR TITLE
feat(profile): sync provider avatars and default placeholder (MDB-232)

### DIFF
--- a/app/(provider-tabs)/messages.tsx
+++ b/app/(provider-tabs)/messages.tsx
@@ -1,3 +1,4 @@
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Conversation, deleteConversation, fetchConversations } from '@/services/conversations';
 import { t } from '@/i18n';
 import { Ionicons } from '@expo/vector-icons';
@@ -235,13 +236,12 @@ export default function ProviderInboxScreen() {
             activeOpacity={0.7}
           >
             <View style={styles.avatarWrap}>
-              {item.other_user_image ? (
-                <Image source={{ uri: item.other_user_image }} style={styles.avatar} />
-              ) : (
-                <View style={styles.avatarPlaceholder}>
-                  <Text style={styles.avatarEmoji}>👤</Text>
-                </View>
-              )}
+              <ProviderAvatar
+                profileImage={item.other_user_image}
+                size={48}
+                rounded
+                style={styles.avatar}
+              />
               {isOnline && <View style={styles.onlineIndicator} />}
             </View>
             <View style={styles.content}>

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,3 +1,4 @@
+import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { t } from "@/i18n";
 import { Conversation, deleteConversation, fetchConversations } from "@/services/conversations";
 import { Ionicons } from "@expo/vector-icons";
@@ -206,12 +207,12 @@ export default function ConversationsListScreen() {
         <View style={[styles.conversationItem, !showBorder && styles.conversationItemNoBorder, { backgroundColor: "#1a1a2e", borderBottomColor: "#374151" }]}>
           <TouchableOpacity style={styles.conversationRowTouchable} onPress={() => handleConversationPress(item.id)} onLongPress={() => handleLongPressConversation(item)} activeOpacity={0.7}>
             <View style={styles.avatarContainer}>
-              {item.other_user_image ?
-                <Image source={{ uri: item.other_user_image }} style={styles.avatar} />
-              : <View style={[styles.avatarPlaceholder, { backgroundColor: "#252542" }]}>
-                  <Text style={styles.avatarEmoji}>👨‍🔧</Text>
-                </View>
-              }
+              <ProviderAvatar
+                profileImage={item.other_user_image}
+                size={56}
+                rounded
+                style={styles.avatar}
+              />
               {isOnline && <View style={styles.onlineIndicator} />}
             </View>
             <View style={styles.conversationContent}>

--- a/app/booking/chat/[orderId].tsx
+++ b/app/booking/chat/[orderId].tsx
@@ -1,7 +1,9 @@
 import { useAuth } from '@/contexts/AuthContext';
 import { t } from '@/i18n';
 import { ApiError, fetchMessages, Message, sendMessage } from '@/services/messages';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { fetchOrderDetail } from '@/services/orders';
+import { getProfileImageUrl } from '@/utils/profileImage';
 import { Ionicons } from '@expo/vector-icons';
 import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
@@ -90,7 +92,7 @@ export default function ChatScreen() {
           // Use supplier object if available (has more complete info)
           if (orderDetails.supplier) {
             setProviderName(orderDetails.supplier.full_name || orderDetails.supplier.business_name || 'Provider');
-            setProviderImage(orderDetails.supplier.profile_image || null);
+            setProviderImage(getProfileImageUrl(orderDetails.supplier.profile_image) ?? null);
           } else if (orderDetails.order) {
             // Fallback to order fields if supplier object not available
             setProviderName(orderDetails.order.supplier_name || orderDetails.order.business_name || 'Provider');
@@ -356,13 +358,12 @@ export default function ChatScreen() {
           <Ionicons name="arrow-back" size={24} color="#FFFFFF" />
         </TouchableOpacity>
         
-        {providerImage ? (
-          <Image source={{ uri: providerImage }} style={styles.headerAvatar} />
-        ) : (
-          <View style={styles.headerAvatarPlaceholder}>
-            <Text style={styles.headerAvatarEmoji}>🧑‍🔧</Text>
-          </View>
-        )}
+        <ProviderAvatar
+          profileImage={providerImage}
+          size={44}
+          rounded
+          style={styles.headerAvatar}
+        />
         
         <View style={styles.headerInfo}>
           <Text style={styles.headerName}>{providerName}</Text>

--- a/app/booking/date-time.tsx
+++ b/app/booking/date-time.tsx
@@ -6,6 +6,7 @@ import {
   SupplierService,
   ApiError,
 } from '@/services/suppliers';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -439,11 +440,12 @@ export default function BookingDateTimeScreen() {
         {/* Provider Mini Card */}
         <View style={styles.providerCard}>
           <View style={styles.providerImageContainer}>
-            {supplier.profile_image ? (
-              <Image source={{ uri: supplier.profile_image }} style={styles.providerImage} />
-            ) : (
-              <Ionicons name="person" size={24} color={colors.textSecondary} />
-            )}
+            <ProviderAvatar
+              profileImage={supplier.profile_image}
+              size={48}
+              rounded
+              style={styles.providerImage}
+            />
           </View>
           <View style={styles.providerInfo}>
             <Text style={styles.providerName}>{supplier.full_name}</Text>

--- a/app/booking/success/[orderId].tsx
+++ b/app/booking/success/[orderId].tsx
@@ -1,3 +1,4 @@
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { ApiError, fetchOrderDetail, OrderDetailResponse } from '@/services/orders';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -5,7 +6,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Animated,
-  Image,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -213,14 +213,12 @@ export default function BookingSuccessScreen() {
             {/* Provider Info */}
             <View style={styles.providerInfo}>
               <View style={styles.providerAvatar}>
-                {supplier?.profile_image ? (
-                  <Image
-                    source={{ uri: supplier.profile_image }}
-                    style={styles.avatarImage}
-                  />
-                ) : (
-                  <Ionicons name="person" size={24} color={colors.textSecondary} />
-                )}
+                <ProviderAvatar
+                  profileImage={supplier?.profile_image}
+                  size={48}
+                  rounded
+                  style={styles.avatarImage}
+                />
               </View>
               <View style={styles.providerText}>
                 <Text style={styles.providerName}>

--- a/app/booking/summary.tsx
+++ b/app/booking/summary.tsx
@@ -1,6 +1,7 @@
 import { CLIENT_TIERS } from "@/constants/tiers";
 import { useAuth } from "@/contexts/AuthContext";
 import { getLocale, t } from "@/i18n";
+import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { Address, getAddresses } from "@/services/addresses";
 import { createOrder, ApiError as OrderApiError } from "@/services/orders";
 import { ApiError, fetchSupplierProfile, fetchSupplierServices, Supplier, SupplierService } from "@/services/suppliers";
@@ -299,9 +300,12 @@ export default function BookingSummaryScreen() {
           <View style={styles.card}>
             <View style={styles.providerRow}>
               <View style={styles.providerAvatar}>
-                {supplier.profile_image ?
-                  <Image source={{ uri: supplier.profile_image }} style={styles.avatarImage} />
-                : <Text style={styles.avatarEmoji}>👨‍🔧</Text>}
+                <ProviderAvatar
+                  profileImage={supplier.profile_image}
+                  size={48}
+                  rounded
+                  style={styles.avatarImage}
+                />
               </View>
               <View style={styles.providerInfo}>
                 <View style={styles.providerNameRow}>

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { useMode } from "@/contexts/ModeContext";
 import { t } from "@/i18n";
+import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { ConversationDetail, fetchConversation, fetchConversationMessages, Message, sendConversationMessage } from "@/services/conversations";
 import { fetchOrderDetail, Order, OrderStatus } from "@/services/orders";
 import { Ionicons } from "@expo/vector-icons";
@@ -302,7 +303,8 @@ export default function ChatScreen() {
   };
 
   const otherUserName = user?.id === conversation?.client_id ? conversation?.supplier_name : conversation?.client_name;
-  const otherUserImage = user?.id === conversation?.client_id ? conversation?.supplier_image : null;
+  const otherUserImageRaw =
+    user?.id === conversation?.client_id ? conversation?.supplier_image : conversation?.client_image ?? null;
 
   if (loading) {
     return (
@@ -355,12 +357,12 @@ export default function ChatScreen() {
           <TouchableOpacity onPress={() => router.back()} style={clientStyles.backButton}>
             <Ionicons name="arrow-back" size={24} color="#FFFFFF" />
           </TouchableOpacity>
-          {otherUserImage ?
-            <Image source={{ uri: otherUserImage }} style={clientStyles.headerAvatar} />
-          : <View style={clientStyles.headerAvatarPlaceholder}>
-              <Text style={clientStyles.headerAvatarEmoji}>👑</Text>
-            </View>
-          }
+          <ProviderAvatar
+            profileImage={otherUserImageRaw}
+            size={44}
+            rounded
+            style={clientStyles.headerAvatar}
+          />
           <View style={clientStyles.headerInfo}>
             <Text style={clientStyles.headerName}>{otherUserName ?? t("chat.title")}</Text>
             <View style={clientStyles.statusContainer}>
@@ -431,12 +433,12 @@ export default function ChatScreen() {
         <TouchableOpacity onPress={() => router.back()} style={styles.headerBtn}>
           <Ionicons name="arrow-back" size={22} color={colors.textMuted40} />
         </TouchableOpacity>
-        {otherUserImage ?
-          <Image source={{ uri: otherUserImage }} style={styles.headerAvatar} />
-        : <View style={styles.headerAvatarPlaceholder}>
-            <Text style={styles.headerAvatarEmoji}>👩</Text>
-          </View>
-        }
+        <ProviderAvatar
+          profileImage={otherUserImageRaw}
+          size={40}
+          rounded
+          style={styles.headerAvatar}
+        />
         <View style={styles.headerInfo}>
           <Text style={styles.headerName}>{otherUserName ?? t("chat.title")}</Text>
           <Text style={styles.headerStatus}>{t("chat.online")}</Text>

--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -1,3 +1,4 @@
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Conversation, fetchConversations } from '@/services/conversations';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
@@ -138,13 +139,12 @@ export default function ConversationsListScreen() {
         activeOpacity={0.7}
       >
         <View style={styles.avatarContainer}>
-          {item.other_user_image ? (
-            <Image source={{ uri: item.other_user_image }} style={styles.avatar} />
-          ) : (
-            <View style={styles.avatarPlaceholder}>
-              <Text style={styles.avatarEmoji}>👨‍🔧</Text>
-            </View>
-          )}
+          <ProviderAvatar
+            profileImage={item.other_user_image}
+            size={56}
+            rounded
+            style={styles.avatar}
+          />
           {isOnline && (
             <View style={styles.onlineIndicator} />
           )}

--- a/app/orders/[orderId].tsx
+++ b/app/orders/[orderId].tsx
@@ -1,5 +1,6 @@
 import { t } from '@/i18n';
 import { fetchOrderDetail, OrderDetailResponse, updateOrderStatus } from '@/services/orders';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
@@ -408,15 +409,12 @@ export default function OrderDetailScreen() {
         {/* Provider Card */}
         <View style={styles.providerCard}>
           <View style={styles.providerImageContainer}>
-            {supplier?.profile_image ? (
-              <View style={styles.providerImage}>
-                <Ionicons name="person" size={24} color="#9ca3af" />
-              </View>
-            ) : (
-              <View style={styles.providerImage}>
-                <Ionicons name="person" size={24} color="#9ca3af" />
-              </View>
-            )}
+            <ProviderAvatar
+              profileImage={supplier?.profile_image}
+              size={48}
+              rounded
+              style={styles.providerImage}
+            />
           </View>
           <View style={styles.providerInfo}>
             <Text style={styles.providerName}>

--- a/app/profile/favorites.tsx
+++ b/app/profile/favorites.tsx
@@ -7,6 +7,7 @@ import {
   fetchFavorites,
   removeFavorite,
 } from '@/services/favorites';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
@@ -248,17 +249,12 @@ export default function FavoritesScreen() {
                   onPress={() => handleCardPress(provider.id)}
                   activeOpacity={0.7}
                 >
-                  {provider.profile_image ? (
-                    <Image
-                      source={{ uri: provider.profile_image }}
-                      style={styles.providerPhoto}
-                      contentFit="cover"
-                    />
-                  ) : (
-                    <View style={[styles.providerPhoto, { backgroundColor: colors.bgInput }]}>
-                      <Ionicons name="person" size={28} color={colors.textSecondary} />
-                    </View>
-                  )}
+                  <ProviderAvatar
+                    profileImage={provider.profile_image}
+                    size={64}
+                    rounded
+                    style={styles.providerPhoto}
+                  />
                 </TouchableOpacity>
 
                 {/* Info in the middle */}

--- a/app/services/suppliers/[supplierId].tsx
+++ b/app/services/suppliers/[supplierId].tsx
@@ -1,6 +1,8 @@
 import { FavoriteButton } from '@/components/FavoriteButton';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { useAuth } from '@/contexts/AuthContext';
 import { getOrCreateConversation } from '@/services/conversations';
+import { getProfileImageUrl } from '@/utils/profileImage';
 import {
   ApiError,
   fetchSupplierProfile,
@@ -207,9 +209,9 @@ export default function ProviderDetailScreen() {
     );
   }
 
-  const headerImage = supplier.gallery && supplier.gallery.length > 0 
-    ? supplier.gallery[0] 
-    : supplier.profile_image || 'https://via.placeholder.com/400x200';
+  const headerImage = supplier.gallery && supplier.gallery.length > 0
+    ? supplier.gallery[0]
+    : getProfileImageUrl(supplier.profile_image) ?? 'https://via.placeholder.com/400x200';
 
   const aboutText = supplier.bio || '';
   const shouldShowReadMore = aboutText.length > 150;
@@ -276,13 +278,17 @@ export default function ProviderDetailScreen() {
         {/* Provider Info Section */}
         <View style={styles.providerInfoSection}>
           <View style={styles.providerInfoRow}>
-            <Image
-              source={{ uri: supplier.profile_image || 'https://via.placeholder.com/90' }}
+            <ProviderAvatar
+              profileImage={supplier.profile_image}
+              size={90}
+              rounded={false}
               style={styles.profileImage}
             />
             <View style={styles.providerInfoText}>
               <View style={styles.nameRow}>
-                <Text style={styles.providerName}>{supplier.full_name}</Text>
+                <Text style={styles.providerName}>
+                {supplier.business_name?.trim() || supplier.full_name}
+              </Text>
                 {supplier.verified && (
                   <Ionicons name="checkmark-circle" size={20} color={colors.secondary} />
                 )}

--- a/components/ProviderAvatar.tsx
+++ b/components/ProviderAvatar.tsx
@@ -1,0 +1,83 @@
+import { getProfileImageUrl } from '@/utils/profileImage';
+import { Ionicons } from '@expo/vector-icons';
+import React, { useState } from 'react';
+import {
+  Image,
+  StyleSheet,
+  View,
+  type ImageStyle,
+  type ViewStyle,
+} from 'react-native';
+
+const PLACEHOLDER_BG = '#2d2d4a';
+const PLACEHOLDER_ICON_COLOR = '#9CA3AF';
+
+interface ProviderAvatarProps {
+  profileImage?: string | null;
+  size?: number;
+  style?: ViewStyle;
+  imageStyle?: ImageStyle;
+  rounded?: boolean; // true = circle, false = rounded rect (e.g. 14px)
+}
+
+/**
+ * Avatar for providers (or any profile). Shows profile image when available,
+ * or a local default placeholder (icon on background). Never relies on external URLs.
+ */
+export function ProviderAvatar({
+  profileImage,
+  size = 48,
+  style,
+  imageStyle,
+  rounded = false,
+}: ProviderAvatarProps) {
+  const [error, setError] = useState(false);
+  const uri = getProfileImageUrl(profileImage);
+  const showImage = uri && !error;
+
+  const borderRadius = rounded ? size / 2 : 14;
+  const containerStyle = [
+    styles.placeholder,
+    {
+      width: size,
+      height: size,
+      borderRadius,
+      backgroundColor: PLACEHOLDER_BG,
+    },
+    style,
+  ];
+
+  if (showImage) {
+    return (
+      <Image
+        source={{ uri }}
+        style={[
+          { width: size, height: size, borderRadius },
+          imageStyle,
+        ]}
+        onError={() => setError(true)}
+      />
+    );
+  }
+
+  return (
+    <View style={containerStyle}>
+      <Ionicons
+        name="person"
+        size={size * 0.5}
+        color={PLACEHOLDER_ICON_COLOR}
+        style={styles.icon}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  placeholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    textAlign: 'center',
+  },
+});

--- a/components/ProviderCard.tsx
+++ b/components/ProviderCard.tsx
@@ -1,4 +1,5 @@
 import { useFavorite } from '@/hooks/useFavorite';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Supplier } from '@/services/suppliers';
 import { Ionicons } from '@expo/vector-icons';
 import React from 'react';
@@ -36,8 +37,10 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
       <View style={styles.content}>
         {/* Profile Image - 80x80px, borderRadius 14px */}
         <View style={styles.imageContainer}>
-          <Image
-            source={{ uri: supplier.profile_image || 'https://via.placeholder.com/80' }}
+          <ProviderAvatar
+            profileImage={supplier.profile_image}
+            size={80}
+            rounded={false}
             style={styles.image}
           />
         </View>

--- a/components/TopProviderCard.tsx
+++ b/components/TopProviderCard.tsx
@@ -1,7 +1,8 @@
 import { useFavorite } from '@/hooks/useFavorite';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Ionicons } from '@expo/vector-icons';
 import React from 'react';
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 interface TopProviderCardProps {
   id: string;
@@ -38,8 +39,10 @@ export function TopProviderCard({
 
   return (
     <TouchableOpacity style={styles.container} onPress={onPress}>
-      <Image
-        source={{ uri: profileImage || 'https://via.placeholder.com/70' }}
+      <ProviderAvatar
+        profileImage={profileImage}
+        size={70}
+        rounded={false}
         style={styles.image}
       />
       <View style={styles.info}>

--- a/services/conversations.ts
+++ b/services/conversations.ts
@@ -37,6 +37,7 @@ export interface ConversationDetail {
   client_name: string;
   supplier_name: string;
   supplier_image: string | null;
+  client_image?: string | null;
   supplier_phone_number?: string;
 }
 

--- a/utils/profileImage.ts
+++ b/utils/profileImage.ts
@@ -1,0 +1,24 @@
+import { API_BASE } from '@/utils/apiConfig';
+
+/**
+ * Default placeholder image for provider/client avatars when no profile image is set.
+ * Single source of truth so all screens show the same placeholder.
+ */
+export const DEFAULT_AVATAR_URI = 'https://via.placeholder.com/96?text=👤';
+
+/**
+ * Normalizes a profile image URL from the API.
+ * - If url is null/empty, returns null.
+ * - If url is already absolute (starts with http), returns as-is.
+ * - If url is relative (e.g. uploads/providers/...), returns absolute URL using API_BASE
+ *   so the same image loads on Home, Chat list, and Chat header.
+ */
+export function getProfileImageUrl(url: string | null | undefined): string | null {
+  if (!url || typeof url !== 'string') return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed;
+  const base = API_BASE.replace(/\/$/, '');
+  const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return `${base}${path}`;
+}


### PR DESCRIPTION
- Add ProviderAvatar component with local placeholder (no external URL)
- Add profileImage utils (getProfileImageUrl, default placeholder)
- Use ProviderAvatar in Home, Chat, Booking, Favorites, Supplier detail
- ConversationDetail: add client_image for provider chat header
- Supplier detail: show business_name first, fix ProviderAvatar import