### PR TITLE
feat(faqs): load FAQs from API/CRM and fix i18n duplicates (MDB-315)

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -280,7 +280,7 @@ export default function LoginScreen() {
 
           {/* Title */}
           <Text style={styles.title}>{t('auth.welcome')}</Text>
-          <Text style={styles.subtitle}>{t('auth.welcomeSubtitle')}</Text>
+          <Text style={styles.subtitle}>{t('auth.loginSubtitle')}</Text>
 
           {showRegistrationSuccess && (
             <View style={styles.successToast}>
@@ -366,7 +366,7 @@ export default function LoginScreen() {
               {loading ? (
                 <ActivityIndicator color="white" />
               ) : (
-                <Text style={styles.loginButtonText}>{t('auth.signIn')}</Text>
+                <Text style={styles.loginButtonText}>{t('auth.loginCta')}</Text>
               )}
             </TouchableOpacity>
           </View>

--- a/app/account/support.tsx
+++ b/app/account/support.tsx
@@ -1,11 +1,14 @@
+import { fetchFaqs, flattenFaqsToItems, type FaqListItem } from '@/services/faqs';
 import { t } from '@/i18n';
+import { getLocale } from '@/i18n';
 import { Ionicons } from '@expo/vector-icons';
+import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import React, { useMemo, useState } from 'react';
 import {
+  ActivityIndicator,
   Alert,
   Linking,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -15,61 +18,26 @@ import {
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
-interface FAQItem {
-  icon: string;
-  question: string;
-  answer: string;
-}
-
 export default function HelpCenterScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const [searchQuery, setSearchQuery] = useState('');
-  const [expandedFaqs, setExpandedFaqs] = useState<Set<number>>(new Set());
+  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(new Set());
 
-  // FAQ items from translations
-  const faqItems: FAQItem[] = useMemo(
-    () => [
-      {
-        icon: '📅',
-        question: t('helpCenter.faqs.howToBook.question'),
-        answer: t('helpCenter.faqs.howToBook.answer'),
-      },
-      {
-        icon: '💳',
-        question: t('helpCenter.faqs.howPaymentWorks.question'),
-        answer: t('helpCenter.faqs.howPaymentWorks.answer'),
-      },
-      {
-        icon: '❌',
-        question: t('helpCenter.faqs.canCancel.question'),
-        answer: t('helpCenter.faqs.canCancel.answer'),
-      },
-      {
-        icon: '⭐',
-        question: t('helpCenter.faqs.howToRate.question'),
-        answer: t('helpCenter.faqs.howToRate.answer'),
-      },
-      {
-        icon: '🔒',
-        question: t('helpCenter.faqs.dataSecure.question'),
-        answer: t('helpCenter.faqs.dataSecure.answer'),
-      },
-      {
-        icon: '💰',
-        question: t('helpCenter.faqs.howRefundsWork.question'),
-        answer: t('helpCenter.faqs.howRefundsWork.answer'),
-      },
-    ],
-    []
-  );
+  const locale = getLocale();
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ['faqs', locale],
+    queryFn: () => fetchFaqs(locale),
+    staleTime: 5 * 60 * 1000,
+  });
 
-  // Filter FAQs based on search query
+  const faqItems: FaqListItem[] = useMemo(() => {
+    if (!data?.categories?.length) return [];
+    return flattenFaqsToItems(data.categories);
+  }, [data?.categories]);
+
   const filteredFaqs = useMemo(() => {
-    if (!searchQuery.trim()) {
-      return faqItems;
-    }
-
+    if (!searchQuery.trim()) return faqItems;
     const query = searchQuery.toLowerCase();
     return faqItems.filter(
       (item) =>
@@ -78,14 +46,13 @@ export default function HelpCenterScreen() {
     );
   }, [searchQuery, faqItems]);
 
-  const toggleFaq = (index: number) => {
-    const newExpanded = new Set(expandedFaqs);
-    if (newExpanded.has(index)) {
-      newExpanded.delete(index);
-    } else {
-      newExpanded.add(index);
-    }
-    setExpandedFaqs(newExpanded);
+  const toggleFaq = (id: string) => {
+    setExpandedFaqs((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   };
 
   const handleLiveChat = () => {
@@ -150,7 +117,7 @@ export default function HelpCenterScreen() {
         style={[styles.scrollView, { backgroundColor: '#1a1a2e' }]}
         contentContainerStyle={[
           styles.scrollContent,
-          { paddingBottom: 20, backgroundColor: '#1a1a2e' },
+          { paddingBottom: 20 + insets.bottom, backgroundColor: '#1a1a2e' },
         ]}
         showsVerticalScrollIndicator={false}
       >
@@ -168,29 +135,37 @@ export default function HelpCenterScreen() {
           </View>
         </View>
 
-        {/* FAQs Section - Exact match to JSX */}
+        {/* FAQs Section - from API (CRM/Backoffice) */}
         <Text style={styles.sectionTitle}>
           {t('helpCenter.frequentlyAskedQuestions')}
         </Text>
 
-        {filteredFaqs.length > 0 ? (
-          filteredFaqs.map((faq, index) => {
-            const originalIndex = faqItems.indexOf(faq);
-            const isExpanded = expandedFaqs.has(originalIndex);
+        {isLoading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color="#3b82f6" />
+            <Text style={styles.loadingText}>{t('common.loading')}</Text>
+          </View>
+        ) : isError ? (
+          <View style={styles.noResultsContainer}>
+            <Text style={styles.noResultsText}>
+              {error instanceof Error ? error.message : t('helpCenter.noResults')}
+            </Text>
+            <TouchableOpacity style={styles.retryButton} onPress={() => refetch()} activeOpacity={0.7}>
+              <Text style={styles.retryButtonText}>{t('chat.retry')}</Text>
+            </TouchableOpacity>
+          </View>
+        ) : filteredFaqs.length > 0 ? (
+          filteredFaqs.map((faq) => {
+            const isExpanded = expandedFaqs.has(faq.id);
             return (
-              <View
-                key={index}
-                style={styles.faqItem}
-              >
+              <View key={faq.id} style={styles.faqItem}>
                 <TouchableOpacity
                   style={styles.faqHeader}
-                  onPress={() => toggleFaq(originalIndex)}
+                  onPress={() => toggleFaq(faq.id)}
                   activeOpacity={0.7}
                 >
                   <Text style={styles.faqIcon}>{faq.icon}</Text>
-                  <Text style={styles.faqQuestion}>
-                    {faq.question}
-                  </Text>
+                  <Text style={styles.faqQuestion}>{faq.question}</Text>
                   <Ionicons
                     name={isExpanded ? 'chevron-up' : 'chevron-forward'}
                     size={20}
@@ -199,9 +174,7 @@ export default function HelpCenterScreen() {
                 </TouchableOpacity>
                 {isExpanded && (
                   <View style={styles.faqAnswerContainer}>
-                    <Text style={styles.faqAnswer}>
-                      {faq.answer}
-                    </Text>
+                    <Text style={styles.faqAnswer}>{faq.answer}</Text>
                   </View>
                 )}
               </View>
@@ -398,6 +371,15 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     color: '#9ca3af', // Hardcode secondary text
   },
+  loadingContainer: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    gap: 12,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#9ca3af',
+  },
   noResultsContainer: {
     paddingVertical: 24,
     alignItems: 'center',
@@ -405,6 +387,18 @@ const styles = StyleSheet.create({
   noResultsText: {
     fontSize: 14,
     color: '#9ca3af', // Hardcode secondary text
+  },
+  retryButton: {
+    marginTop: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    backgroundColor: '#3b82f6',
+  },
+  retryButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#FFFFFF',
   },
   contactItem: {
     flexDirection: 'row',

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -12,6 +12,7 @@ export default {
     back: "Back",
     discard: "Discard",
     redirecting: "Redirecting...",
+    loading: "Loading...",
   },
   auth: {
     firstName: "First Name",
@@ -34,8 +35,7 @@ export default {
     searchCountry: "Search country...",
     loginTitle: "Login",
     welcome: "Welcome",
-    welcomeSubtitle: "Enter your credentials to continue",
-    signIn: "Log in",
+    loginSubtitle: "Enter your credentials to continue",
     signUp: "Sign up",
     forgotPassword: "Forgot password?",
     forgotPasswordTitle: "Forgot your password?",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -12,6 +12,7 @@ export default {
     back: "Volver",
     discard: "Descartar",
     redirecting: "Redirigiendo...",
+    loading: "Cargando...",
   },
   auth: {
     firstName: "Nombre",
@@ -34,8 +35,7 @@ export default {
     searchCountry: "Buscar país...",
     loginTitle: "Iniciar sesión",
     welcome: "Bienvenido",
-    welcomeSubtitle: "Ingresa tus credenciales para continuar",
-    signIn: "Iniciar sesión",
+    loginSubtitle: "Ingresa tus credenciales para continuar",
     signUp: "Registrarse",
     forgotPassword: "¿Olvidaste tu contraseña?",
     forgotPasswordTitle: "¿Olvidaste tu contraseña?",

--- a/services/faqs.ts
+++ b/services/faqs.ts
@@ -1,0 +1,85 @@
+import { API_BASE } from '@/utils/apiConfig';
+
+/** API response: one answer per question (first published answer) */
+export interface FaqAnswer {
+  id: string;
+  answer: string | null;
+  order: number;
+}
+
+export interface FaqQuestion {
+  id: string;
+  question: string | null;
+  order: number;
+  answers: FaqAnswer[];
+}
+
+export interface FaqCategory {
+  id: string;
+  title: string | null;
+  order: number;
+  questions: FaqQuestion[];
+}
+
+export interface FaqsResponse {
+  categories: FaqCategory[];
+}
+
+/** Flattened item for the help center list: one row per question with first answer text */
+export interface FaqListItem {
+  id: string;
+  categoryId: string;
+  categoryTitle: string | null;
+  question: string;
+  answer: string;
+  icon: string;
+}
+
+const DEFAULT_ICONS = ['📅', '💳', '❌', '⭐', '🔒', '💰', '📋', '❓'];
+
+/**
+ * Fetches published FAQs from the API (parametrized via CRM/Backoffice).
+ * @param locale - 'en' | 'es'. Should match app language.
+ */
+export async function fetchFaqs(locale: 'en' | 'es'): Promise<FaqsResponse> {
+  const url = `${API_BASE}/api/content/faqs?locale=${locale}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    const message = (body && typeof body.message === 'string') ? body.message : `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  const data = (await response.json()) as FaqsResponse;
+  if (!data || !Array.isArray(data.categories)) {
+    return { categories: [] };
+  }
+  return data;
+}
+
+/**
+ * Flattens API categories into a list of FAQ items (one per question).
+ * Uses the first published answer per question. Assigns a default icon per category.
+ */
+export function flattenFaqsToItems(categories: FaqCategory[]): FaqListItem[] {
+  const items: FaqListItem[] = [];
+  categories.forEach((cat, catIndex) => {
+    const icon = DEFAULT_ICONS[catIndex % DEFAULT_ICONS.length];
+    (cat.questions || []).forEach((q) => {
+      const firstAnswer = (q.answers && q.answers[0]) ? (q.answers[0].answer ?? '').trim() : '';
+      items.push({
+        id: q.id,
+        categoryId: cat.id,
+        categoryTitle: cat.title ?? null,
+        question: (q.question ?? '').trim() || '—',
+        answer: firstAnswer || '—',
+        icon,
+      });
+    });
+  });
+  return items;
+}


### PR DESCRIPTION
- Add services/faqs.ts: fetchFaqs(locale), flattenFaqsToItems(), types for API response
- support.tsx: replace hardcoded FAQs with useQuery fetching GET /api/content/faqs?locale=; loading state, error + retry; flatten categories to list; keep search and contact section
- i18n: remove duplicate auth.signIn and auth.welcomeSubtitle; add auth.loginSubtitle for login screen; login.tsx uses auth.loginSubtitle and auth.loginCta for button
- i18n: add common.loading (en/es) for help center loading state
