### PR TITLE
fix(profile): show provider profile picture in client views (MDB-261)

### DIFF
--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -436,7 +436,11 @@ export default function ChatScreen() {
         <View style={[styles.messageRow, isMine && styles.messageRowMine]}>
           {!isMine && (
             <View style={styles.avatarSmall}>
-              <Text style={styles.avatarSmallEmoji}>👩</Text>
+              <ProviderAvatar
+                profileImage={user?.id === conversation?.client_id ? conversation?.supplier_image : conversation?.client_image ?? null}
+                size={28}
+                rounded
+              />
             </View>
           )}
           <View style={[styles.bubbleWrapper, isMine && styles.bubbleWrapperMine]}>

--- a/services/suppliers.ts
+++ b/services/suppliers.ts
@@ -205,7 +205,13 @@ export const fetchSupplierProfile = async (
     }
 
     const data: SupplierProfileResponse = await response.json();
-    return data.supplier;
+    const raw = data.supplier as Record<string, unknown>;
+    // API may return profile_image_url (resolved) and/or profile_image (raw); ensure profile_image is set for UI
+    const profileImage =
+      (raw.profile_image_url as string | undefined) ??
+      (raw.profile_image as string | undefined) ??
+      (raw.profileImage as string | undefined);
+    return { ...raw, profile_image: profileImage } as Supplier;
   } catch (error) {
     if (error instanceof ApiError) {
       throw error;


### PR DESCRIPTION
- Normalize supplier profile response: set profile_image from profile_image_url when API returns resolved URL so customer view shows provider avatar.
- Use ProviderAvatar with supplier/client image in chat message rows instead of static emoji so provider photo appears in conversation.