### PR TITLE
fix(chat): remove inoperative options button (3 dots) from chat header

### DIFF
--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -627,9 +627,6 @@ export default function ChatScreen() {
             {showQuoteBanner ? t("chat.viewQuote") : hasActiveOrder ? t("chat.viewOrder") : hasActiveQuote ? t("chat.viewQuote") : t("createQuote.createQuoteButton")}
           </Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.headerBtn}>
-          <Ionicons name="ellipsis-vertical" size={20} color={colors.textPrimary} />
-        </TouchableOpacity>
       </View>
 
       {/* Job banner - only when active order (not for pending_for_client — those show quote banner instead) */}


### PR DESCRIPTION
- Remove ellipsis-vertical button inside conversation screen; options menu remains available in the chat list (client and provider)