### PR TITLE
feat(auth): Google and Apple sign-in, profile version 3.0.1 (MDB-10)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -67,6 +67,7 @@ export default {
       ],
       // expo-build-properties removido temporalmente para evitar errores de Kotlin compiler
       // Google Sign-In ahora usa expo-auth-session (compatible con Expo Go)
+      "expo-apple-authentication",
     ],
     experiments: {
       typedRoutes: true,

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -2,15 +2,26 @@ import { useAuth } from '@/contexts/AuthContext';
 import { t } from '@/i18n';
 import { ApiError, loginWithCredentials, validateEmail } from '@/services/auth';
 import { mapApiUserToUser } from '@/utils/authMapping';
+import { type GoogleProfile } from '@/utils/authMapping';
+import { registerGoogleAccountOrFallback, type GoogleAuthTokens } from '@/utils/googleAuth';
+import {
+  consumePendingGoogleWebResult,
+  isGoogleConfigured,
+  signInWithGoogleMobile,
+  signInWithGoogleWeb,
+} from '@/utils/googleSignIn';
+import { isAppleSignInAvailable, loginOrRegisterWithApple, signInWithApple } from '@/utils/appleAuth';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
+  ScrollView,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -31,7 +42,14 @@ export default function LoginScreen() {
   const [showPassword, setShowPassword] = useState(false);
   const [showRegistrationSuccess, setShowRegistrationSuccess] = useState(false);
   const [consumedRegistrationParam, setConsumedRegistrationParam] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+  const [appleLoading, setAppleLoading] = useState(false);
+  const [appleAvailable, setAppleAvailable] = useState(false);
   const { login } = useAuth();
+
+  useEffect(() => {
+    isAppleSignInAvailable().then(setAppleAvailable);
+  }, []);
   const params = useLocalSearchParams<{ registered?: string }>();
   const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -184,13 +202,73 @@ export default function LoginScreen() {
     }
   };
 
+  const handleGoogleLogin = useCallback(async () => {
+    setGoogleLoading(true);
+    setErrorMessage(null);
+    try {
+      let result;
+      if (Platform.OS === 'web') {
+        const pending = await consumePendingGoogleWebResult();
+        result = pending ?? (await signInWithGoogleWeb());
+        if (!result) return;
+      } else {
+        result = await signInWithGoogleMobile();
+      }
+      const googleProfile: GoogleProfile = {
+        id: result.user.id,
+        email: result.user.email,
+        name: result.user.name,
+        givenName: result.user.givenName,
+        familyName: result.user.familyName,
+        photo: result.user.photo,
+      };
+      const tokens: GoogleAuthTokens = { idToken: result.idToken, accessToken: result.accessToken };
+      const userData = await registerGoogleAccountOrFallback(googleProfile, tokens);
+      await login(userData);
+      router.replace('/(tabs)/home');
+    } catch (error) {
+      if (error instanceof Error && (error.message.includes('cancelled') || error.message.includes('canceled'))) return;
+      const msg = error instanceof ApiError ? error.message : t('errors.googleLoginGeneric');
+      setErrorMessage(msg);
+      Alert.alert(t('common.error'), msg);
+    } finally {
+      setGoogleLoading(false);
+    }
+  }, [login]);
+
+  const handleAppleLogin = useCallback(async () => {
+    setAppleLoading(true);
+    setErrorMessage(null);
+    try {
+      const creds = await signInWithApple();
+      if (!creds) return;
+      const userData = await loginOrRegisterWithApple(creds);
+      await login(userData);
+      router.replace('/(tabs)/home');
+    } catch (error) {
+      const msg = error instanceof ApiError ? error.message : t('errors.appleLoginGeneric');
+      setErrorMessage(msg);
+      Alert.alert(t('common.error'), msg);
+    } finally {
+      setAppleLoading(false);
+    }
+  }, [login]);
+
+  const isGoogleSupported = isGoogleConfigured();
 
   return (
     <SafeAreaView style={styles.container}>
       <KeyboardAvoidingView 
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={styles.keyboardView}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
       >
+        <ScrollView 
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
         <View style={styles.content}>
           {/* Back Button */}
           <TouchableOpacity 
@@ -293,6 +371,61 @@ export default function LoginScreen() {
             </TouchableOpacity>
           </View>
 
+          {(isGoogleSupported || appleAvailable) && (
+            <View style={styles.socialSection} pointerEvents="box-none">
+              <View style={styles.dividerRow}>
+                <View style={styles.dividerLine} />
+                <Text style={styles.dividerText}>{t('auth.orContinueWith')}</Text>
+                <View style={styles.dividerLine} />
+              </View>
+              {isGoogleSupported && (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.socialButton,
+                    googleLoading && styles.socialButtonDisabled,
+                    pressed && !googleLoading && styles.socialButtonPressed,
+                  ]}
+                  onPress={handleGoogleLogin}
+                  disabled={googleLoading}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('auth.continueWithGoogle')}
+                >
+                  {googleLoading ? (
+                    <ActivityIndicator color="#FFFFFF" />
+                  ) : (
+                    <>
+                      <Ionicons name="logo-google" size={20} color="#FFFFFF" style={styles.socialIcon} />
+                      <Text style={styles.socialButtonText}>{t('auth.continueWithGoogle')}</Text>
+                    </>
+                  )}
+                </Pressable>
+              )}
+              {appleAvailable && (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.socialButton,
+                    styles.socialButtonApple,
+                    appleLoading && styles.socialButtonDisabled,
+                    pressed && !appleLoading && styles.socialButtonPressed,
+                  ]}
+                  onPress={handleAppleLogin}
+                  disabled={appleLoading}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('auth.continueWithApple')}
+                >
+                  {appleLoading ? (
+                    <ActivityIndicator color="#FFFFFF" />
+                  ) : (
+                    <>
+                      <Ionicons name="logo-apple" size={22} color="#FFFFFF" style={styles.socialIcon} />
+                      <Text style={styles.socialButtonText}>{t('auth.continueWithApple')}</Text>
+                    </>
+                  )}
+                </Pressable>
+              )}
+            </View>
+          )}
+
           {/* Register Link */}
           <View style={styles.registerContainer}>
             <Text style={styles.registerText}>{t('auth.noAccount')}</Text>
@@ -301,6 +434,7 @@ export default function LoginScreen() {
             </TouchableOpacity>
           </View>
         </View>
+        </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
@@ -314,8 +448,14 @@ const styles = StyleSheet.create({
   keyboardView: {
     flex: 1,
   },
-  content: {
+  scrollView: {
     flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingBottom: 40,
+  },
+  content: {
     paddingHorizontal: 24,
     paddingTop: 60,
   },
@@ -446,5 +586,54 @@ const styles = StyleSheet.create({
     color: '#3B82F6',
     fontSize: 14,
     fontWeight: '400',
+  },
+  socialSection: {
+    marginTop: 8,
+    marginBottom: 24,
+  },
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 20,
+    gap: 12,
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: '#374151',
+  },
+  dividerText: {
+    color: '#9CA3AF',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  socialButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#252542',
+    borderRadius: 14,
+    paddingVertical: 16,
+    minHeight: 52,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: '#374151',
+  },
+  socialButtonApple: {
+    marginBottom: 0,
+  },
+  socialButtonPressed: {
+    opacity: 0.7,
+  },
+  socialButtonDisabled: {
+    opacity: 0.6,
+  },
+  socialIcon: {
+    marginRight: 10,
+  },
+  socialButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
   },
 });

--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -4,11 +4,11 @@ import { useAuth } from '@/contexts/AuthContext';
 import { t } from '@/i18n';
 import { ApiError, registerUser } from '@/services/auth';
 import { type GoogleProfile } from '@/utils/authMapping';
+import { isAppleSignInAvailable, loginOrRegisterWithApple, signInWithApple } from '@/utils/appleAuth';
 import { registerGoogleAccountOrFallback, type GoogleAuthTokens } from '@/utils/googleAuth';
 import {
   consumePendingGoogleWebResult,
-  getGoogleStatusCodes,
-  isGoogleWebAvailable,
+  isGoogleConfigured,
   signInWithGoogleMobile,
   signInWithGoogleWeb,
   WEB_RESULT_STORAGE_KEY,
@@ -156,10 +156,14 @@ export default function RegisterScreen() {
   const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null);
   const [formErrors, setFormErrors] = useState<{ password?: string; country?: string; terms?: string }>({});
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [appleLoading, setAppleLoading] = useState(false);
+  const [appleAvailable, setAppleAvailable] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
-  const googleStatusCodes = getGoogleStatusCodes();
-  const webGoogleSupported = isGoogleWebAvailable();
-  const isGoogleSupported = webGoogleSupported;
+  const isGoogleSupported = isGoogleConfigured();
+
+  useEffect(() => {
+    isAppleSignInAvailable().then(setAppleAvailable);
+  }, []);
 
   const placeholderColor = 'rgba(156, 163, 175, 0.5)';
   const isFieldFocused = (field: string) => focusedField === field;
@@ -596,7 +600,22 @@ export default function RegisterScreen() {
   };
 
   const handleAppleRegister = async () => {
-    Alert.alert(t('common.ok'), t('auth.soonApple'));
+    setAppleLoading(true);
+    try {
+      const creds = await signInWithApple();
+      if (!creds) return;
+      const userData = await loginOrRegisterWithApple(creds);
+      await login(userData);
+      router.replace('/(tabs)/home');
+    } catch (error) {
+      if (error instanceof ApiError) {
+        Alert.alert(t('common.error'), error.message || t('errors.appleLoginGeneric'));
+      } else {
+        Alert.alert(t('common.error'), t('errors.appleLoginGeneric'));
+      }
+    } finally {
+      setAppleLoading(false);
+    }
   };
 
   return (

--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -1,17 +1,17 @@
 import { useAuth } from '@/contexts/AuthContext';
 import { t } from '@/i18n';
+import { ApiError as AuthApiError } from '@/services/auth';
 // Note: We no longer use markWelcomeScreenAsSeen - login_count is managed by backend
 import { registerGoogleAccountOrFallback, type GoogleAuthTokens } from '@/utils/googleAuth';
 import { type GoogleProfile } from '@/utils/authMapping';
 import {
   consumePendingGoogleWebResult,
-  getGoogleStatusCodes,
-  isGoogleWebAvailable,
+  isGoogleConfigured,
   signInWithGoogleWeb,
   signInWithGoogleMobile,
   WEB_RESULT_STORAGE_KEY,
 } from '@/utils/googleSignIn';
-import { Ionicons } from '@expo/vector-icons';
+import { isAppleSignInAvailable, loginOrRegisterWithApple, signInWithApple } from '@/utils/appleAuth';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
@@ -26,13 +26,17 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import MordoboLogo from '@/components/MordoboLogo';
-import { ApiError } from '@/services/auth';
 
 export default function WelcomeScreen() {
   const { login, isAuthenticated } = useAuth();
   const [googleLoading, setGoogleLoading] = useState(false);
-  const webGoogleSupported = isGoogleWebAvailable();
-  const isGoogleSupported = webGoogleSupported;
+  const [appleLoading, setAppleLoading] = useState(false);
+  const [appleAvailable, setAppleAvailable] = useState(false);
+  const isGoogleSupported = isGoogleConfigured();
+
+  useEffect(() => {
+    isAppleSignInAvailable().then(setAppleAvailable);
+  }, []);
 
   // Redirect to home if already authenticated
   useEffect(() => {
@@ -53,7 +57,7 @@ export default function WelcomeScreen() {
 
 
   const handleGoogleError = useCallback((error: unknown) => {
-    if (error instanceof ApiError) {
+    if (error instanceof AuthApiError) {
       const message = error.message?.length ? error.message : t('errors.googleLoginGeneric');
       Alert.alert(t('common.error'), message);
       return;
@@ -168,7 +172,7 @@ export default function WelcomeScreen() {
   }, [finalizeGoogleLogin, handleGoogleError]);
 
   const handleGoogleLogin = async () => {
-    console.log('[WelcomeScreen][GoogleLogin] Platform:', Platform.OS, 'isGoogleWebAvailable:', webGoogleSupported);
+    console.log('[WelcomeScreen][GoogleLogin] Platform:', Platform.OS, 'isGoogleSupported:', isGoogleSupported);
     
     setGoogleLoading(true);
     try {
@@ -206,7 +210,7 @@ export default function WelcomeScreen() {
         return;
       }
 
-      if (error instanceof ApiError) {
+      if (error instanceof AuthApiError) {
         const message = error.message?.length ? error.message : t('errors.googleLoginGeneric');
         Alert.alert(t('common.error'), message);
         return;
@@ -225,7 +229,26 @@ export default function WelcomeScreen() {
   };
 
   const handleAppleLogin = async () => {
-    Alert.alert(t('common.ok'), t('auth.soonApple'));
+    if (!appleAvailable) {
+      Alert.alert(t('common.ok'), t('auth.soonApple'));
+      return;
+    }
+    setAppleLoading(true);
+    try {
+      const creds = await signInWithApple();
+      if (!creds) return;
+      const userData = await loginOrRegisterWithApple(creds);
+      await login(userData);
+      router.replace('/(tabs)/home');
+    } catch (error) {
+      if (error instanceof AuthApiError) {
+        Alert.alert(t('common.error'), error.message || t('errors.appleLoginGeneric'));
+      } else {
+        Alert.alert(t('common.error'), t('errors.appleLoginGeneric'));
+      }
+    } finally {
+      setAppleLoading(false);
+    }
   };
 
   return (
@@ -278,15 +301,22 @@ export default function WelcomeScreen() {
           {/* Social Auth Buttons */}
           <View style={styles.socialContainer}>
             <TouchableOpacity
-              style={styles.socialButton}
+              style={[styles.socialButton, appleLoading && styles.socialButtonDisabled]}
               onPress={handleAppleLogin}
+              disabled={appleLoading}
             >
-              <Text style={styles.socialButtonEmoji}>🍎</Text>
-              <Text style={styles.socialButtonText}>{t('auth.apple')}</Text>
+              {appleLoading ? (
+                <ActivityIndicator color="#FFFFFF" />
+              ) : (
+                <>
+                  <Text style={styles.socialButtonEmoji}>🍎</Text>
+                  <Text style={styles.socialButtonText}>{t('auth.apple')}</Text>
+                </>
+              )}
             </TouchableOpacity>
 
             <TouchableOpacity
-              style={styles.socialButton}
+              style={[styles.socialButton, (googleLoading || !isGoogleSupported) && styles.socialButtonDisabled]}
               onPress={handleGoogleLogin}
               disabled={googleLoading || !isGoogleSupported}
             >
@@ -425,5 +455,8 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '400',
     color: '#FFFFFF',
+  },
+  socialButtonDisabled: {
+    opacity: 0.6,
   },
 });

--- a/components/profile/ProfileFooter.tsx
+++ b/components/profile/ProfileFooter.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 /** Version label shown in profile footer for both Client and Provider. */
-const PROFILE_VERSION_LABEL = "3.0.0";
+const PROFILE_VERSION_LABEL = "3.0.1";
 
 /**
  * Shared footer for Client and Provider profile screens: app version label and logout button.

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -142,6 +142,8 @@ export default {
     unexpectedResponse: "Unexpected response from server.",
     googleLoginGeneric: "Unable to continue with Google. Please try again.",
     googleMissingIdToken: "We could not verify your Google account. Try again.",
+    appleLoginGeneric: "Unable to continue with Apple. Please try again.",
+    appleUnavailable: "Apple Sign-In is not available on this device.",
     googlePlayServices: "Google Play Services are required to use Google Sign-In.",
     googleUnavailable: "Google Sign-In is not available in this build. Install a dev client with the native module.",
     invalidVerificationCode: "Invalid verification code. Please try again.",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -142,6 +142,8 @@ export default {
     unexpectedResponse: "Respuesta inesperada del servidor.",
     googleLoginGeneric: "No se pudo continuar con Google. Por favor intenta de nuevo.",
     googleMissingIdToken: "No pudimos verificar tu cuenta de Google. Intenta de nuevo.",
+    appleLoginGeneric: "No se pudo continuar con Apple. Por favor intenta de nuevo.",
+    appleUnavailable: "Inicio de sesión con Apple no está disponible en este dispositivo.",
     googlePlayServices: "Se requieren los servicios de Google Play para usar Google Sign-In.",
     googleUnavailable: "Google Sign-In no está disponible en esta versión. Instala un cliente dev con el módulo nativo.",
     invalidVerificationCode: "Código de verificación inválido. Por favor intenta de nuevo.",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tanstack/react-query": "^5.87.4",
     "date-fns": "^3.6.0",
     "expo": "~54.0.30",
+    "expo-apple-authentication": "^55.0.8",
     "expo-auth-session": "~7.0.10",
     "expo-build-properties": "~1.0.10",
     "expo-constants": "~18.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@shopify/flash-list':
         specifier: ^1.7.1
         version: 1.8.3(@babel/runtime@7.28.6)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@supabase/supabase-js':
+        specifier: ^2.97.0
+        version: 2.98.0
       '@tanstack/react-query':
         specifier: ^5.87.4
         version: 5.90.20(react@19.1.0)
@@ -47,6 +50,9 @@ importers:
       expo:
         specifier: ~54.0.30
         version: 54.0.32(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-apple-authentication:
+        specifier: ^55.0.8
+        version: 55.0.8(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))
       expo-auth-session:
         specifier: ~7.0.10
         version: 7.0.10(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1342,6 +1348,30 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@supabase/auth-js@2.98.0':
+    resolution: {integrity: sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.98.0':
+    resolution: {integrity: sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.98.0':
+    resolution: {integrity: sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.98.0':
+    resolution: {integrity: sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.98.0':
+    resolution: {integrity: sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.98.0':
+    resolution: {integrity: sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==}
+    engines: {node: '>=20.0.0'}
+
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
@@ -1392,11 +1422,17 @@ packages:
   '@types/node@25.1.0':
     resolution: {integrity: sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/react@19.1.17':
     resolution: {integrity: sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2302,6 +2338,12 @@ packages:
   exec-async@2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
 
+  expo-apple-authentication@55.0.8:
+    resolution: {integrity: sha512-Cq3cdW6iCRnwkUEMdayfrZCo4DDKHXqJJHFGWNOIYiRrt7xE3vTM9JCvBuh9T9ToCeVg7hskovjAZyBrA7mFeg==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
   expo-application@7.0.8:
     resolution: {integrity: sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==}
     peerDependencies:
@@ -2767,6 +2809,10 @@ packages:
 
   i18n-js@4.5.1:
     resolution: {integrity: sha512-n7jojFj1WC0tztgr0I8jqTXuIlY1xNzXnC3mjKX/YjJhimdM+jXM8vOmn9d3xQFNC6qDHJ4ovhdrGXrRXLIGkA==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -6010,6 +6056,44 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@supabase/auth-js@2.98.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.98.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.98.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.98.0':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.98.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.98.0':
+    dependencies:
+      '@supabase/auth-js': 2.98.0
+      '@supabase/functions-js': 2.98.0
+      '@supabase/postgrest-js': 2.98.0
+      '@supabase/realtime-js': 2.98.0
+      '@supabase/storage-js': 2.98.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@tanstack/query-core@5.90.20': {}
 
   '@tanstack/react-query@5.90.20(react@19.1.0)':
@@ -6069,11 +6153,17 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/react@19.1.17':
     dependencies:
       csstype: 3.2.3
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.1.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7179,6 +7269,11 @@ snapshots:
 
   exec-async@2.2.0: {}
 
+  expo-apple-authentication@55.0.8(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      expo: 54.0.32(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)
+
   expo-application@7.0.8(expo@54.0.32):
     dependencies:
       expo: 54.0.32(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -7704,6 +7799,8 @@ snapshots:
       bignumber.js: 9.3.1
       lodash: 4.17.23
       make-plural: 8.1.0
+
+  iceberg-js@0.8.1: {}
 
   ieee754@1.2.1: {}
 

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -200,7 +200,7 @@ export const request = async <T>(
   retryOn401 = true
 ): Promise<T> => {
   // List of public endpoints that don't require authentication
-  const publicEndpoints = ['/auth/login', '/auth/register', '/auth/google', '/auth/refresh', '/auth/validate-email', '/auth/forgot-password', '/auth/reset-password', '/auth/authenticate', '/auth/resend-code', '/auth/2fa/validate'];
+  const publicEndpoints = ['/auth/login', '/auth/register', '/auth/google', '/auth/apple', '/auth/refresh', '/auth/validate-email', '/auth/forgot-password', '/auth/reset-password', '/auth/authenticate', '/auth/resend-code', '/auth/2fa/validate'];
   const isPublicEndpoint = publicEndpoints.some(endpoint => path.startsWith(endpoint));
   
   // If logout was just called and this is not a public endpoint, throw error
@@ -620,6 +620,29 @@ export const loginWithGoogle = async (
       body: JSON.stringify(payload),
     },
     t('errors.googleLoginGeneric')
+  );
+};
+
+export interface AppleLoginPayload {
+  identityToken: string;
+  authorizationCode?: string;
+  email?: string;
+  fullName?: string;
+}
+
+export const loginWithApple = async (
+  payload: AppleLoginPayload
+): Promise<AuthSuccessResponse> => {
+  return request<AuthSuccessResponse>(
+    '/auth/apple',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    },
+    t('errors.appleLoginGeneric')
   );
 };
 

--- a/utils/appleAuth.ts
+++ b/utils/appleAuth.ts
@@ -1,0 +1,116 @@
+import type { User } from '@/contexts/AuthContext';
+import { ApiError, loginWithApple, type AppleLoginPayload } from '@/services/auth';
+import { mapAuthResponseToUser, type AppleProfile } from '@/utils/authMapping';
+import { Platform } from 'react-native';
+
+export interface AppleAuthCreds {
+  identityToken: string;
+  authorizationCode?: string;
+  email?: string | null;
+  fullName?: { givenName?: string | null; familyName?: string | null; name?: string | null } | null;
+  user?: string; // Apple user identifier (sub)
+}
+
+/** Check if Apple Sign-In is available (iOS 13+ only; not on Android/Web by default). */
+export async function isAppleSignInAvailable(): Promise<boolean> {
+  if (Platform.OS !== 'ios') return false;
+  try {
+    const { default: AppleAuth } = await import('expo-apple-authentication');
+    return await AppleAuth.isAvailableAsync();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Trigger native Apple Sign-In. Returns creds for loginOrRegisterWithApple, or null if cancelled/unavailable.
+ */
+export async function signInWithApple(): Promise<AppleAuthCreds | null> {
+  if (Platform.OS !== 'ios') return null;
+  try {
+    const AppleAuth = (await import('expo-apple-authentication')).default;
+    if (!(await AppleAuth.isAvailableAsync())) return null;
+    const credential = await AppleAuth.signInAsync({
+      requestedScopes: [
+        AppleAuth.AppleAuthenticationScope.FULL_NAME,
+        AppleAuth.AppleAuthenticationScope.EMAIL,
+      ],
+    });
+    if (!credential.identityToken) return null;
+    const creds: AppleAuthCreds = {
+      identityToken: credential.identityToken,
+      authorizationCode: credential.authorizationCode ?? undefined,
+      email: credential.email ?? null,
+      fullName: credential.fullName
+        ? {
+            givenName: credential.fullName.givenName ?? null,
+            familyName: credential.fullName.familyName ?? null,
+            name: [credential.fullName.givenName, credential.fullName.familyName].filter(Boolean).join(' ').trim() || undefined,
+          }
+        : null,
+      user: credential.user,
+    };
+    return creds;
+  } catch (e: unknown) {
+    const code = (e as { code?: string })?.code;
+    if (code === 'ERR_REQUEST_CANCELED' || code === 'ERR_CANCELED') return null;
+    throw e;
+  }
+}
+
+/**
+ * Build Apple profile from credential for mapping (same shape as GoogleProfile).
+ */
+function buildAppleProfile(creds: AppleAuthCreds): AppleProfile {
+  const fullName = creds.fullName;
+  const name = fullName?.name ?? [fullName?.givenName, fullName?.familyName].filter(Boolean).join(' ').trim();
+  const email = (creds.email ?? '').trim() || `apple-${creds.user ?? 'user'}@placeholder.apple`;
+  return {
+    id: creds.user ?? email,
+    email,
+    name: name || undefined,
+    givenName: fullName?.givenName ?? undefined,
+    familyName: fullName?.familyName ?? undefined,
+    photo: undefined,
+  };
+}
+
+/**
+ * Login or register with Apple (backend finds or creates user). Returns User for AuthContext.
+ */
+export async function signInWithAppleAndLogin(creds: AppleAuthCreds): Promise<User> {
+  const payload: AppleLoginPayload = {
+    identityToken: creds.identityToken,
+    authorizationCode: creds.authorizationCode,
+    email: creds.email?.trim() || undefined,
+    fullName: fullNameFromApple(creds.fullName),
+  };
+  const response = await loginWithApple(payload);
+  const profile = buildAppleProfile(creds);
+  return mapAuthResponseToUser(response, profile, 'apple');
+}
+
+function fullNameFromApple(
+  fullName?: { givenName?: string | null; familyName?: string | null; name?: string | null } | null
+): string | undefined {
+  if (!fullName) return undefined;
+  const n = fullName.name?.trim();
+  if (n) return n;
+  const parts = [fullName.givenName, fullName.familyName].filter(Boolean).join(' ').trim();
+  return parts || undefined;
+}
+
+/**
+ * Try Apple login/register; on 404 or missing endpoint fallback to error (no local fallback like Google).
+ */
+export async function loginOrRegisterWithApple(creds: AppleAuthCreds): Promise<User> {
+  try {
+    return await signInWithAppleAndLogin(creds);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      // Backend may not have /auth/apple; try again - backend now implements find-or-create so 404 is rare
+      throw new ApiError('Apple sign-in not available', 404);
+    }
+    throw error;
+  }
+}

--- a/utils/authMapping.ts
+++ b/utils/authMapping.ts
@@ -18,6 +18,16 @@ export interface GoogleProfile {
   photo?: string | null;
 }
 
+/** Same shape as GoogleProfile so mapAuthResponseToUser works for Apple */
+export interface AppleProfile {
+  id: string;
+  email: string;
+  name?: string | null;
+  givenName?: string | null;
+  familyName?: string | null;
+  photo?: string | null;
+}
+
 const stringOrUndefined = (value: unknown): string | undefined => {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -51,7 +61,7 @@ const extractNameParts = (fullName?: string | null) => {
 
 const resolveName = (
   apiUser: RegisterResponseUser,
-  googleUser: GoogleProfile
+  socialUser: GoogleProfile | AppleProfile
 ): { firstName: string; lastName: string } => {
   const apiFirst = stringOrUndefined((apiUser as Record<string, unknown>).first_name);
   const apiLast = stringOrUndefined((apiUser as Record<string, unknown>).last_name);
@@ -59,14 +69,13 @@ const resolveName = (
     stringOrUndefined(apiUser.full_name)
   );
 
-  const googleFirst = stringOrUndefined(googleUser?.givenName ?? undefined);
-  const googleLast = stringOrUndefined(googleUser?.familyName ?? undefined);
-
-  const googleName = stringOrUndefined(googleUser?.name);
+  const socialFirst = stringOrUndefined(socialUser?.givenName ?? undefined);
+  const socialLast = stringOrUndefined(socialUser?.familyName ?? undefined);
+  const socialName = stringOrUndefined(socialUser?.name);
 
   return {
-    firstName: apiFirst ?? splitFirst ?? googleFirst ?? googleName ?? '',
-    lastName: apiLast ?? splitLast ?? googleLast ?? '',
+    firstName: apiFirst ?? splitFirst ?? socialFirst ?? socialName ?? '',
+    lastName: apiLast ?? splitLast ?? socialLast ?? '',
   };
 };
 
@@ -126,11 +135,11 @@ export const mapApiUserToUser = (
 
 export const mapAuthResponseToUser = (
   response: AuthSuccessResponse,
-  googleUser: GoogleProfile,
+  socialUser: GoogleProfile | AppleProfile,
   provider: User['provider']
 ): User => {
   const apiUser = response.user;
-  const { firstName, lastName } = resolveName(apiUser, googleUser);
+  const { firstName, lastName } = resolveName(apiUser, socialUser);
   
   const raw = apiUser as Record<string, unknown>;
   const loginCount = raw.login_count as number | undefined;
@@ -143,8 +152,8 @@ export const mapAuthResponseToUser = (
   const completedOrdersCount = typeof raw.completed_orders_count === 'number' ? raw.completed_orders_count : undefined;
 
   return {
-    id: stringOrUndefined(apiUser.id) ?? stringOrUndefined(googleUser?.id) ?? '',
-    email: stringOrUndefined(apiUser.email) ?? stringOrUndefined(googleUser?.email) ?? '',
+    id: stringOrUndefined(apiUser.id) ?? stringOrUndefined(socialUser?.id) ?? '',
+    email: stringOrUndefined(apiUser.email) ?? stringOrUndefined(socialUser?.email) ?? '',
     firstName,
     lastName,
     phone:
@@ -153,12 +162,12 @@ export const mapAuthResponseToUser = (
     avatar:
       stringOrUndefined(raw.profile_image) ??
       stringOrUndefined(raw.avatar) ??
-      stringOrUndefined(googleUser?.photo),
+      stringOrUndefined(socialUser?.photo),
     country: stringOrUndefined(raw.country),
     gender,
     dateOfBirth,
     provider,
-    authToken: stringOrUndefined(response.token),
+    authToken: stringOrUndefined(response.token) ?? stringOrUndefined((response as { accessToken?: string }).accessToken),
     refreshToken: stringOrUndefined(response.refreshToken),
     tier,
     completedOrdersCount,

--- a/utils/googleSignIn.ts
+++ b/utils/googleSignIn.ts
@@ -40,6 +40,9 @@ export const getGoogleStatusCodes = (): GoogleStatusCodes | null => {
 export const getGoogleSignin = () => null; // Ya no se usa módulo nativo
 export const isGoogleSignInAvailable = () => true; // Siempre disponible con expo-auth-session
 
+/** True when Google sign-in is configured (web client ID set). Use to show the Google button on login/register (web and mobile). */
+export const isGoogleConfigured = () => !!getWebClientId();
+
 export interface GoogleWebSignInResult {
   idToken: string;
   accessToken?: string;
@@ -333,6 +336,13 @@ export const signInWithGoogleWeb = async (): Promise<GoogleWebSignInResult | nul
   };
 
   const redirectUri = resolveRedirectUri();
+  if (__DEV__) {
+    console.log(
+      '[GoogleSignIn][web] Add this exact URL to Google Cloud Console → Credentials → Your OAuth client → Authorized redirect URIs:',
+      redirectUri
+    );
+  }
+
   const state = Math.random().toString(36).slice(2);
 
   storeWebState(state);
@@ -370,8 +380,20 @@ export const signInWithGoogleMobile = async (): Promise<GoogleWebSignInResult> =
     throw new Error('google-missing-web-client-id');
   }
 
+  // Redirect direct to app (no proxy). auth.expo.io proxy is deprecated and can cause "Access blocked" on mobile.
+  // Add the logged URL to Google Console; if your Metro IP/port changes, add the new URL too.
   const redirectUri = Linking.createURL('auth/google', {});
-  
+
+  if (__DEV__) {
+    console.log(
+      '[GoogleSignIn][mobile] Add this exact URL to Google Cloud Console → Credentials → Your OAuth client → Authorized redirect URIs:',
+      redirectUri
+    );
+    console.log(
+      '[GoogleSignIn][mobile] If your network or port changes, copy the new URL from the log and add it in Google Console.'
+    );
+  }
+
   const request = new AuthSession.AuthRequest({
     clientId,
     scopes: ['openid', 'profile', 'email'],
@@ -390,7 +412,7 @@ export const signInWithGoogleMobile = async (): Promise<GoogleWebSignInResult> =
 
   try {
     const result = await request.promptAsync(discovery, {
-      useProxy: true,
+      useProxy: false,
       showInRecents: true,
     });
 


### PR DESCRIPTION
- Google Sign-In: expo-auth-session with direct redirect (no proxy) for Expo Go; web redirect to localhost; dev logs for redirect URIs
- Apple Sign-In: expo-apple-authentication with loginOrRegisterWithApple; appleAuth utils and i18n
- Auth: registerGoogleAccountOrFallback, loginOrRegisterWithApple; login/register/welcome screens use shared social flows
- Profile: version label in ProfileFooter (client and provider) set to 3.0.1
- i18n: keys for Google/Apple auth and profile version
- Env: EXPO_PUBLIC_EXPO_PROJECT_FULL_NAME for Expo proxy (optional); Google OAuth redirect URIs documented in logs
