### PR TITLE
fix: show provider name (business_name) instead of client name

### DIFF
--- a/app/booking/chat/[orderId].tsx
+++ b/app/booking/chat/[orderId].tsx
@@ -91,7 +91,7 @@ export default function ChatScreen() {
           const orderDetails = await fetchOrderDetail(orderId);
           // Use supplier object if available (has more complete info)
           if (orderDetails.supplier) {
-            setProviderName(orderDetails.supplier.full_name || orderDetails.supplier.business_name || 'Provider');
+            setProviderName(orderDetails.supplier.business_name?.trim() || orderDetails.supplier.full_name || 'Provider');
             setProviderImage(getProfileImageUrl(orderDetails.supplier.profile_image) ?? null);
           } else if (orderDetails.order) {
             // Fallback to order fields if supplier object not available

--- a/app/booking/date-time.tsx
+++ b/app/booking/date-time.tsx
@@ -448,7 +448,7 @@ export default function BookingDateTimeScreen() {
             />
           </View>
           <View style={styles.providerInfo}>
-            <Text style={styles.providerName}>{supplier.full_name}</Text>
+            <Text style={styles.providerName}>{supplier.business_name?.trim() || supplier.full_name}</Text>
             <Text style={styles.serviceInfo}>
               {service.category_name || 'Service'} • ${service.price || 0}{t('supplier.perHour')}
             </Text>

--- a/app/booking/scheduled/[orderId].tsx
+++ b/app/booking/scheduled/[orderId].tsx
@@ -63,7 +63,7 @@ export default function ScheduledBookingScreen() {
   }, [loadOrder]);
 
   const order = orderDetail?.order;
-  const providerName = order?.supplier_name ?? order?.business_name ?? orderDetail?.supplier?.full_name ?? orderDetail?.supplier?.business_name ?? t('orders.provider');
+  const providerName = order?.supplier_name ?? order?.business_name ?? orderDetail?.supplier?.business_name?.trim() ?? orderDetail?.supplier?.full_name ?? t('orders.provider');
   const serviceName = order?.service_name ?? t('orders.service');
   const scheduledLabel = formatScheduledAt(order?.scheduled_at);
   const statusLabel = order?.status ? getStatusLabel(order.status) : t('orders.status.confirmed');

--- a/app/booking/success/[orderId].tsx
+++ b/app/booking/success/[orderId].tsx
@@ -222,7 +222,7 @@ export default function BookingSuccessScreen() {
               </View>
               <View style={styles.providerText}>
                 <Text style={styles.providerName}>
-                  {supplier?.full_name || supplier?.business_name || 'Provider'}
+                  {supplier?.business_name?.trim() || supplier?.full_name || 'Provider'}
                 </Text>
                 <Text style={styles.serviceName}>
                   {orderData.quote?.line_items?.[0]?.description || 'Service'}

--- a/app/booking/summary.tsx
+++ b/app/booking/summary.tsx
@@ -309,7 +309,7 @@ export default function BookingSummaryScreen() {
               </View>
               <View style={styles.providerInfo}>
                 <View style={styles.providerNameRow}>
-                  <Text style={styles.providerName}>{supplier.full_name || supplier.business_name}</Text>
+                  <Text style={styles.providerName}>{supplier.business_name?.trim() || supplier.full_name}</Text>
                   {supplier.verified && <Text style={styles.verifiedCheckmark}>✓</Text>}
                 </View>
                 <Text style={styles.ratingText}>

--- a/app/orders/[orderId].tsx
+++ b/app/orders/[orderId].tsx
@@ -418,7 +418,7 @@ export default function OrderDetailScreen() {
           </View>
           <View style={styles.providerInfo}>
             <Text style={styles.providerName}>
-              {supplier?.full_name || 'Proveedor'}
+              {supplier?.business_name?.trim() || supplier?.full_name || 'Proveedor'}
             </Text>
             <View style={styles.locationRow}>
               <View style={styles.locationDot} />

--- a/app/orders/rate/[orderId].tsx
+++ b/app/orders/rate/[orderId].tsx
@@ -59,7 +59,7 @@ export default function RateExperienceScreen() {
 
   const order = orderDetail?.order;
   const supplierId = order?.supplier_id ?? orderDetail?.supplier?.id;
-  const providerName = order?.supplier_name ?? order?.business_name ?? orderDetail?.supplier?.full_name ?? orderDetail?.supplier?.business_name ?? t('orders.provider');
+  const providerName = order?.supplier_name ?? order?.business_name ?? orderDetail?.supplier?.business_name?.trim() ?? orderDetail?.supplier?.full_name ?? t('orders.provider');
   const serviceName = order?.service_name ?? '';
   const scheduledLabel = formatScheduledAt(order?.scheduled_at);
 

--- a/app/profile/chat-history.tsx
+++ b/app/profile/chat-history.tsx
@@ -72,9 +72,9 @@ export default function ChatHistoryScreen() {
       onPress={() => handleConversationPress(item.id)}
     >
       <View style={styles.avatarContainer}>
-        {item.supplier?.avatar ? (
+        {item.other_user_image ? (
           <Image
-            source={{ uri: item.supplier.avatar }}
+            source={{ uri: item.other_user_image }}
             style={styles.avatar}
           />
         ) : (
@@ -86,7 +86,7 @@ export default function ChatHistoryScreen() {
       <View style={styles.conversationInfo}>
         <View style={styles.conversationHeader}>
           <Text style={styles.supplierName}>
-            {item.supplier?.name || 'Unknown Supplier'}
+            {item.other_user_name || 'Unknown Supplier'}
           </Text>
           {item.lastMessage?.createdAt && (
             <Text style={styles.timeText}>

--- a/app/profile/favorites.tsx
+++ b/app/profile/favorites.tsx
@@ -259,7 +259,7 @@ export default function FavoritesScreen() {
 
                 {/* Info in the middle */}
                 <View style={styles.providerInfo}>
-                  <Text style={styles.providerName}>{provider.full_name}</Text>
+                  <Text style={styles.providerName}>{provider.business_name?.trim() || provider.full_name}</Text>
                   <Text style={[styles.providerService, { color: colors.secondary }]}>
                     {getServiceName(provider)}
                   </Text>
@@ -276,7 +276,7 @@ export default function FavoritesScreen() {
                 {/* Heart and price on the right - Exact match to JSX */}
                 <View style={styles.rightSection}>
                   <TouchableOpacity
-                    onPress={() => handleRemoveFavorite(provider.id, provider.full_name)}
+                    onPress={() => handleRemoveFavorite(provider.id, provider.business_name?.trim() || provider.full_name)}
                     disabled={removingId === provider.id}
                     style={styles.heartButton}
                   >

--- a/app/services/[categoryId]/index.tsx
+++ b/app/services/[categoryId]/index.tsx
@@ -1,6 +1,7 @@
 import { ProviderCard } from "@/components/ProviderCard";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
+import { t } from "@/i18n";
 import { getAddresses } from "@/services/addresses";
 import { ApiError, CategoryWithSubcategories, fetchCategoryWithSubcategories } from "@/services/categories";
 import { fetchSuppliers, Supplier } from "@/services/suppliers";
@@ -222,7 +223,7 @@ export default function CategoryDetailScreen() {
           contentContainerStyle={[styles.suppliersSection, { paddingBottom: insets.bottom + 40 }]}
           ListEmptyComponent={() => (
             <View style={styles.emptyState}>
-              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>No suppliers found for this category</Text>
+              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>{t("categories.noResultsForCategory")}</Text>
             </View>
           )}
           showsVerticalScrollIndicator={false}

--- a/components/ProviderCard.tsx
+++ b/components/ProviderCard.tsx
@@ -49,7 +49,7 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
         <View style={styles.info}>
           {/* Name and Favorite Row */}
           <View style={styles.headerRow}>
-            <Text style={styles.name} numberOfLines={1}>{supplier.full_name || 'Unknown'}</Text>
+            <Text style={styles.name} numberOfLines={1}>{supplier.business_name?.trim() || supplier.full_name || 'Unknown'}</Text>
             <TouchableOpacity 
               style={styles.favoriteButton}
               onPress={handleFavoritePress}

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -220,6 +220,7 @@ export default {
     price: "Price",
     distance: "Distance",
     noResults: "No suppliers found",
+    noResultsForCategory: "No suppliers found for this category",
     available: "{{count}} categories available",
     availableOne: "{{count}} category available",
     grid: "Grid",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -220,6 +220,7 @@ export default {
     price: "Precio",
     distance: "Distancia",
     noResults: "No se encontraron proveedores",
+    noResultsForCategory: "No se encontraron proveedores para esta categoría",
     available: "{{count}} categorías disponibles",
     availableOne: "{{count}} categoría disponible",
     grid: "Grid",


### PR DESCRIPTION
- ProviderCard, favorites, orders, booking: prefer business_name then full_name
- Chat history: use other_user_name and other_user_image from API
- Category detail: i18n for empty state (noResultsForCategory)