### PR TITLE
fix(client): show provider-specific service names instead of category…

### DIFF
--- a/app/booking/date-time.tsx
+++ b/app/booking/date-time.tsx
@@ -121,7 +121,7 @@ export default function BookingDateTimeScreen() {
         return;
       }
 
-      console.log('[BookingDateTime] Selected service:', selectedService.category_name);
+      console.log('[BookingDateTime] Selected service:', selectedService.name || selectedService.category_name);
     } catch (err) {
       console.error('[BookingDateTime] Error loading data:', err);
       if (err instanceof ApiError) {
@@ -178,7 +178,7 @@ export default function BookingDateTimeScreen() {
   const providerCardInfo: BookingDateTimePickerProviderCard | undefined = supplier && service
     ? {
         name: supplier.business_name?.trim() || supplier.full_name,
-        serviceInfo: `${service.category_name || 'Service'} • $${service.price || 0}${t('supplier.perHour')}`,
+        serviceInfo: `${service.name?.trim() || service.category_name || 'Service'} • $${service.price || 0}${t('supplier.perHour')}`,
         profileImage: supplier.profile_image,
       }
     : undefined;

--- a/app/booking/summary.tsx
+++ b/app/booking/summary.tsx
@@ -251,7 +251,7 @@ export default function BookingSummaryScreen() {
             {/* Service */}
             <View style={styles.detailRow}>
               <Text style={styles.detailLabel}>{t("booking.service")}</Text>
-              <Text style={styles.detailValue}>{service.category_name || service.description || "Service"}</Text>
+              <Text style={styles.detailValue}>{service.name?.trim() || service.category_name || service.description || "Service"}</Text>
             </View>
 
             {/* Date */}
@@ -294,7 +294,7 @@ export default function BookingSummaryScreen() {
             {/* Service Cost */}
             <View style={styles.priceRow}>
               <Text style={styles.priceLabel}>
-                {service.category_name || "Service"} ({duration} {t("booking.hours")} x ${service.price || 60}/hr)
+                {service.name?.trim() || service.category_name || "Service"} ({duration} {t("booking.hours")} x ${service.price || 60}/hr)
               </Text>
               <Text style={styles.priceValue}>${pricing.serviceCost.toFixed(2)}</Text>
             </View>

--- a/app/services/suppliers/[supplierId].tsx
+++ b/app/services/suppliers/[supplierId].tsx
@@ -159,8 +159,14 @@ export default function ProviderDetailScreen() {
     setAboutExpanded(!aboutExpanded);
   };
 
-  // Format service duration - extract from description or use defaults
+  // Format service duration - use API value, then description, then defaults
   const getServiceDuration = (service: SupplierService): string => {
+    if (service.duration_minutes != null && service.duration_minutes > 0) {
+      const mins = service.duration_minutes;
+      if (mins < 60) return `${mins} min`;
+      const hrs = mins / 60;
+      return hrs % 1 === 0 ? `${hrs} hr` : `${(mins / 60).toFixed(1)} hr`;
+    }
     // Try to extract duration from description (e.g., "2-3 hours", "1-2 hrs")
     if (service.description) {
       const durationMatch = service.description.match(/(\d+)[-\s](\d+)\s*(hr|hour|h)/i);
@@ -362,7 +368,7 @@ export default function ProviderDetailScreen() {
                   >
                     <View style={styles.serviceInfo}>
                       <Text style={styles.serviceName}>
-                        {service.category_name || 'Service'}
+                        {service.name?.trim() || service.category_name || 'Service'}
                       </Text>
                       <View style={styles.serviceDurationRow}>
                         <Ionicons name="time-outline" size={14} color={colors.textSecondary} />

--- a/services/suppliers.ts
+++ b/services/suppliers.ts
@@ -30,11 +30,15 @@ export interface Supplier {
 export interface SupplierService {
   id: string;
   supplier_id: string;
+  /** Provider-defined specific name (e.g. "Electricidad cocina"). Shown to clients. */
+  name?: string;
   category_id: string;
   category_name?: string;
   category_key?: string;
   price?: number;
   description?: string;
+  /** Duration in minutes. Used for display (e.g. "45 min", "1-3 hrs"). */
+  duration_minutes?: number | null;
   active: boolean;
 }
 


### PR DESCRIPTION
… only

- Add name and duration_minutes to SupplierService type (from API)
- Provider detail: display service.name with fallback to category_name
- Use duration_minutes in getServiceDuration when available
- Booking date-time and summary: show specific service name in UI

Fixes loss of service name specificity in client view (e.g. Kitchen Electricity vs generic Electrical).
