### PR TITLE
fix(provider-dashboard): remove dead space on provider home and impro…

### DIFF
--- a/app/(provider-tabs)/index.tsx
+++ b/app/(provider-tabs)/index.tsx
@@ -152,8 +152,13 @@ export default function ProviderDashboardScreen() {
 
   const cardStyle = { backgroundColor: colors.card, borderColor: colors.cardBorder };
   return (
-    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom + 80, backgroundColor: colors.background }]}>
-      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent} refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#25A870" />} showsVerticalScrollIndicator={false}>
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <ScrollView
+        style={[styles.scroll, { backgroundColor: colors.background }]}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: 100 + insets.bottom }]}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#25A870" />}
+        showsVerticalScrollIndicator={true}
+      >
         {/* Header: green gradient matching preview (linear-gradient 135deg #1B8B5E → #25A870) */}
         <LinearGradient colors={["#1B8B5E", "#25A870"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.header}>
           <View style={styles.headerTop}>
@@ -297,8 +302,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    paddingBottom: 16,
-    flexGrow: 0,
+    paddingBottom: 100,
   },
   header: {
     paddingHorizontal: 20,

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -421,7 +421,9 @@ export const request = async <T>(
           refreshFailedRaw != null && refreshFailedRaw !== ''
             ? String(refreshFailedRaw)
             : t('errors.tokenRefreshFailed');
-        throw new ApiError(message, response.status, responseData, false);
+        const msgLower = message.toLowerCase();
+        const isTokenInvalidOrExpired = (msgLower.includes('invalid') && (msgLower.includes('expired') || msgLower.includes('token'))) || msgLower.includes('token');
+        throw new ApiError(message, response.status, responseData, isTokenInvalidOrExpired);
       }
     }
 


### PR DESCRIPTION
…ve token error handling

- Align provider home layout with client home: no flexGrow, no spacer View, no minHeight: 0; use only paddingBottom (100 + insets.bottom) on scroll content so content scrolls correctly without empty black area below Today's Schedule.
- Mark token refresh failure as sessionExpired when message indicates invalid/expired token so the uncaught error overlay is suppressed and AuthContext redirect flows work without red error screen.
