### PR TITLE
feat(chat): redirect after send quote, red dot for unread, fix naviga…

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Redirect, Tabs, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { AppState, AppStateStatus, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { HapticTab } from '@/components/haptic-tab';
@@ -9,6 +9,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useMode } from '@/contexts/ModeContext';
 import { fetchUnreadCount } from '@/services/conversations';
 import { fetchUnreadNotificationCount } from '@/services/notifications';
+
+const CHAT_UNREAD_POLL_MS = 5000; // Check every 5s so new messages show quickly
 
 function ChatTabIcon({ color, focused }: { color: string; focused: boolean }) {
   const [unreadCount, setUnreadCount] = useState(0);
@@ -24,7 +26,7 @@ function ChatTabIcon({ color, focused }: { color: string; focused: boolean }) {
 
   useEffect(() => {
     loadUnreadCount();
-    const interval = setInterval(loadUnreadCount, 30000); // Check every 30s
+    const interval = setInterval(loadUnreadCount, CHAT_UNREAD_POLL_MS);
     return () => clearInterval(interval);
   }, [loadUnreadCount]);
 
@@ -33,13 +35,19 @@ function ChatTabIcon({ color, focused }: { color: string; focused: boolean }) {
     if (focused) loadUnreadCount();
   }, [focused, loadUnreadCount]);
 
+  // Refresh badge when app comes to foreground so new message indicator appears right away
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'active') loadUnreadCount();
+    });
+    return () => sub.remove();
+  }, [loadUnreadCount]);
+
   return (
     <View>
       <Ionicons name={focused ? 'chatbubbles' : 'chatbubbles-outline'} size={20} color={color} />
       {unreadCount > 0 && (
-        <View style={styles.badge}>
-          <Text style={styles.badgeText}>{unreadCount > 9 ? '9+' : unreadCount}</Text>
-        </View>
+        <View style={styles.badgeDot} />
       )}
     </View>
   );
@@ -195,18 +203,6 @@ export default function TabLayout() {
 }
 
 const styles = StyleSheet.create({
-  badge: {
-    position: 'absolute',
-    top: -4,
-    right: -8,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  badgeText: {
-    color: '#FFFFFF',
-    fontSize: 10,
-    fontWeight: '600',
-  },
   badgeDot: {
     width: 8,
     height: 8,

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -94,15 +94,19 @@ export default function ConversationsListScreen() {
   useEffect(() => {
     if (!isAuthenticated) return;
     const sub = AppState.addEventListener("change", (state: AppStateStatus) => {
-      if (state === "active") startPolling();
-      else stopPolling();
+      if (state === "active") {
+        loadConversations(false);
+        startPolling();
+      } else {
+        stopPolling();
+      }
     });
     startPolling();
     return () => {
       sub.remove();
       stopPolling();
     };
-  }, [isAuthenticated, startPolling, stopPolling]);
+  }, [isAuthenticated, loadConversations, startPolling, stopPolling]);
 
   useFocusEffect(
     useCallback(() => {
@@ -121,9 +125,7 @@ export default function ConversationsListScreen() {
         console.error("[Chat] Invalid conversation ID:", conversationId);
         return;
       }
-      router.push(`/chat/${conversationId}`).catch((error) => {
-        console.error("[Chat] Navigation error:", error);
-      });
+      router.push(`/chat/${conversationId}`);
     } catch (error) {
       console.error("[Chat] Error in handleConversationPress:", error);
     }

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -113,6 +113,7 @@ export default function ChatScreen() {
     try {
       const { quote } = await fetchConversationActiveQuote(conversationId);
       setActiveQuote(quote);
+      if (!quote) setActiveOrder(null);
     } catch {
       setActiveQuote(null);
     }
@@ -199,7 +200,10 @@ export default function ChatScreen() {
 
     const startPolling = () => {
       if (pollingRef.current) return;
-      pollingRef.current = setInterval(() => loadMessages(false), POLLING_INTERVAL_MS);
+      pollingRef.current = setInterval(() => {
+        loadMessages(false);
+        refreshActiveQuote();
+      }, POLLING_INTERVAL_MS);
     };
     const stopPolling = () => {
       if (pollingRef.current) {
@@ -218,7 +222,7 @@ export default function ChatScreen() {
       sub.remove();
       stopPolling();
     };
-  }, [conversationId, loadConversation, loadMessages, router]);
+  }, [conversationId, loadConversation, loadMessages, refreshActiveQuote, router]);
 
   useEffect(() => {
     const showSub = Keyboard.addListener(Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow", (e) => {
@@ -278,9 +282,9 @@ export default function ChatScreen() {
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await loadMessages(false);
+    await Promise.all([loadMessages(false), refreshActiveQuote()]);
     setRefreshing(false);
-  }, [loadMessages]);
+  }, [loadMessages, refreshActiveQuote]);
 
   const handleCall = () => {
     const phone = conversation?.supplier_phone_number;

--- a/app/chat/create-quote.tsx
+++ b/app/chat/create-quote.tsx
@@ -113,6 +113,18 @@ export default function CreateQuoteScreen() {
           if (!cancelled && data.clientAddress) {
             setClientAddress(data.clientAddress);
           }
+          // If order already has an active quote, redirect to view it (avoids 409 on submit)
+          if (!cancelled && !isEditMode && data.quote && data.order?.quote_id) {
+            const status = data.quote.status;
+            if (status === "draft" || status === "sent" || status === "pending") {
+              if (conversationId) {
+                router.replace(`/chat/${conversationId}`);
+              } else {
+                router.replace(`/booking/quote/${orderId}`);
+              }
+              return;
+            }
+          }
         } else if (conversationId) {
           const addr = await fetchConversationClientAddress(conversationId);
           if (!cancelled && addr) {
@@ -126,7 +138,7 @@ export default function CreateQuoteScreen() {
       }
     })();
     return () => { cancelled = true; };
-  }, [orderId, conversationId]);
+  }, [orderId, conversationId, isEditMode, router]);
 
   useEffect(() => {
     if (!isEditMode || !orderId) return;
@@ -309,9 +321,6 @@ export default function CreateQuoteScreen() {
           address: clientAddress ? formatAddress(clientAddress) : undefined,
         };
 
-        // #region agent log
-        fetch('http://127.0.0.1:7242/ingest/0bf175bf-b05a-422e-87c8-7c4bfaecaeeb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'9b56fb'},body:JSON.stringify({sessionId:'9b56fb',location:'create-quote.tsx:handleSend',message:'create quote attempt',data:{orderId:orderId??null,conversationId:conversationId??null,path:orderId?'POST /orders/:id/quote':'POST from-conversation/quote'},timestamp:Date.now(),hypothesisId:'H2'})}).catch(()=>{});
-        // #endregion
         if (isEditMode && orderId) {
           payload.status = isDraft ? "draft" : "sent";
           await updateQuote(orderId, payload);
@@ -321,19 +330,28 @@ export default function CreateQuoteScreen() {
           await createQuoteFromConversation(conversationId!, payload);
         }
 
-        Alert.alert(
-          t("common.success"),
-          isDraft ? t("createQuote.draftSaved") : t("createQuote.quoteSent"),
-          [
-            {
-              text: t("common.ok"),
-              onPress: () =>
-                isEditMode && orderId
-                  ? router.replace(`/booking/quote/${orderId}`)
-                  : router.back(),
-            },
-          ]
-        );
+        if (!isDraft && conversationId) {
+          router.replace(`/chat/${conversationId}`);
+        } else {
+          Alert.alert(
+            t("common.success"),
+            isDraft ? t("createQuote.draftSaved") : t("createQuote.quoteSent"),
+            [
+              {
+                text: t("common.ok"),
+                onPress: () => {
+                  if (isEditMode && orderId) {
+                    router.replace(`/booking/quote/${orderId}`);
+                  } else if (conversationId) {
+                    router.replace(`/chat/${conversationId}`);
+                  } else {
+                    router.back();
+                  }
+                },
+              },
+            ]
+          );
+        }
       } catch (err: unknown) {
         const apiErr = err as { status?: number; data?: unknown; message?: string };
         const apiData = apiErr.data;
@@ -359,15 +377,19 @@ export default function CreateQuoteScreen() {
             ]
           );
         } else if (isQuoteAlreadyActive) {
+          const buttons: Array<{ text: string; onPress?: () => void }> = [
+            { text: t("common.cancel") },
+            ...(orderId
+              ? [{ text: t("chat.viewQuote"), onPress: () => router.replace(`/booking/quote/${orderId}`) }]
+              : []),
+            ...(conversationId
+              ? [{ text: t("quote.chatBack"), onPress: () => router.replace(`/chat/${conversationId}`) }]
+              : []),
+          ];
           Alert.alert(
             t("createQuote.quoteExistsTitle"),
             t("createQuote.quoteExistsMessage"),
-            [
-              { text: t("common.cancel") },
-              ...(orderId
-                ? [{ text: t("chat.viewQuote"), onPress: () => router.replace(`/booking/quote/${orderId}`) }]
-                : []),
-            ]
+            buttons
           );
         } else {
           const message = typeof apiErr.message === "string" && apiErr.message


### PR DESCRIPTION
…tion error

- Create quote: redirect to client chat immediately on successful send (no alert)
- Create quote: redirect to chat when 409 quote_already_active (add Volver al chat)
- Create quote: prevent 409 by redirecting when order already has active quote
- Chat tab: show red dot (like notifications) when unread messages; poll every 5s
- Chat tab: refresh unread count when app becomes active
- Chat list: refresh conversations when app becomes active for faster unread badges
- Chat: fix handleConversationPress TypeError (router.push().catch on undefined)
- Rejected quotes: refresh active quote in chat polling so provider sees updated status
