### PR TITLE
feat(app): gate app on platform maintenance status (MDB-377)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,16 +1,18 @@
 import { DarkTheme, DefaultTheme, ThemeProvider as NavigationThemeProvider } from "@react-navigation/native";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { ActivityIndicator, Platform, View } from "react-native";
+import { ActivityIndicator, AppState, type AppStateStatus, Platform, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
+import { MaintenanceScreen } from "@/components/MaintenanceScreen";
 import { initializeGoogleSignIn } from "@/config/google-signin";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import { ModeProvider } from "@/contexts/ModeContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { ApiError } from "@/services/auth";
+import { fetchPlatformStatus } from "@/services/platformStatus";
 import { useEffect } from "react";
 
 
@@ -21,14 +23,54 @@ export const unstable_settings = {
 const queryClient = new QueryClient();
 
 function RootLayoutNav() {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isLoading } = useAuth();
   const colorScheme = useColorScheme();
+
+  const {
+    data: platformStatus,
+    isPending: platformStatusPending,
+    isError: platformStatusError,
+    refetch: refetchPlatformStatus,
+    isFetching: platformStatusFetching,
+  } = useQuery({
+    queryKey: ["platform-status"],
+    queryFn: fetchPlatformStatus,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+    retry: 1,
+  });
+
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state: AppStateStatus) => {
+      if (state === "active") {
+        void refetchPlatformStatus();
+      }
+    });
+    return () => sub.remove();
+  }, [refetchPlatformStatus]);
 
   if (isLoading) {
     return (
       <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
         <ActivityIndicator size="large" color="#10B981" />
       </View>
+    );
+  }
+
+  const maintenanceOn =
+    !platformStatusError && platformStatus?.maintenance_mode === true;
+
+  if (platformStatusPending && !platformStatusError) {
+    return (
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+        <ActivityIndicator size="large" color="#10B981" />
+      </View>
+    );
+  }
+
+  if (maintenanceOn) {
+    return (
+      <MaintenanceScreen onRetry={() => void refetchPlatformStatus()} isChecking={platformStatusFetching} />
     );
   }
 

--- a/components/MaintenanceScreen.tsx
+++ b/components/MaintenanceScreen.tsx
@@ -1,0 +1,87 @@
+import MordoboLogo from '@/components/MordoboLogo';
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { t } from '@/i18n';
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+interface MaintenanceScreenProps {
+  onRetry: () => void;
+  isChecking?: boolean;
+}
+
+export function MaintenanceScreen({ onRetry, isChecking = false }: MaintenanceScreenProps) {
+  const colors = useThemeColors();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      style={[
+        styles.root,
+        {
+          paddingTop: insets.top + 24,
+          paddingBottom: insets.bottom + 24,
+          backgroundColor: colors.background,
+        },
+      ]}
+    >
+      <MordoboLogo size={72} />
+      <Text style={[styles.title, { color: colors.textPrimary }]}>{t('maintenance.title')}</Text>
+      <Text style={[styles.message, { color: colors.textSecondary }]}>{t('maintenance.message')}</Text>
+      <TouchableOpacity
+        style={[styles.button, { backgroundColor: colors.primary }]}
+        onPress={onRetry}
+        disabled={isChecking}
+        accessibilityRole="button"
+        accessibilityLabel={t('maintenance.checkAgain')}
+      >
+        {isChecking ? (
+          <ActivityIndicator color="#FFFFFF" />
+        ) : (
+          <Text style={styles.buttonLabel}>{t('maintenance.checkAgain')}</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 28,
+  },
+  title: {
+    marginTop: 28,
+    fontSize: 22,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  message: {
+    marginTop: 12,
+    fontSize: 16,
+    lineHeight: 24,
+    textAlign: 'center',
+  },
+  button: {
+    marginTop: 32,
+    minWidth: 200,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonLabel: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/components/profile/ProfileFooter.tsx
+++ b/components/profile/ProfileFooter.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 /** Version label shown in profile footer for both Client and Provider. */
-const PROFILE_VERSION_LABEL = "3.0.4";
+const PROFILE_VERSION_LABEL = "3.0.6";
 
 /**
  * Shared footer for Client and Provider profile screens: app version label and logout button.

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -14,6 +14,12 @@ export default {
     redirecting: "Redirecting...",
     loading: "Loading...",
   },
+  maintenance: {
+    title: "Under maintenance",
+    message:
+      "Mordobo is temporarily unavailable while we improve the platform. Please try again in a few minutes.",
+    checkAgain: "Check again",
+  },
   auth: {
     firstName: "First Name",
     lastName: "Last Name",
@@ -161,6 +167,8 @@ export default {
     connectionFailed: "Cannot connect to server. Please check your internet connection and ensure the backend is running.",
     requestTimeout: "The server took too long to respond. Please check your connection and try again. If the problem persists, ensure the backend server is running.",
     requestTimeoutRenderHint: "If using Render (QA), the server may sleep after inactivity and take up to 1–2 minutes to wake up. Wait and try again.",
+    maintenanceMode:
+      "The app is temporarily unavailable due to maintenance. Please try again later.",
     getSettingsFailed: "Failed to load settings. Please try again.",
     updateSettingsFailed: "Failed to update settings. Please try again.",
     changePasswordFailed: "Failed to change password. Please try again.",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -14,6 +14,12 @@ export default {
     redirecting: "Redirigiendo...",
     loading: "Cargando...",
   },
+  maintenance: {
+    title: "En mantenimiento",
+    message:
+      "Mordobo no está disponible por un momento mientras mejoramos la plataforma. Vuelve a intentarlo en unos minutos.",
+    checkAgain: "Comprobar de nuevo",
+  },
   auth: {
     firstName: "Nombre",
     lastName: "Apellido",
@@ -161,6 +167,8 @@ export default {
     connectionFailed: "No se puede conectar al servidor. Por favor verifica tu conexión a internet y asegúrate de que el backend esté corriendo.",
     requestTimeout: "El servidor tardó demasiado en responder. Por favor verifica tu conexión e intenta de nuevo. Si el problema persiste, asegúrate de que el servidor backend esté corriendo.",
     requestTimeoutRenderHint: "Si usas Render (QA), el servidor puede dormirse por inactividad y tardar 1–2 minutos en despertar. Espera e intenta de nuevo.",
+    maintenanceMode:
+      "La app no está disponible por mantenimiento. Por favor, inténtalo más tarde.",
     getSettingsFailed: "Error al cargar configuración. Por favor intenta de nuevo.",
     updateSettingsFailed: "Error al actualizar configuración. Por favor intenta de nuevo.",
     changePasswordFailed: "Error al cambiar contraseña. Por favor intenta de nuevo.",

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -444,6 +444,13 @@ export const request = async <T>(
     }
 
     if (!response.ok) {
+      const errCodeEarly =
+        typeof responseData === 'object' && responseData && 'code' in responseData
+          ? String((responseData as { code: unknown }).code)
+          : '';
+      if (response.status === 503 && errCodeEarly === 'maintenance_mode') {
+        throw new ApiError(t('errors.maintenanceMode'), 503, responseData);
+      }
       // #region agent log
       if (path.includes('validate-email')) fetch('http://127.0.0.1:7242/ingest/0bf175bf-b05a-422e-87c8-7c4bfaecaeeb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'auth.ts:request',message:'response not ok',data:{path,status:response.status,code:(responseData as {code?:string})?.code},timestamp:Date.now(),hypothesisId:'H2',runId:'validate-email'})}).catch(()=>{});
       // #endregion

--- a/services/platformStatus.ts
+++ b/services/platformStatus.ts
@@ -1,0 +1,26 @@
+import { API_BASE } from '@/utils/apiConfig';
+
+export interface PlatformStatusResponse {
+  maintenance_mode: boolean;
+}
+
+/**
+ * Public endpoint: no auth. Used to show maintenance UI before login.
+ */
+export async function fetchPlatformStatus(): Promise<PlatformStatusResponse> {
+  const url = `${API_BASE}/api/platform/status`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error('platform_status_failed');
+  }
+  const data = (await response.json()) as unknown;
+  if (typeof data !== 'object' || data === null || !('maintenance_mode' in data)) {
+    throw new Error('platform_status_invalid');
+  }
+  return {
+    maintenance_mode: Boolean((data as { maintenance_mode: unknown }).maintenance_mode),
+  };
+}


### PR DESCRIPTION
- Add fetchPlatformStatus client for GET /api/platform/status (public).
- Show MaintenanceScreen from root layout when API reports maintenance_mode.
- Wire retry/check flow; extend i18n for maintenance copy (en/es).
- Adjust auth and ProfileFooter as needed for the feature.
