### PR TITLE
fix(ui): fix bottom safe area on Android edge-to-edge screens

### DIFF
--- a/app/account/edit.tsx
+++ b/app/account/edit.tsx
@@ -21,7 +21,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { COUNTRIES, CountryPicker, type Country } from '@/components/CountryPicker';
 
@@ -425,7 +425,7 @@ export default function EditProfileScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['bottom']}>
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={styles.keyboardView}
@@ -462,7 +462,7 @@ export default function EditProfileScreen() {
 
         <ScrollView
           style={styles.content}
-          contentContainerStyle={[styles.contentContainer, { paddingBottom: insets.bottom + 40 }]}
+          contentContainerStyle={[styles.contentContainer, { paddingBottom: 40 }]}
           showsVerticalScrollIndicator={true}
           keyboardShouldPersistTaps="handled"
         >
@@ -678,7 +678,7 @@ export default function EditProfileScreen() {
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/app/account/my-addresses.tsx
+++ b/app/account/my-addresses.tsx
@@ -25,7 +25,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface Address {
   id: string;
@@ -271,7 +271,7 @@ export default function MyAddressesScreen() {
   };
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['bottom']}>
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
@@ -288,7 +288,7 @@ export default function MyAddressesScreen() {
       ) : (
         <ScrollView 
           style={styles.content} 
-          contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
+          contentContainerStyle={{ paddingBottom: 20 }}
           showsVerticalScrollIndicator={false}
         >
           {/* Address Cards */}
@@ -581,7 +581,7 @@ export default function MyAddressesScreen() {
         type={toastType}
         duration={toastType === 'error' ? 4000 : 3000}
       />
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/app/account/payment-methods.tsx
+++ b/app/account/payment-methods.tsx
@@ -20,7 +20,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 
 interface PaymentMethod {
@@ -195,7 +195,7 @@ export default function PaymentMethodsScreen() {
   };
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['bottom']}>
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
@@ -212,7 +212,7 @@ export default function PaymentMethodsScreen() {
       ) : (
         <ScrollView 
           style={styles.content} 
-          contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
+          contentContainerStyle={{ paddingBottom: 20 }}
           showsVerticalScrollIndicator={false}
         >
           {/* Security Badge */}
@@ -376,7 +376,7 @@ export default function PaymentMethodsScreen() {
         type={toastType}
         duration={toastType === 'error' ? 4000 : 3000}
       />
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/app/account/support.tsx
+++ b/app/account/support.tsx
@@ -13,7 +13,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface FAQItem {
   icon: string;
@@ -117,8 +117,8 @@ export default function HelpCenterScreen() {
   };
 
   return (
-    <View style={styles.container}>
-      {/* Header - Exact match to JSX: padding: '50px 20px 20px', display: 'flex', alignItems: 'center', gap: '16px' */}
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      {/* Header */}
       <View
         style={[
           styles.header,
@@ -150,7 +150,7 @@ export default function HelpCenterScreen() {
         style={[styles.scrollView, { backgroundColor: '#1a1a2e' }]}
         contentContainerStyle={[
           styles.scrollContent,
-          { paddingBottom: insets.bottom + 20, backgroundColor: '#1a1a2e' },
+          { paddingBottom: 20, backgroundColor: '#1a1a2e' },
         ]}
         showsVerticalScrollIndicator={false}
       >
@@ -292,7 +292,7 @@ export default function HelpCenterScreen() {
           />
         </TouchableOpacity>
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/app/switch-mode.tsx
+++ b/app/switch-mode.tsx
@@ -14,7 +14,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 
 const BACKGROUND = "#12121A";
 const CARD_BG = "#1E1B2E";
@@ -88,7 +88,7 @@ export default function SwitchModeScreen() {
   const isToProvider = targetMode === "provider";
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <SafeAreaView style={[styles.container, { paddingTop: insets.top }]} edges={['bottom']}>
       <View style={styles.header}>
         <TouchableOpacity
           style={styles.backButton}
@@ -104,7 +104,7 @@ export default function SwitchModeScreen() {
 
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 24 }]}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: 24 }]}
         showsVerticalScrollIndicator={false}
       >
         {/* Visual: two modes with swap arrow */}
@@ -230,7 +230,7 @@ export default function SwitchModeScreen() {
           <Text style={styles.cancelButtonText}>{t("common.cancel")}</Text>
         </TouchableOpacity>
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 }
 


### PR DESCRIPTION
Replace plain View containers with SafeAreaView edges={['bottom']} from react-native-safe-area-context to properly handle Android edge-to-edge navigation bar overlap on: edit profile, my addresses, help center, payment methods, and switch mode screens.
