### PR TITLE
fix(i18n): merge duplicate booking keys in Spanish locale

### DIFF
--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -534,13 +534,6 @@ export default {
     addItemButton: "Agregar",
     createQuoteButton: "Crear Cotización",
   },
-  booking: {
-    selectDateTime: "Selecciona fecha y hora",
-    availableTimes: "Horarios disponibles",
-    estimatedDuration: "Duración estimada",
-    selectAllFields: "Por favor selecciona fecha, hora y duración",
-    continue: "Continuar",
-  },
   payment: {
     title: "Método de pago",
     addNewCard: "Agregar nueva tarjeta",
@@ -629,6 +622,11 @@ export default {
     add: "Agregar",
   },
   booking: {
+    selectDateTime: "Selecciona fecha y hora",
+    availableTimes: "Horarios disponibles",
+    estimatedDuration: "Duración estimada",
+    selectAllFields: "Por favor selecciona fecha, hora y duración",
+    continue: "Continuar",
     serviceAddress: "Dirección del servicio",
     locationMap: "Mapa de ubicación",
     savedAddresses: "Direcciones guardadas",


### PR DESCRIPTION
- Remove duplicate root-level 'booking' object in es.ts
- Merge selectDateTime, availableTimes, estimatedDuration, selectAllFields, continue into single booking object
- Fixes 'object literal cannot have multiple properties with the same' error
