### PR TITLE
fix(payment): center loading spinner in Add Card button (MDB-279)

### DIFF
--- a/components/payment/AddCardModal.tsx
+++ b/components/payment/AddCardModal.tsx
@@ -281,7 +281,7 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
                   <Text style={styles.modalButtonTextCancel}>{t('common.cancel')}</Text>
                 </TouchableOpacity>
                 {loading ? (
-                  <View style={styles.modalButtonConfirm}>
+                  <View style={[styles.modalButtonConfirm, styles.modalButtonConfirmLoading]}>
                     <ActivityIndicator color="#FFFFFF" />
                   </View>
                 ) : (
@@ -404,6 +404,12 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.4,
     shadowRadius: 15,
     elevation: 8,
+  },
+  modalButtonConfirmLoading: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 18,
+    backgroundColor: colors.primary,
   },
   modalButtonGradient: {
     padding: 18,


### PR DESCRIPTION
- Add modalButtonConfirmLoading style with alignItems/justifyContent center
- Apply padding and primary background so loading state matches button size and appearance
- Fixes visual overflow/misalignment of spinner inside the Add button on Payment Methods (Client)
