### PR TITLE
fix(portfolio): fix image display in portfolio and provider profile

### DIFF
--- a/app/(provider-tabs)/profile/index.tsx
+++ b/app/(provider-tabs)/profile/index.tsx
@@ -11,7 +11,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect, useRouter } from "expo-router";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { ActivityIndicator, RefreshControl, ScrollView, Share, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -73,6 +73,7 @@ export default function ProviderProfileScreen() {
     staleTime: 60_000,
   });
   const providerAvatarUrl = getProfileImageUrl(providerProfile?.avatarUrl ?? null) ?? null;
+  const [avatarError, setAvatarError] = useState(false);
   const displayName = (providerProfile?.displayName ?? "").trim() || "—";
   const initials = getInitialsFromDisplayName(displayName);
   const categoryName = (providerProfile?.categoryName ?? "").trim() || null;
@@ -80,6 +81,7 @@ export default function ProviderProfileScreen() {
 
   useFocusEffect(
     useCallback(() => {
+      setAvatarError(false);
       refetchProviderProfile();
     }, [refetchProviderProfile])
   );
@@ -187,8 +189,14 @@ export default function ProviderProfileScreen() {
           </View>
           <View style={styles.avatarRow}>
             <View style={styles.avatarWrapper}>
-              {providerAvatarUrl ? (
-                <Image source={{ uri: providerAvatarUrl }} style={styles.avatar} contentFit="contain" />
+              {providerAvatarUrl && !avatarError ? (
+                <Image
+                  source={{ uri: providerAvatarUrl }}
+                  style={styles.avatar}
+                  contentFit="cover"
+                  cachePolicy="disk"
+                  onError={() => setAvatarError(true)}
+                />
               ) : (
                 <View style={styles.avatarPlaceholder}>
                   <Text style={styles.avatarInitials}>{initials}</Text>

--- a/app/(provider-tabs)/profile/portfolio-add.tsx
+++ b/app/(provider-tabs)/profile/portfolio-add.tsx
@@ -426,7 +426,7 @@ export default function PortfolioAddScreen() {
       </KeyboardAvoidingView>
 
       {toast && (
-        <Toast message={toast.message} onDismiss={() => setToast(null)} />
+        <Toast message={toast.message} onHide={() => setToast(null)} />
       )}
     </View>
   );

--- a/app/(provider-tabs)/profile/portfolio.tsx
+++ b/app/(provider-tabs)/profile/portfolio.tsx
@@ -6,6 +6,7 @@ import {
     getPortfolioProject,
     type PortfolioProject,
 } from "@/services/portfolio";
+import { getProfileImageUrl } from "@/utils/profileImage";
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Image } from "expo-image";
@@ -43,6 +44,7 @@ export default function ProviderPortfolioScreen() {
   const [toast, setToast] = useState<{ message: string } | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [detailProjectId, setDetailProjectId] = useState<string | null>(null);
+  const [failedImages, setFailedImages] = useState<Set<string>>(new Set());
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: ["providerPortfolio"],
@@ -236,7 +238,10 @@ export default function ProviderPortfolioScreen() {
         ) : (
           /* Grid */
           <View style={styles.grid}>
-            {filteredProjects.map((project) => (
+            {filteredProjects.map((project) => {
+              const normalizedCover = getProfileImageUrl(project.coverImageUrl);
+              const showImage = normalizedCover && !failedImages.has(project.id);
+              return (
               <TouchableOpacity
                 key={project.id}
                 style={styles.gridItem}
@@ -244,11 +249,13 @@ export default function ProviderPortfolioScreen() {
                 activeOpacity={0.9}
               >
                 <View style={styles.gridImageWrap}>
-                  {project.coverImageUrl ? (
+                  {showImage ? (
                     <Image
-                      source={{ uri: project.coverImageUrl }}
+                      source={{ uri: normalizedCover }}
                       style={styles.gridImage}
                       contentFit="cover"
+                      cachePolicy="disk"
+                      onError={() => setFailedImages((prev) => new Set(prev).add(project.id))}
                     />
                   ) : (
                     <View style={styles.gridPlaceholder}>
@@ -267,7 +274,8 @@ export default function ProviderPortfolioScreen() {
                   </View>
                 </View>
               </TouchableOpacity>
-            ))}
+              );
+            })}
           </View>
         )}
 
@@ -336,14 +344,22 @@ export default function ProviderPortfolioScreen() {
                       <Text style={styles.detailPlaceholderEmoji}>📸</Text>
                     </View>
                   ) : (
-                    detailData.project.images.map((img) => (
-                      <Image
-                        key={img.id}
-                        source={{ uri: img.url }}
-                        style={styles.detailImage}
-                        contentFit="cover"
-                      />
-                    ))
+                    detailData.project.images.map((img) => {
+                      const normalizedUrl = getProfileImageUrl(img.url);
+                      return normalizedUrl ? (
+                        <Image
+                          key={img.id}
+                          source={{ uri: normalizedUrl }}
+                          style={styles.detailImage}
+                          contentFit="cover"
+                          cachePolicy="disk"
+                        />
+                      ) : (
+                        <View key={img.id} style={styles.detailPlaceholder}>
+                          <Text style={styles.detailPlaceholderEmoji}>📸</Text>
+                        </View>
+                      );
+                    })
                   )}
                 </View>
                 <Text style={styles.detailTitle}>{detailData.project.title}</Text>
@@ -388,7 +404,7 @@ export default function ProviderPortfolioScreen() {
       {toast && (
         <Toast
           message={toast.message}
-          onDismiss={() => setToast(null)}
+          onHide={() => setToast(null)}
         />
       )}
     </View>

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,28 +1,49 @@
 import { Ionicons } from '@expo/vector-icons';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { Animated, StyleSheet, Text, View } from 'react-native';
 
 export interface ToastProps {
   message: string;
-  visible: boolean;
-  onHide: () => void;
+  visible?: boolean;
+  onHide?: () => void;
+  onDismiss?: () => void;
   duration?: number;
   type?: 'success' | 'error' | 'info';
 }
 
 export function Toast({
   message,
-  visible,
+  visible = true,
   onHide,
+  onDismiss,
   duration = 3000,
   type = 'success',
 }: ToastProps) {
-  const fadeAnim = React.useRef(new Animated.Value(0)).current;
-  const slideAnim = React.useRef(new Animated.Value(-50)).current;
+  const dismiss = onHide ?? onDismiss;
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(-50)).current;
+  const dismissRef = useRef(dismiss);
+  dismissRef.current = dismiss;
+
+  const hideToast = useCallback(() => {
+    Animated.parallel([
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+      Animated.timing(slideAnim, {
+        toValue: -50,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+    ]).start(() => {
+      dismissRef.current?.();
+    });
+  }, [fadeAnim, slideAnim]);
 
   useEffect(() => {
     if (visible) {
-      // Show animation
       Animated.parallel([
         Animated.timing(fadeAnim, {
           toValue: 1,
@@ -37,35 +58,16 @@ export function Toast({
         }),
       ]).start();
 
-      // Auto hide after duration
       const timer = setTimeout(() => {
         hideToast();
       }, duration);
 
       return () => clearTimeout(timer);
-    } else {
-      hideToast();
     }
-  }, [visible, duration]);
+    hideToast();
+  }, [visible, duration, hideToast, fadeAnim, slideAnim]);
 
-  const hideToast = () => {
-    Animated.parallel([
-      Animated.timing(fadeAnim, {
-        toValue: 0,
-        duration: 200,
-        useNativeDriver: true,
-      }),
-      Animated.timing(slideAnim, {
-        toValue: -50,
-        duration: 200,
-        useNativeDriver: true,
-      }),
-    ]).start(() => {
-      onHide();
-    });
-  };
-
-  if (!visible && fadeAnim._value === 0) {
+  if (!visible) {
     return null;
   }
 


### PR DESCRIPTION
- Normalize portfolio image URLs through getProfileImageUrl() to handle relative paths from the API
- Add onError fallback on grid images and detail modal images
- Fix provider avatar: contentFit cover + error fallback with initials
- Fix Toast component: support both onHide/onDismiss props, default visible to true, prevent crash when callback is undefined
