### PR TITLE
fix(security): restrict provider access to active status only (MDB-336)

### DIFF
--- a/app/(provider-tabs)/_layout.tsx
+++ b/app/(provider-tabs)/_layout.tsx
@@ -3,13 +3,15 @@ import { AvailabilityProvider } from "@/contexts/AvailabilityContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { useMode } from "@/contexts/ModeContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
-import { t } from "@/i18n";
+import { checkProviderStatus } from "@/services/providers";
 import { useIsFocused } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs, useRouter, useSegments } from "expo-router";
-import React, { useEffect } from "react";
-import { StyleSheet, View } from "react-native";
+import React, { useCallback, useEffect, useState } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const ACTIVE_STATUS = "active";
 
 export default function ProviderTabLayout() {
   const insets = useSafeAreaInsets();
@@ -20,6 +22,33 @@ export default function ProviderTabLayout() {
   const { mode } = useMode();
   const isFocused = useIsFocused();
   const bottomPadding = Math.max(insets.bottom, 24);
+
+  const [providerStatusCheck, setProviderStatusCheck] = useState<{
+    loading: boolean;
+    status: string | null;
+  }>({ loading: true, status: null });
+
+  const refreshProviderStatus = useCallback(async () => {
+    try {
+      const res = await checkProviderStatus();
+      setProviderStatusCheck({ loading: false, status: res.status ?? null });
+    } catch {
+      setProviderStatusCheck({ loading: false, status: null });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!user || !isFocused) return;
+    refreshProviderStatus();
+  }, [user, isFocused, refreshProviderStatus]);
+
+  // When provider is not active, redirect to Request Sent screen (provider-onboarding/verification).
+  useEffect(() => {
+    if (providerStatusCheck.loading || !isFocused) return;
+    if (providerStatusCheck.status !== ACTIVE_STATUS) {
+      router.replace("/provider-onboarding/verification");
+    }
+  }, [providerStatusCheck.loading, providerStatusCheck.status, isFocused, router]);
 
   // MDB-257: When Profile tab is pressed from a nested route (e.g. /profile/security), navigate to profile root.
   const isNestedProfileRoute =
@@ -38,6 +67,16 @@ export default function ProviderTabLayout() {
       router.replace("/(tabs)");
     }
   }, [mode, isFocused, router]);
+
+  const isActive = providerStatusCheck.status === ACTIVE_STATUS;
+
+  if (providerStatusCheck.loading || !isActive) {
+    return (
+      <View style={[styles.screenBg, styles.centered, { backgroundColor: colors.screenBackground }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.screenBg, { backgroundColor: colors.screenBackground }]} collapsable={false}>
@@ -155,5 +194,9 @@ export default function ProviderTabLayout() {
 const styles = StyleSheet.create({
   screenBg: {
     flex: 1,
+  },
+  centered: {
+    justifyContent: "center",
+    alignItems: "center",
   },
 });

--- a/app/switch-mode.tsx
+++ b/app/switch-mode.tsx
@@ -2,10 +2,9 @@ import { useMode } from "@/contexts/ModeContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { checkProviderStatus } from "@/services/providers";
-import { CommonActions } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
-import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useState } from "react";
 import {
     ActivityIndicator,
@@ -29,28 +28,21 @@ export default function SwitchModeScreen() {
   const { target = "client" } = useLocalSearchParams<{ target?: string }>();
   const targetMode: TargetMode = target === "provider" ? "provider" : "client";
   const router = useRouter();
-  const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
   const { setMode } = useMode();
   const [switching, setSwitching] = useState(false);
 
-  const resetTo = useCallback((routeName: string) => {
-    navigation.dispatch(
-      CommonActions.reset({ index: 0, routes: [{ name: routeName }] })
-    );
-  }, [navigation]);
-
   const handleSwitchToClient = useCallback(async () => {
     try {
       setSwitching(true);
       await setMode("client");
-      resetTo("(tabs)");
+      router.replace("/(tabs)");
     } catch (e) {
       console.error("[SwitchMode] Switch to client failed:", e);
       setSwitching(false);
     }
-  }, [setMode, resetTo]);
+  }, [setMode, router]);
 
   const handleSwitchToProvider = useCallback(async () => {
     try {
@@ -59,22 +51,22 @@ export default function SwitchModeScreen() {
       const status = await checkProviderStatus();
       if (result.needsOnboarding || !status.onboardingCompleted) {
         if (status.onboardingCompleted && !status.isVerified) {
-          resetTo("provider-onboarding/verification");
+          router.replace("/provider-onboarding/verification");
         } else {
-          resetTo("provider-onboarding");
+          router.replace("/provider-onboarding");
         }
         return;
       }
       if (!status.isVerified) {
-        resetTo("provider-onboarding/verification");
+        router.replace("/provider-onboarding/verification");
         return;
       }
-      resetTo("(provider-tabs)");
+      router.replace("/(provider-tabs)");
     } catch (e) {
       console.error("[SwitchMode] Switch to provider failed:", e);
       setSwitching(false);
     }
-  }, [setMode, resetTo]);
+  }, [setMode, router]);
 
   const handleConfirm = useCallback(() => {
     if (targetMode === "client") handleSwitchToClient();

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -17,6 +17,22 @@ const getPhysicalDeviceHint = (): string => {
   return '\n\nSi usas un dispositivo físico (no emulador), en .env pon EXPO_PUBLIC_API_URL con la IP de tu PC, ej: http://192.168.1.x:3000 (misma Wi‑Fi).';
 };
 
+const SENSITIVE_HEADER_KEYS = ['authorization', 'cookie', 'x-api-key', 'x-auth-token'];
+
+/** Returns a copy of headers with sensitive values redacted for safe logging. */
+function sanitizeHeadersForLog(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const keyLower = key.toLowerCase();
+    if (SENSITIVE_HEADER_KEYS.some((s) => keyLower === s)) {
+      out[key] = value ? '[REDACTED]' : value;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 export interface RegisterPayload {
   fullName: string;
   email: string;
@@ -266,7 +282,7 @@ export const request = async <T>(
     let response: Response;
     try {
       console.log('[API] Attempting fetch to:', url);
-      console.log('[API] Headers:', headers);
+      console.log('[API] Headers:', sanitizeHeadersForLog(headers));
       console.log('[API] Method:', init.method || 'GET');
       
       response = await fetch(url, { 

--- a/services/providers.ts
+++ b/services/providers.ts
@@ -78,11 +78,16 @@ export const uploadProviderAvatar = async (
   );
 };
 
+/** Supplier status from backend. Only 'active' is allowed to access provider screens. */
+export type ProviderAccountStatus = "pending" | "pending_verification" | "active" | "rejected" | "suspended";
+
 export interface ProviderStatusResponse {
   isProvider: boolean;
   isVerified: boolean;
   onboardingCompleted: boolean;
   onboardingStep?: number; // Current step (0-7)
+  /** Supplier account status. Must be 'active' to use provider tabs. */
+  status?: ProviderAccountStatus;
 }
 
 export interface ProviderOnboardingData {


### PR DESCRIPTION
- Provider tabs: allow access only when supplier status is 'active'; redirect non-active providers to Request Sent screen (/provider-onboarding/verification) instead of showing custom Account under review screen
- Add provider status to GET /api/providers/status response and ProviderStatusResponse (ProviderAccountStatus type)
- switch-mode: use router.replace() instead of CommonActions.reset() for Expo Router compatibility (fix RESET navigator warning)
- auth: sanitize sensitive headers in logs (Authorization, cookie, x-api-key) to avoid exposing tokens in debug output
