### PR TITLE
fix(jobs): remove empty space below content on Job Details screen

### DIFF
--- a/app/(provider-tabs)/jobs/[id].tsx
+++ b/app/(provider-tabs)/jobs/[id].tsx
@@ -242,7 +242,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   content: {
-    flexGrow: 1,
     paddingBottom: 24,
     gap: 16,
   },


### PR DESCRIPTION
Remove flexGrow: 1 from ScrollView contentContainerStyle so content does not expand and create a large black gap between the action buttons and the bottom tab bar.
