### PR TITLE
fix(MDB-321): booking fixed price, no fee, token-expired handling

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -66,20 +66,40 @@ export default function RootLayout() {
     initializeGoogleSignIn();
   }, []);
 
-  // Prevent "Uncaught Error" overlay when token expired (session expired already emitted, app redirects to login)
+  // Prevent "Uncaught Error" overlay when token invalid/expired (session expired or cleared, user stays on welcome)
   // Only on web: window.addEventListener/removeEventListener do not exist in React Native (APK)
   useEffect(() => {
     if (Platform.OS !== "web") return;
     const w = typeof window !== "undefined" ? window : null;
     if (!w?.addEventListener || !w?.removeEventListener) return;
-    const handler = (event: PromiseRejectionEvent) => {
-      const reason = event?.reason;
-      if (reason instanceof ApiError && reason.sessionExpired) {
+
+    const isTokenExpiredError = (reason: unknown): boolean => {
+      if (reason instanceof ApiError && reason.sessionExpired) return true;
+      const msg = reason instanceof Error ? reason.message?.toLowerCase() ?? "" : "";
+      return msg.includes("invalid") && (msg.includes("expired") || msg.includes("token"));
+    };
+
+    const handleRejection = (event: PromiseRejectionEvent) => {
+      if (isTokenExpiredError(event?.reason)) {
         event.preventDefault();
       }
     };
-    w.addEventListener("unhandledrejection", handler);
-    return () => w.removeEventListener("unhandledrejection", handler);
+
+    const handleError = (event: ErrorEvent) => {
+      const msg = (event?.message ?? "").toLowerCase();
+      if (msg.includes("invalid") && (msg.includes("expired") || msg.includes("token"))) {
+        event.preventDefault();
+        return true;
+      }
+      return false;
+    };
+
+    w.addEventListener("unhandledrejection", handleRejection);
+    w.addEventListener("error", handleError);
+    return () => {
+      w.removeEventListener("unhandledrejection", handleRejection);
+      w.removeEventListener("error", handleError);
+    };
   }, []);
 
   return (

--- a/app/booking/date-time.tsx
+++ b/app/booking/date-time.tsx
@@ -289,7 +289,7 @@ export default function BookingDateTimeScreen() {
   const providerCardInfo: BookingDateTimePickerProviderCard | undefined = supplier && service
     ? {
         name: supplier.business_name?.trim() || supplier.full_name,
-        serviceInfo: `${service.name?.trim() || service.category_name || 'Service'} • $${service.price || 0}${t('supplier.perHour')}`,
+        serviceInfo: `${service.name?.trim() || service.category_name || 'Service'} • $${service.price ?? 0}`,
         profileImage: supplier.profile_image,
       }
     : undefined;

--- a/app/booking/summary.tsx
+++ b/app/booking/summary.tsx
@@ -1,4 +1,3 @@
-import { CLIENT_TIERS } from "@/constants/tiers";
 import { useAuth } from "@/contexts/AuthContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { getLocale, t } from "@/i18n";
@@ -241,7 +240,6 @@ export default function BookingSummaryScreen() {
     addressId: string;
   }>();
   const insets = useSafeAreaInsets();
-  const tierConfig = CLIENT_TIERS[user?.tier ?? "bronze"];
 
   const [supplier, setSupplier] = useState<Supplier | null>(null);
   const [service, setService] = useState<SupplierService | null>(null);
@@ -326,27 +324,24 @@ export default function BookingSummaryScreen() {
     return parts.join(", ");
   };
 
-  // Calculate pricing
+  // Pricing: service has a fixed price (not per hour). No platform fee for direct booking.
   const calculatePricing = () => {
-    if (!service || !duration) {
+    if (!service) {
       return {
         serviceCost: 0,
-        travelFee: 5.0,
-        platformFee: 5.0,
+        serviceFee: 0,
         discount: 0,
         total: 0,
       };
     }
 
-    const durationHours = parseFloat(duration) || 2;
-    const hourlyRate = service.price || 60;
-    const serviceCost = hourlyRate * durationHours;
-    const serviceFee = tierConfig.platformFee;
-    const subtotal = serviceCost + serviceFee;
+    const serviceCost = Number(service.price) || 0;
+    const serviceFee = 0;
+    const subtotal = serviceCost;
 
     const discountPercent = appliedDiscount > 0 ? appliedDiscount : 0;
     const discount = subtotal * (discountPercent / 100);
-    const total = subtotal - discount;
+    const total = Math.max(0, subtotal - discount);
 
     return {
       serviceCost,
@@ -359,7 +354,7 @@ export default function BookingSummaryScreen() {
   const pricing = calculatePricing();
 
   const handleProceedToPayment = () => {
-    if (!supplierId || !serviceId || !scheduledAt || !duration || !addressId || !address || !service) {
+    if (!supplierId || !serviceId || !scheduledAt || !addressId || !address || !service) {
       Alert.alert(t("common.error"), t("booking.missingBookingData"));
       return;
     }
@@ -470,11 +465,17 @@ export default function BookingSummaryScreen() {
               <Text style={styles.detailValue}>{formattedTime}</Text>
             </View>
 
-            {/* Duration */}
+            {/* Duration (estimated job length; price is fixed, not per hour) */}
             <View style={styles.detailRow}>
               <Text style={styles.detailLabel}>{t("booking.estimatedDuration")}</Text>
               <Text style={styles.detailValue}>
-                {duration} {t("booking.hours")}
+                {duration
+                  ? `${duration} ${t("booking.hours")}`
+                  : service.duration_minutes != null
+                    ? service.duration_minutes >= 60
+                      ? `${Math.round(service.duration_minutes / 60)} ${t("booking.hours")}`
+                      : `${service.duration_minutes} ${t("booking.minutes")}`
+                    : "—"}
               </Text>
             </View>
 
@@ -495,27 +496,12 @@ export default function BookingSummaryScreen() {
           <View style={styles.card}>
             <Text style={styles.cardTitle}>{t("booking.paymentSummary")}</Text>
 
-            {/* Service Cost */}
+            {/* Service cost (fixed price) */}
             <View style={styles.priceRow}>
               <Text style={styles.priceLabel}>
-                {service.name?.trim() || service.category_name || "Service"} ({duration} {t("booking.hours")} x ${service.price || 60}/hr)
+                {service.name?.trim() || service.category_name || "Service"}
               </Text>
               <Text style={styles.priceValue}>${pricing.serviceCost.toFixed(2)}</Text>
-            </View>
-
-            {/* Platform Fee */}
-            <View style={styles.priceRow}>
-              <View>
-                <Text style={styles.priceLabel}>{t("booking.travelFee")}</Text>
-                {tierConfig.key !== "bronze" && (
-                  <Text style={[styles.priceLabel, { color: tierConfig.color, fontSize: 11 }]}>
-                    {t("booking.tierFeeLabel", { tier: t(tierConfig.i18nKey) })}
-                  </Text>
-                )}
-              </View>
-              <Text style={[styles.priceValue, pricing.serviceFee === 0 && { color: "#10b981" }]}>
-                {pricing.serviceFee === 0 ? "$0.00" : `$${pricing.serviceFee.toFixed(2)}`}
-              </Text>
             </View>
 
             {/* Discount */}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -153,7 +153,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             await AsyncStorage.setItem('user', JSON.stringify(syncedUser));
             console.log('AuthContext - User synced from backend');
           } catch (syncError: unknown) {
-            console.warn('AuthContext - Failed to sync user from backend, using stored data:', syncError);
+            const isTokenError = syncError instanceof ApiError &&
+              (syncError.status === 401 || syncError.status === 403 || syncError.sessionExpired === true);
+            const msg = syncError instanceof Error ? syncError.message.toLowerCase() : '';
+            const isInvalidExpiredToken = msg.includes('invalid') && (msg.includes('expired') || msg.includes('token'));
+            if (isTokenError || isInvalidExpiredToken) {
+              console.warn('AuthContext - Token invalid or expired on profile sync, clearing session');
+              setUser(null);
+              await AsyncStorage.removeItem('user');
+              clearTokenState();
+            } else {
+              console.warn('AuthContext - Failed to sync user from backend, using stored data:', syncError);
+            }
           }
         }
       } else {

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -657,6 +657,7 @@ export default {
     time: "Time",
     address: "Address",
     hours: "hours",
+    minutes: "min",
     additionalNotes: "Additional notes",
     notesPlaceholder: "Special instructions for the provider...",
     paymentSummary: "Payment summary",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -657,6 +657,7 @@ export default {
     time: "Hora",
     address: "Dirección",
     hours: "horas",
+    minutes: "min",
     additionalNotes: "Notas adicionales",
     notesPlaceholder: "Instrucciones especiales para el proveedor...",
     paymentSummary: "Resumen de pago",


### PR DESCRIPTION
- Booking summary: use service fixed price only (no hours × rate), remove platform fee and fee row; add booking.minutes i18n; duration fallback from service.duration_minutes.
- Booking date-time: show fixed price in provider card (no /hr).
- AuthContext: on profile sync failure with 401/403 or invalid/expired token, clear session and storage to avoid redirect to home with bad token.
- _layout (web): suppress error overlay for token-expired errors (unhandledrejection + error listener).
