### PR TITLE
fix(profile): show client received reviews count (provider feedback)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useMode } from "@/contexts/ModeContext";
 import { t } from "@/i18n";
 import { fetchOrders } from "@/services/orders";
+import { getClientReceivedReviews } from "@/services/reviews";
 import { Ionicons } from "@expo/vector-icons";
 import { useIsFocused } from "@react-navigation/native";
 import { Image } from "expo-image";
@@ -39,15 +40,17 @@ export default function ProfileScreen() {
 
   const loadStats = useCallback(async () => {
     try {
-      const ordersData = await fetchOrders();
+      const [ordersData, reviewsData] = await Promise.all([
+        fetchOrders(),
+        getClientReceivedReviews().catch(() => ({ count: 0, reviews: [] })),
+      ]);
 
       setStats({
         services: Array.isArray(ordersData) ? ordersData.length : 0,
-        reviews: 0, // TODO: Get from reviews endpoint when available
+        reviews: reviewsData.count ?? 0,
       });
     } catch (error) {
       console.error("Error loading stats:", error);
-      // Keep default values on error
       setStats({ services: 0, reviews: 0 });
     } finally {
       setLoadingStats(false);

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -796,6 +796,9 @@ export default {
     reviews: "Reviews",
     guest: "Guest",
     version: "Version",
+    errors: {
+      reviewsFetchFailed: "Failed to load reviews",
+    },
   },
   favorites: {
     loadError: "Failed to load favorites",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -798,6 +798,9 @@ export default {
     reviews: "Reseñas",
     guest: "Invitado",
     version: "Versión",
+    errors: {
+      reviewsFetchFailed: "Error al cargar reseñas",
+    },
   },
   favorites: {
     loadError: "Error al cargar favoritos",

--- a/services/reviews.ts
+++ b/services/reviews.ts
@@ -152,8 +152,30 @@ export const respondToReview = async (
   );
 };
 
+// --- Client: ratings that providers left for the current user (provider feedback) ---
 
+export interface ClientReceivedReview {
+  id: string;
+  order_id: string;
+  rating: number;
+  comment: string | null;
+  tags: string[];
+  provider_name: string;
+  service_name: string;
+}
 
+export interface ClientReceivedReviewsResponse {
+  count: number;
+  reviews: ClientReceivedReview[];
+}
 
+// GET /reviews/received - List ratings that providers left for the current user
+export const getClientReceivedReviews = async (): Promise<ClientReceivedReviewsResponse> => {
+  return request<ClientReceivedReviewsResponse>(
+    '/reviews/received',
+    { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+    t('profile.errors.reviewsFetchFailed')
+  );
+};
 
 


### PR DESCRIPTION
- Add getClientReceivedReviews() calling GET /reviews/received
- Profile stats load reviews count in parallel with orders; display in Reseñas card
- Add ClientReceivedReview types and profile.errors.reviewsFetchFailed i18n (en/es)
- Fixes sync: provider feedback now appears in client view
