### PR TITLE
feat(profile): provider avatar upload, sync, display and expo-file-sy…

### DIFF
--- a/app/(provider-tabs)/earnings.tsx
+++ b/app/(provider-tabs)/earnings.tsx
@@ -11,7 +11,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useQuery } from "@tanstack/react-query";
 import { format, parseISO } from "date-fns";
 import { enUS, es } from "date-fns/locale";
-import * as FileSystem from "expo-file-system";
+import * as FileSystem from "expo-file-system/legacy";
 import { LinearGradient } from "expo-linear-gradient";
 import React, { useCallback, useMemo, useState } from "react";
 import {

--- a/app/(provider-tabs)/index.tsx
+++ b/app/(provider-tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { useAvailability } from "@/contexts/AvailabilityContext";
 import { t } from "@/i18n";
 import { getProviderProfile } from "@/services/providers";
+import { getProfileImageUrl } from "@/utils/profileImage";
 import {
     acceptOrder,
     getDashboardRequests,
@@ -109,7 +110,7 @@ export default function ProviderDashboardScreen() {
     staleTime: 60_000,
   });
   const displayName = (providerProfile?.displayName ?? "").trim() || "—";
-  const providerAvatarUrl = providerProfile?.avatarUrl ?? null;
+  const providerAvatarUrl = getProfileImageUrl(providerProfile?.avatarUrl ?? null) ?? null;
 
   const loadAll = useCallback(async () => {
     try {
@@ -205,7 +206,7 @@ export default function ProviderDashboardScreen() {
                 accessibilityLabel={t("providerDashboard.providerProfile.screenTitle")}
               >
                 {providerAvatarUrl ? (
-                  <Image source={{ uri: providerAvatarUrl }} style={styles.profileAvatar} contentFit="cover" />
+                  <Image source={{ uri: providerAvatarUrl }} style={styles.profileAvatar} contentFit="contain" />
                 ) : (
                   <Ionicons name="person" size={24} color="rgba(255,255,255,0.5)" />
                 )}

--- a/app/(provider-tabs)/profile/edit.tsx
+++ b/app/(provider-tabs)/profile/edit.tsx
@@ -7,11 +7,13 @@ import {
     uploadProviderAvatar,
     type UpdateProviderProfilePayload,
 } from "@/services/providers";
+import { getProfileImageUrl } from "@/utils/profileImage";
 import { normalizePhoneInput, validatePhone } from "@/utils/phoneValidation";
 import { Ionicons } from "@expo/vector-icons";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Image } from "expo-image";
+import * as FileSystem from "expo-file-system/legacy";
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
@@ -187,8 +189,12 @@ export default function ProviderEditProfileScreen() {
       phoneNumber: normalizePhoneInput(profile.phoneNumber || ""),
       yearsExperience: profile.yearsExperience ?? null,
     });
-    if (profile.avatarUrl) setAvatarUri(profile.avatarUrl);
+    if (profile.avatarUrl) setAvatarUri(getProfileImageUrl(profile.avatarUrl) ?? profile.avatarUrl);
   }, [profile, resolvedCategoryId, reset]);
+
+  const goToProfile = useCallback(() => {
+    router.replace("/(provider-tabs)/profile");
+  }, [router]);
 
   const handleBack = useCallback(() => {
     if (isDirty) {
@@ -197,13 +203,13 @@ export default function ProviderEditProfileScreen() {
         t("providerDashboard.providerEditProfile.unsavedChangesMessage"),
         [
           { text: t("providerDashboard.providerEditProfile.cancel"), style: "cancel" },
-          { text: t("common.discard"), style: "destructive", onPress: () => router.back() },
+          { text: t("common.discard"), style: "destructive", onPress: goToProfile },
         ],
       );
     } else {
-      router.back();
+      goToProfile();
     }
-  }, [isDirty, router]);
+  }, [isDirty, goToProfile]);
 
 
   const pickImage = useCallback(async () => {
@@ -215,15 +221,14 @@ export default function ProviderEditProfileScreen() {
       }
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
-        allowsEditing: true,
-        aspect: [1, 1],
+        allowsEditing: false,
         quality: 0.8,
       });
       if (result.canceled || !result.assets[0]) return;
       const uri = result.assets[0].uri;
       const compressed = await ImageManipulator.manipulateAsync(
         uri,
-        [{ resize: { width: 400, height: 400 } }],
+        [{ resize: { width: 400 } }],
         { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG },
       );
       setUploadingAvatar(true);
@@ -242,11 +247,16 @@ export default function ProviderEditProfileScreen() {
             reader.readAsDataURL(blob);
           });
         }
-        const fs = await import("expo-file-system");
-        return fs.default.readAsStringAsync(compressed.uri, { encoding: fs.EncodingType.Base64 });
+        return FileSystem.readAsStringAsync(compressed.uri, {
+          encoding: "base64",
+        } as { encoding: "base64" });
       })();
+      if (!base64 || base64.length === 0) {
+        Alert.alert(t("common.error"), t("errors.uploadProviderAvatarFailed"));
+        return;
+      }
       const { avatarUrl } = await uploadProviderAvatar(base64, "avatar.jpg", "image/jpeg");
-      setAvatarUri(avatarUrl);
+      setAvatarUri(getProfileImageUrl(avatarUrl) ?? avatarUrl);
       await queryClient.invalidateQueries({ queryKey: ["providerProfile"] });
     } catch (e) {
       console.error("[ProviderEditProfile] Avatar upload failed:", e);
@@ -279,13 +289,13 @@ export default function ProviderEditProfileScreen() {
         await queryClient.invalidateQueries({ queryKey: ["providerProfile"] });
         setToastMessage(t("providerDashboard.providerEditProfile.saveSuccess"));
         setToastVisible(true);
-        setTimeout(() => router.back(), 1500);
+        setTimeout(goToProfile, 1500);
       } catch (e) {
         console.error("[ProviderEditProfile] Update failed:", e);
         Alert.alert(t("common.error"), t("errors.updateProviderProfileFailed"));
       }
     },
-    [queryClient, router],
+    [queryClient, goToProfile],
   );
 
   if (profileLoading && !profile) {
@@ -338,7 +348,7 @@ export default function ProviderEditProfileScreen() {
           <View style={styles.avatarSection}>
             <TouchableOpacity onPress={pickImage} style={styles.avatarWrap} activeOpacity={0.8} disabled={uploadingAvatar}>
               {avatarUri ? (
-                <Image source={{ uri: avatarUri }} style={styles.avatarImage} contentFit="cover" />
+                <Image source={{ uri: avatarUri }} style={styles.avatarImage} contentFit="contain" />
               ) : (
                 <View style={styles.avatarPlaceholder}>
                   <Text style={styles.avatarInitials}>

--- a/app/(provider-tabs)/profile/index.tsx
+++ b/app/(provider-tabs)/profile/index.tsx
@@ -4,6 +4,7 @@ import { t } from "@/i18n";
 import { getPortfolio } from "@/services/portfolio";
 import { getProviderProfile } from "@/services/providers";
 import { getDashboardStats } from "@/services/providerDashboard";
+import { getProfileImageUrl } from "@/utils/profileImage";
 import { getProviderServices } from "@/services/providerServices";
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery } from "@tanstack/react-query";
@@ -71,7 +72,7 @@ export default function ProviderProfileScreen() {
     queryFn: getProviderProfile,
     staleTime: 60_000,
   });
-  const providerAvatarUrl = providerProfile?.avatarUrl ?? null;
+  const providerAvatarUrl = getProfileImageUrl(providerProfile?.avatarUrl ?? null) ?? null;
   const displayName = (providerProfile?.displayName ?? "").trim() || "—";
   const initials = getInitialsFromDisplayName(displayName);
   const categoryName = (providerProfile?.categoryName ?? "").trim() || null;
@@ -187,7 +188,7 @@ export default function ProviderProfileScreen() {
           <View style={styles.avatarRow}>
             <View style={styles.avatarWrapper}>
               {providerAvatarUrl ? (
-                <Image source={{ uri: providerAvatarUrl }} style={styles.avatar} contentFit="cover" />
+                <Image source={{ uri: providerAvatarUrl }} style={styles.avatar} contentFit="contain" />
               ) : (
                 <View style={styles.avatarPlaceholder}>
                   <Text style={styles.avatarInitials}>{initials}</Text>

--- a/app/(provider-tabs)/profile/portfolio-add.tsx
+++ b/app/(provider-tabs)/profile/portfolio-add.tsx
@@ -9,6 +9,7 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import * as FileSystem from "expo-file-system/legacy";
 import { Image } from "expo-image";
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
@@ -61,8 +62,9 @@ async function uriToBase64(uri: string): Promise<string> {
       reader.readAsDataURL(blob);
     });
   }
-  const fs = await import("expo-file-system");
-  return fs.default.readAsStringAsync(uri, { encoding: fs.EncodingType.Base64 });
+  return FileSystem.readAsStringAsync(uri, {
+    encoding: "base64",
+  } as { encoding: "base64" });
 }
 
 export default function PortfolioAddScreen() {

--- a/app/booking/chat/[orderId].tsx
+++ b/app/booking/chat/[orderId].tsx
@@ -5,7 +5,7 @@ import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { fetchOrderDetail } from '@/services/orders';
 import { getProfileImageUrl } from '@/utils/profileImage';
 import { Ionicons } from '@expo/vector-icons';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as ImagePicker from 'expo-image-picker';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -5,7 +5,7 @@ import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { ConversationDetail, fetchConversation, fetchConversationMessages, Message, sendConversationMessage } from "@/services/conversations";
 import { fetchOrderDetail, Order, OrderStatus } from "@/services/orders";
 import { Ionicons } from "@expo/vector-icons";
-import * as FileSystem from "expo-file-system";
+import * as FileSystem from "expo-file-system/legacy";
 import * as ImagePicker from "expo-image-picker";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import React, { useCallback, useEffect, useRef, useState } from "react";

--- a/app/profile/edit.tsx
+++ b/app/profile/edit.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { t } from '@/i18n';
 import { updateProfile } from '@/services/profile';
 import { Ionicons } from '@expo/vector-icons';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';

--- a/app/provider-onboarding/documents.tsx
+++ b/app/provider-onboarding/documents.tsx
@@ -2,7 +2,7 @@ import { ProgressBar } from "@/components/onboarding/ProgressBar";
 import { t } from "@/i18n";
 import { getOnboardingDocuments, submitOnboardingStep, type OnboardingDocumentType, uploadOnboardingDocument } from "@/services/providers";
 import { Ionicons } from "@expo/vector-icons";
-import * as FileSystem from "expo-file-system";
+import * as FileSystem from "expo-file-system/legacy";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect, useRouter } from "expo-router";


### PR DESCRIPTION
…stem legacy

- Use getProfileImageUrl for avatar on Profile and Home so image loads
- Back button from Edit Profile goes to Profile screen (router.replace)
- expo-file-system/legacy for readAsStringAsync (SDK 54 compatibility)
- Avatar: no forced crop, resize preserve aspect, contentFit contain
- Avatar image smaller with padding wrapper on Edit/Profile/Home