### PR TITLE
fix(api): add timeout to token-refresh retry fetch and improve onboar…

### DIFF
--- a/app/provider-onboarding/terms.tsx
+++ b/app/provider-onboarding/terms.tsx
@@ -1,11 +1,12 @@
 import { ProgressBar } from "@/components/onboarding/ProgressBar";
 import { t } from "@/i18n";
+import { ApiError } from "@/services/auth";
 import { submitOnboardingStep } from "@/services/providers";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
-import { ActivityIndicator, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Alert, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const TOTAL_STEPS = 8;
@@ -50,6 +51,11 @@ export default function ProviderOnboardingTermsScreen() {
       router.push("/provider-onboarding/verification");
     } catch (e) {
       console.error("[Terms] submitOnboardingStep failed:", e);
+      const message =
+        e instanceof ApiError && e.message.trim().length > 0
+          ? e.message
+          : t("providerOnboarding.terms.saveError");
+      Alert.alert(t("common.error"), message, [{ text: t("common.ok") }]);
     } finally {
       setSaving(false);
     }

--- a/app/provider-onboarding/verification.tsx
+++ b/app/provider-onboarding/verification.tsx
@@ -1,5 +1,6 @@
 import { useMode } from '@/contexts/ModeContext';
 import { t } from '@/i18n';
+import { ApiError } from '@/services/auth';
 import { submitOnboardingStep } from '@/services/providers';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
@@ -14,15 +15,22 @@ export default function ProviderOnboardingVerificationScreen() {
   const insets = useSafeAreaInsets();
   const { setMode } = useMode();
   const [submitState, setSubmitState] = useState<SubmitState>('submitting');
+  const [errorDetail, setErrorDetail] = useState<string | null>(null);
   const step7Sent = useRef(false);
 
   const sendStep7 = useCallback(async () => {
     setSubmitState('submitting');
+    setErrorDetail(null);
     try {
       await submitOnboardingStep(7, {});
       setSubmitState('submitted');
     } catch (e) {
       console.error('[Verification] submitOnboardingStep(7) failed:', e);
+      const message =
+        e instanceof ApiError && e.message.trim().length > 0
+          ? e.message
+          : t('providerOnboarding.verification.submitError');
+      setErrorDetail(message);
       setSubmitState('error');
     }
   }, []);
@@ -76,7 +84,7 @@ export default function ProviderOnboardingVerificationScreen() {
               </View>
             </View>
             <Text style={styles.errorText}>
-              {t('providerOnboarding.verification.submitError')}
+              {errorDetail ?? t('providerOnboarding.verification.submitError')}
             </Text>
             <TouchableOpacity
               style={styles.retryButton}

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1191,6 +1191,7 @@ export default {
       acceptNotifications: "I accept receiving notifications",
       back: "Back",
       accept: "Accept",
+      saveError: "Could not save your acceptance. Check your connection and try again.",
     },
     verification: {
       title: "Request sent!",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -1191,6 +1191,7 @@ export default {
       acceptNotifications: "Acepto recibir notificaciones",
       back: "Atrás",
       accept: "Aceptar",
+      saveError: "No se pudieron guardar los términos. Revisa tu conexión e intenta de nuevo.",
     },
     verification: {
       title: "¡Solicitud enviada!",

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -387,7 +387,47 @@ export const request = async <T>(
           ...(init.headers as Record<string, string>),
           Authorization: `Bearer ${newTokens.accessToken}`,
         };
-        const retryResponse = await fetch(url, { ...init, headers: retryHeaders, mode: 'cors' });
+        const retryController = new AbortController();
+        const retryTimeoutId = setTimeout(() => retryController.abort(), timeoutMs);
+        let retryResponse: Response;
+        try {
+          retryResponse = await fetch(url, {
+            ...init,
+            headers: retryHeaders,
+            mode: 'cors',
+            signal: retryController.signal,
+          });
+          clearTimeout(retryTimeoutId);
+        } catch (retryFetchError) {
+          clearTimeout(retryTimeoutId);
+          const isRetryTimeout =
+            retryFetchError instanceof Error && retryFetchError.name === 'AbortError';
+          if (isRetryTimeout) {
+            const renderHint = url.includes('onrender.com')
+              ? '\n\n' + t('errors.requestTimeoutRenderHint')
+              : '';
+            throw new ApiError(
+              t('errors.requestTimeout') + renderHint + getPhysicalDeviceHint(),
+              0,
+              { code: 'request_timeout', isTimeout: true },
+            );
+          }
+          if (retryFetchError instanceof TypeError) {
+            throw new ApiError(
+              t('errors.connectionFailed') + getPhysicalDeviceHint(),
+              0,
+              { code: 'network_error' },
+            );
+          }
+          throw new ApiError(
+            retryFetchError instanceof Error
+              ? retryFetchError.message || t('errors.connectionFailed')
+              : t('errors.connectionFailed'),
+            0,
+            { code: 'fetch_error' },
+          );
+        }
+
         const retryText = await retryResponse.text();
         let retryData: unknown = undefined;
         if (retryText) {


### PR DESCRIPTION
…ding errors

- auth request(): retry after token refresh now uses AbortController and the same timeout as the initial fetch, avoiding indefinite hang on bad network.
- provider onboarding verification: show ApiError message (connection/timeout) instead of only the generic submit error.
- terms step: Alert on step-6 save failure with i18n fallback.
- Add providerOnboarding.terms.saveError in en/es locales.
