### PR TITLE
fix(safe-area): apply top and bottom insets across affected screens (…

### DIFF
--- a/app/(auth)/verify-2fa.tsx
+++ b/app/(auth)/verify-2fa.tsx
@@ -90,7 +90,7 @@ export default function Verify2FAScreen() {
   }, []);
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top + 24 }]}>
+    <View style={[styles.container, { paddingTop: insets.top + 24, paddingBottom: insets.bottom }]}>
       <TouchableOpacity style={styles.backButton} onPress={handleBack}>
         <Ionicons name="arrow-back" size={24} color="#FFFFFF" />
       </TouchableOpacity>

--- a/app/(provider-tabs)/index.tsx
+++ b/app/(provider-tabs)/index.tsx
@@ -153,7 +153,7 @@ export default function ProviderDashboardScreen() {
   }, []);
 
   return (
-    <View style={[styles.container, { paddingBottom: insets.bottom + 80 }]}>
+    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom + 80 }]}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent} refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#25A870" />} showsVerticalScrollIndicator={false}>
         {/* Header: green gradient matching preview (linear-gradient 135deg #1B8B5E → #25A870) */}
         <LinearGradient colors={["#1B8B5E", "#25A870"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.header}>

--- a/app/(provider-tabs)/profile/index.tsx
+++ b/app/(provider-tabs)/profile/index.tsx
@@ -179,7 +179,7 @@ export default function ProviderProfileScreen() {
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
-      <ScrollView ref={scrollViewRef} style={styles.scroll} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} refreshControl={<RefreshControl refreshing={isRefetching && !statsLoading} onRefresh={onRefresh} tintColor="#8B5CF6" />}>
+      <ScrollView ref={scrollViewRef} style={styles.scroll} contentContainerStyle={[styles.scrollContent, { paddingBottom: 100 + insets.bottom }]} showsVerticalScrollIndicator={false} refreshControl={<RefreshControl refreshing={isRefetching && !statsLoading} onRefresh={onRefresh} tintColor="#8B5CF6" />}>
         {/* Header with gradient and avatar */}
         <View style={styles.headerWrapper}>
           <LinearGradient colors={[...GRADIENT_COLORS]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.gradientHeader} />

--- a/app/(provider-tabs)/profile/security.tsx
+++ b/app/(provider-tabs)/profile/security.tsx
@@ -355,9 +355,9 @@ export default function ProviderSecurityScreen() {
 
       {/* QR Code + Verify Modal */}
       <Modal visible={twoFASetup !== null} transparent animationType="fade" onRequestClose={() => setTwoFASetup(null)}>
-        <KeyboardAvoidingView style={styles.modalOverlay} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <KeyboardAvoidingView style={[styles.modalOverlay, { paddingBottom: insets.bottom }]} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
           <TouchableOpacity style={styles.modalOverlay} activeOpacity={1} onPress={() => setTwoFASetup(null)}>
-            <View style={[styles.modalBox, { maxWidth: 340 }]} onStartShouldSetResponder={() => true}>
+            <View style={[styles.modalBox, { maxWidth: 340, paddingBottom: 24 + insets.bottom }]} onStartShouldSetResponder={() => true}>
               <Text style={styles.modalTitle}>{t(`${I18N}.scanQRCode`)}</Text>
               {twoFASetup?.qrCode && (
                 <View style={styles.qrContainer}>

--- a/app/(provider-tabs)/profile/settings.tsx
+++ b/app/(provider-tabs)/profile/settings.tsx
@@ -99,7 +99,7 @@ export default function ProviderSettingsScreen() {
       </View>
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: 32 + insets.bottom }]}
         showsVerticalScrollIndicator={false}
       >
         <SettingsSection

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -85,17 +85,10 @@ export default function ProfileScreen() {
   const fullName = user ? [user.firstName, user.lastName].filter(Boolean).join(" ").trim() || "" : "";
 
   return (
-    <View style={styles.container} collapsable={false}>
+    <View style={[styles.container, { paddingTop: insets.top }]} collapsable={false}>
       <ScrollView style={styles.scrollView} contentContainerStyle={[styles.scrollContent, { paddingBottom: 100 + insets.bottom }]} showsVerticalScrollIndicator={false}>
         {/* Header - Exact match to JSX: padding: '50px 20px 30px', backgroundColor: colors.bgCard */}
-        <View
-          style={[
-            styles.header,
-            {
-              paddingTop: insets.top + 20,
-            },
-          ]}
-        >
+        <View style={styles.header}>
           <View style={styles.profileHeader}>
             {/* Avatar - Exact match: width: '80px', height: '80px', borderRadius: '50%', border: '3px solid primary' */}
             <View style={styles.avatarContainer}>
@@ -202,8 +195,9 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: 100, // Space for bottom nav
   },
-  // Header: padding: '50px 20px 30px' from JSX
+  // Header: padding: '50px 20px 30px' from JSX (top padding from container safe area)
   header: {
+    paddingTop: 20,
     paddingHorizontal: 20,
     paddingBottom: 30,
     backgroundColor: "#252542", // Hardcode dark header

--- a/app/account/security.tsx
+++ b/app/account/security.tsx
@@ -348,13 +348,13 @@ export default function ClientSecurityScreen() {
       </Modal>
 
       <Modal visible={twoFASetup !== null} transparent animationType="fade" onRequestClose={() => setTwoFASetup(null)}>
-        <KeyboardAvoidingView style={styles.modalOverlay} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <KeyboardAvoidingView style={[styles.modalOverlay, { paddingBottom: insets.bottom }]} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
           <TouchableOpacity
             style={[styles.modalOverlay, styles.modalOverlayTouchable]}
             activeOpacity={1}
             onPress={() => setTwoFASetup(null)}
           />
-          <View style={[styles.modalBox, { maxWidth: 340 }]}>
+          <View style={[styles.modalBox, { maxWidth: 340, paddingBottom: 24 + insets.bottom }]}>
               <Text style={styles.modalTitle}>{t(`${I18N}.scanQRCode`)}</Text>
               {twoFASetup?.qrCode && (
                 <View style={styles.qrContainer}>

--- a/app/booking/quote/[orderId].tsx
+++ b/app/booking/quote/[orderId].tsx
@@ -566,7 +566,7 @@ export default function QuoteScreen() {
       </ScrollView>
 
       {/* Actions */}
-      <View style={[styles.actions, theme?.actions]}>
+      <View style={[styles.actions, theme?.actions, { paddingBottom: 20 + insets.bottom }]}>
         {isClient && order.status === 'pending_for_client' && (
           <>
             <TouchableOpacity

--- a/app/booking/success/[orderId].tsx
+++ b/app/booking/success/[orderId].tsx
@@ -6,7 +6,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Animated,
-  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -162,24 +161,24 @@ export default function BookingSuccessScreen() {
 
   if (loading) {
     return (
-      <SafeAreaView style={styles.container}>
+      <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
         <View style={styles.centerContainer}>
           <ActivityIndicator size="large" color={colors.secondary} />
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 
   if (error || !orderData) {
     return (
-      <SafeAreaView style={styles.container}>
+      <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
         <View style={styles.centerContainer}>
           <Text style={styles.errorText}>{error || t('errors.requestFailed')}</Text>
           <TouchableOpacity style={styles.retryButton} onPress={loadOrderData}>
             <Text style={styles.retryButtonText}>{t('chat.retry')}</Text>
           </TouchableOpacity>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 
@@ -189,9 +188,9 @@ export default function BookingSuccessScreen() {
   const formattedTime = formatTime(order.scheduled_at);
 
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
       <ScrollView
-        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 20 }]}
+        contentContainerStyle={[styles.scrollContent, { paddingTop: 24, paddingBottom: 24 }]}
         showsVerticalScrollIndicator={false}
       >
         {/* Success Icon with Animation */}
@@ -293,7 +292,7 @@ export default function BookingSuccessScreen() {
           </View>
         </Animated.View>
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 
@@ -307,8 +306,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 20,
-    paddingTop: 40,
-    paddingBottom: 40,
   },
   centerContainer: {
     flex: 1,


### PR DESCRIPTION
…MDB-317)

- Client profile: add paddingTop (insets.top) to container so header/avatar sit below status bar; keep bottom scroll padding with insets.bottom
- Provider profile: add paddingBottom (100 + insets.bottom) to scroll content so last items clear tab bar and system nav
- Provider settings: add paddingBottom (32 + insets.bottom) to scroll content so Contactar soporte is above system nav bar
- Provider dashboard: add paddingTop (insets.top) so green header is below status bar
- Verify 2FA: add paddingBottom (insets.bottom) so content stays above system nav
- Client and provider security 2FA modals: add overlay and modal paddingBottom with insets so Cancel/Verify buttons are above nav bar
- Quote screen: add paddingBottom (20 + insets.bottom) to actions bar so Volver al chat and other actions clear system nav
- Booking success: replace RN SafeAreaView with View + explicit paddingTop/paddingBottom from useSafeAreaInsets so Volver a inicio and Ver mis reservas stay above system nav on Android

Uses useSafeAreaInsets() from react-native-safe-area-context consistently. Fixes status bar overlap and bottom nav overlap on Android (translucent status bar).