### PR TITLE
feat(profile): add app version label and logout to Provider profile (…

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -19,7 +19,7 @@ export default {
   expo: {
     name: getAppName(),
     slug: "mordobo",
-    version: "2.0.7",
+    version: "3.0.0",
     orientation: "portrait",
     icon: "./assets/images/icon.png",
     scheme: "mordobo",

--- a/app/(provider-tabs)/profile/index.tsx
+++ b/app/(provider-tabs)/profile/index.tsx
@@ -1,4 +1,5 @@
 import { ModeSwitch } from "@/components/common/ModeSwitch";
+import { ProfileFooter } from "@/components/profile/ProfileFooter";
 import { useMode } from "@/contexts/ModeContext";
 import { t } from "@/i18n";
 import { getPortfolio } from "@/services/portfolio";
@@ -274,6 +275,9 @@ export default function ProviderProfileScreen() {
             ))}
           </View>
         </View>
+
+        {/* App version label and logout button — same layout/behavior as Client profile */}
+        <ProfileFooter />
       </ScrollView>
     </View>
   );
@@ -288,7 +292,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    paddingBottom: 32,
+    paddingBottom: 100,
   },
   headerWrapper: {
     position: "relative",

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,4 +1,5 @@
 import { ModeSwitch } from "@/components/common/ModeSwitch";
+import { ProfileFooter } from "@/components/profile/ProfileFooter";
 import { Toast } from "@/components/Toast";
 import { CLIENT_TIERS } from "@/constants/tiers";
 import { useAuth } from "@/contexts/AuthContext";
@@ -10,7 +11,7 @@ import { useIsFocused } from "@react-navigation/native";
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
-import { Alert, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface UserStats {
@@ -20,7 +21,7 @@ interface UserStats {
 
 export default function ProfileScreen() {
   const router = useRouter();
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const { mode, setMode } = useMode();
   const isFocused = useIsFocused();
   const insets = useSafeAreaInsets();
@@ -67,70 +68,6 @@ export default function ProfileScreen() {
     }, 0);
     return () => clearTimeout(id);
   }, [mode, isFocused, router]);
-
-  const handleLogout = () => {
-    const performLogout = async () => {
-      try {
-        console.log("[Profile] ========== LOGOUT BUTTON PRESSED ==========");
-
-        // Perform logout (clears user state and storage)
-        await logout();
-
-        console.log("[Profile] Logout function completed, navigating...");
-
-        // Use a small delay to ensure state has updated
-        // Then navigate to auth root which will redirect to welcome
-        setTimeout(() => {
-          try {
-            console.log("[Profile] Attempting navigation to /(auth)...");
-
-            // Navigate to auth root - the index will redirect to welcome
-            router.replace("/(auth)");
-
-            console.log("[Profile] Navigation completed");
-          } catch (navError) {
-            console.error("[Profile] Navigation error:", navError);
-            // Try alternative navigation
-            try {
-              router.replace("/(auth)/welcome");
-            } catch (altNavError) {
-              console.error("[Profile] Alternative navigation also failed:", altNavError);
-            }
-          }
-        }, 100);
-      } catch (error) {
-        console.error("[Profile] Logout error:", error);
-        // Even if logout fails, try to navigate
-        try {
-          router.replace("/(auth)");
-        } catch (navError) {
-          console.error("[Profile] Navigation error after logout failure:", navError);
-          Alert.alert(t("common.error"), t("profile.logoutError"));
-        }
-      }
-    };
-
-    // Handle Alert differently on web vs mobile
-    if (Platform.OS === "web") {
-      const confirmed = window.confirm(`${t("profile.logout")}\n\n${t("profile.logoutConfirm")}`);
-      if (confirmed) {
-        performLogout();
-      } else {
-      }
-    } else {
-      Alert.alert(t("profile.logout"), t("profile.logoutConfirm"), [
-        {
-          text: t("common.cancel"),
-          style: "cancel",
-        },
-        {
-          text: t("profile.logout"),
-          style: "destructive",
-          onPress: performLogout,
-        },
-      ]);
-    }
-  };
 
   const menuItems = [
     { icon: "👤", label: t("profile.editProfile"), route: "/account/edit" },
@@ -241,24 +178,7 @@ export default function ProfileScreen() {
           ))}
         </View>
 
-        {/* Logout Button - Exact match: padding: '20px', backgroundColor: danger20, borderRadius: '12px' */}
-        <View style={styles.logoutContainer}>
-          <TouchableOpacity
-            style={styles.logoutButton}
-            onPress={() => {
-              handleLogout();
-            }}
-            activeOpacity={0.7}
-          >
-            <Text style={styles.logoutIcon}>🚪</Text>
-            <Text style={styles.logoutText}>{t("profile.logout")}</Text>
-          </TouchableOpacity>
-        </View>
-
-        {/* Version from app.config */}
-        <View style={styles.versionContainer}>
-          <Text style={styles.versionText}>{t("profile.version")} 2.0.8</Text>
-        </View>
+        <ProfileFooter />
       </ScrollView>
 
       {/* Toast for mode change notifications */}
@@ -404,37 +324,6 @@ const styles = StyleSheet.create({
   // Chevron: fontSize: '16px' from JSX
   menuChevron: {
     fontSize: 16,
-    color: "#9ca3af", // Hardcode secondary text
-  },
-  // Logout: padding: '20px' from JSX
-  logoutContainer: {
-    padding: 20,
-  },
-  // Logout Button: padding: '16px', borderRadius: '12px', display: 'flex', gap: '8px' from JSX
-  logoutButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 16,
-    borderRadius: 12,
-    gap: 8,
-    backgroundColor: "#ef444420", // Hardcode danger20
-  },
-  logoutIcon: {
-    fontSize: 20,
-  },
-  // Logout Text: fontSize: '15px', fontWeight: '600' from JSX
-  logoutText: {
-    fontSize: 15,
-    fontWeight: "600",
-    color: "#ef4444", // Hardcode danger color
-  },
-  versionContainer: {
-    alignItems: "center",
-    paddingVertical: 16,
-  },
-  versionText: {
-    fontSize: 12,
     color: "#9ca3af", // Hardcode secondary text
   },
 });

--- a/components/profile/ProfileFooter.tsx
+++ b/components/profile/ProfileFooter.tsx
@@ -1,0 +1,98 @@
+import { useAuth } from "@/contexts/AuthContext";
+import { t } from "@/i18n";
+import Constants from "expo-constants";
+import { useRouter } from "expo-router";
+import React from "react";
+import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+/**
+ * Shared footer for Client and Provider profile screens: app version label and logout button.
+ * Reused to avoid duplicating logic and ensure consistent layout and behavior.
+ */
+export function ProfileFooter() {
+  const router = useRouter();
+  const { logout } = useAuth();
+
+  const appVersion = Constants.expoConfig?.version ?? "0.0.0";
+
+  const handleLogout = () => {
+    const performLogout = async () => {
+      try {
+        await logout();
+        setTimeout(() => {
+          try {
+            router.replace("/(auth)");
+          } catch {
+            router.replace("/(auth)/welcome");
+          }
+        }, 100);
+      } catch (error) {
+        console.error("[ProfileFooter] Logout error:", error);
+        try {
+          router.replace("/(auth)");
+        } catch (navError) {
+          console.error("[ProfileFooter] Navigation error after logout failure:", navError);
+          Alert.alert(t("common.error"), t("profile.logoutError"));
+        }
+      }
+    };
+
+    if (Platform.OS === "web") {
+      const confirmed = window.confirm(`${t("profile.logout")}\n\n${t("profile.logoutConfirm")}`);
+      if (confirmed) performLogout();
+    } else {
+      Alert.alert(t("profile.logout"), t("profile.logoutConfirm"), [
+        { text: t("common.cancel"), style: "cancel" },
+        { text: t("profile.logout"), style: "destructive", onPress: performLogout },
+      ]);
+    }
+  };
+
+  return (
+    <View style={styles.footer}>
+      <View style={styles.logoutContainer}>
+        <TouchableOpacity style={styles.logoutButton} onPress={handleLogout} activeOpacity={0.7}>
+          <Text style={styles.logoutIcon}>🚪</Text>
+          <Text style={styles.logoutText}>{t("profile.logout")}</Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.versionContainer}>
+        <Text style={styles.versionText}>{t("profile.version")} {appVersion}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  footer: {
+    paddingHorizontal: 20,
+  },
+  logoutContainer: {
+    padding: 20,
+  },
+  logoutButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 16,
+    borderRadius: 12,
+    gap: 8,
+    backgroundColor: "#ef444420",
+  },
+  logoutIcon: {
+    fontSize: 20,
+  },
+  logoutText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#ef4444",
+  },
+  versionContainer: {
+    alignItems: "center",
+    paddingVertical: 16,
+  },
+  versionText: {
+    fontSize: 12,
+    color: "#9ca3af",
+  },
+});


### PR DESCRIPTION
…MDB-260)

- Add shared ProfileFooter component with version label and logout button
- Version read from Constants.expoConfig (app.config.js), set to 3.0.0
- Reuse ProfileFooter in Client and Provider profile screens for consistency
- Logout: confirmation dialog, auth logout(), router.replace to (auth)
- Provider profile: footer visible in scroll area with same layout as Client
