### PR TITLE
fix(MDB-378): notifications, QA API defaults, profile version 3.0.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Copy to `.env` and fill values. Do not commit `.env`.
+
+# REST API → QA (Render). All services use `@/utils/apiConfig` (default env is `qa` if unset).
+EXPO_PUBLIC_API_ENV=qa
+EXPO_PUBLIC_API_URL=https://mordobo-api-qa.onrender.com
+
+# If you set EXPO_PUBLIC_API_ENV=production but still want QA, set both URLs to QA (matches current EAS production profile).
+# EXPO_PUBLIC_API_URL_PROD=https://mordobo-api-qa.onrender.com
+
+# Supabase Realtime: use the project tied to the same environment as the API (QA project for QA API).
+EXPO_PUBLIC_SUPABASE_URL=
+EXPO_PUBLIC_SUPABASE_ANON_KEY=
+
+# Google Sign-In (Expo / native)
+# EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=
+# EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
+# EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=
+# EXPO_PUBLIC_GOOGLE_IOS_URL_SCHEME=
+# EXPO_PUBLIC_EXPO_PROJECT_FULL_NAME=@your-account/mordobo

--- a/app.config.js
+++ b/app.config.js
@@ -1,4 +1,7 @@
 // app.config.js - Expo configuration with environment variables support
+/** Same default QA host as utils/apiConfig.ts (REST API → QA DB on Render). */
+const DEFAULT_QA_API_URL = "https://mordobo-api-qa.onrender.com";
+
 const IS_DEV = process.env.EXPO_PUBLIC_ENV === "development";
 const IS_STAGING = process.env.EXPO_PUBLIC_ENV === "staging";
 const IS_PRODUCTION = process.env.EXPO_PUBLIC_ENV === "production";
@@ -78,7 +81,7 @@ export default {
       googleIosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID || "",
       googleAndroidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID || "",
       googleIosUrlScheme: process.env.EXPO_PUBLIC_GOOGLE_IOS_URL_SCHEME || "",
-      expoPublicApiUrl: process.env.EXPO_PUBLIC_API_URL || "http://localhost:3000",
+      expoPublicApiUrl: (process.env.EXPO_PUBLIC_API_URL || "").trim() || DEFAULT_QA_API_URL,
       environment: process.env.EXPO_PUBLIC_ENV || "development",
       buildNumber: getBuildNumber(),
       buildDate: new Date().toISOString(),

--- a/app/(provider-tabs)/notifications.tsx
+++ b/app/(provider-tabs)/notifications.tsx
@@ -2,10 +2,12 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { type Notification, type NotificationCategory, deleteAllNotifications, deleteNotification, fetchNotifications, getNotificationCategory, markAllNotificationsAsRead, markNotificationAsRead } from "@/services/notifications";
+import { getLocalizedNotificationDisplay } from "@/utils/notificationDisplay";
 import { fetchOrderDetail } from "@/services/orders";
 import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ActivityIndicator, Modal, RefreshControl, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -40,6 +42,7 @@ function NotificationCard({ notification, onPress, onDelete }: NotificationCardP
   const category = getNotificationCategory(notification.type);
   const color = CATEGORY_COLORS[category];
   const iconName = CATEGORY_ICONS[category];
+  const display = getLocalizedNotificationDisplay(notification, "provider");
 
   const formatTime = useCallback((dateString: string) => {
     const date = new Date(dateString);
@@ -72,12 +75,12 @@ function NotificationCard({ notification, onPress, onDelete }: NotificationCardP
         <View style={styles.cardContent}>
           <View style={styles.cardRow}>
             <Text style={[styles.cardTitle, !notification.read && styles.cardTitleUnread, { color: colors.textPrimary }]} numberOfLines={1}>
-              {notification.title}
+              {display.title}
             </Text>
             <Text style={[styles.cardTime, { color: colors.textTertiary }]}>{formatTime(notification.created_at)}</Text>
           </View>
           <Text style={[styles.cardMessage, { color: colors.textSecondary }]} numberOfLines={2}>
-            {notification.message}
+            {display.message}
           </Text>
         </View>
         {!notification.read && <View style={[styles.unreadDot, { backgroundColor: color }]} />}
@@ -139,13 +142,15 @@ export default function ProviderNotificationsScreen() {
     }
   }, [isAuthenticated]);
 
-  useEffect(() => {
-    if (isAuthenticated) loadNotifications();
-    else {
-      setNotifications([]);
-      setLoading(false);
-    }
-  }, [loadNotifications, isAuthenticated]);
+  useFocusEffect(
+    useCallback(() => {
+      if (isAuthenticated) loadNotifications();
+      else {
+        setNotifications([]);
+        setLoading(false);
+      }
+    }, [loadNotifications, isAuthenticated]),
+  );
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -7,10 +7,12 @@ import {
   markNotificationAsRead,
   markAllNotificationsAsRead,
 } from '@/services/notifications';
+import { getLocalizedNotificationDisplay } from '@/utils/notificationDisplay';
 import { fetchOrderDetail } from '@/services/orders';
 import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   RefreshControl,
@@ -102,6 +104,7 @@ function NotificationItem({ notification, onPress, colors }: NotificationItemPro
   };
 
   const config = getNotificationConfig(notification.type);
+  const display = getLocalizedNotificationDisplay(notification, 'client');
 
   return (
     <TouchableOpacity
@@ -122,10 +125,10 @@ function NotificationItem({ notification, onPress, colors }: NotificationItemPro
       </View>
       <View style={styles.notificationContent}>
         <Text style={[styles.notificationTitle, { color: colors.textPrimary }]}>
-          {notification.title}
+          {display.title}
         </Text>
         <Text style={[styles.notificationMessage, { color: colors.textSecondary }]}>
-          {notification.message}
+          {display.message}
         </Text>
         <Text style={[styles.notificationTime, { color: colors.textTertiary }]}>
           {formatTime(notification.created_at)}
@@ -164,9 +167,12 @@ export default function NotificationsScreen() {
     }
   }, []);
 
-  useEffect(() => {
-    loadNotifications();
-  }, [loadNotifications]);
+  // Tab screens often stay mounted; reload when user opens Alertas so new items (e.g. refunds) appear.
+  useFocusEffect(
+    useCallback(() => {
+      loadNotifications();
+    }, [loadNotifications]),
+  );
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);

--- a/components/profile/ProfileFooter.tsx
+++ b/components/profile/ProfileFooter.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 /** Version label shown in profile footer for both Client and Provider. */
-const PROFILE_VERSION_LABEL = "3.0.6";
+const PROFILE_VERSION_LABEL = "3.0.7";
 
 /**
  * Shared footer for Client and Provider profile screens: app version label and logout button.

--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,9 @@
         "gradleCommand": ":app:assembleDebug"
       },
       "env": {
-        "EXPO_PUBLIC_ENV": "development"
+        "EXPO_PUBLIC_ENV": "development",
+        "EXPO_PUBLIC_API_ENV": "qa",
+        "EXPO_PUBLIC_API_URL": "https://mordobo-api-qa.onrender.com"
       }
     },
     "preview": {
@@ -37,6 +39,7 @@
       },
       "env": {
         "EXPO_PUBLIC_ENV": "staging",
+        "EXPO_PUBLIC_API_ENV": "qa",
         "EXPO_PUBLIC_API_URL": "https://mordobo-api-qa.onrender.com"
       }
     },
@@ -55,6 +58,7 @@
       },
       "env": {
         "EXPO_PUBLIC_ENV": "staging",
+        "EXPO_PUBLIC_API_ENV": "qa",
         "EXPO_PUBLIC_API_URL": "https://mordobo-api-qa.onrender.com"
       },
       "channel": "staging"
@@ -74,6 +78,7 @@
       },
       "env": {
         "EXPO_PUBLIC_ENV": "qa",
+        "EXPO_PUBLIC_API_ENV": "qa",
         "EXPO_PUBLIC_API_URL": "https://mordobo-api-qa.onrender.com"
       },
       "channel": "qa"
@@ -91,7 +96,9 @@
       },
       "env": {
         "EXPO_PUBLIC_ENV": "production",
-        "EXPO_PUBLIC_API_URL": "https://api.mordobo.com"
+        "EXPO_PUBLIC_API_ENV": "qa",
+        "EXPO_PUBLIC_API_URL": "https://mordobo-api-qa.onrender.com",
+        "EXPO_PUBLIC_API_URL_PROD": "https://mordobo-api-qa.onrender.com"
       },
       "channel": "production"
     }

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -979,6 +979,13 @@ export default {
     empty: "You have no notifications",
     today: "TODAY",
     yesterday: "YESTERDAY",
+    refundIssuedClientTitle: "Refund issued",
+    refundIssuedClientMessage:
+      "A refund of %{amount} has been issued for %{serviceName}. Reason: %{reason}.",
+    refundIssuedProviderTitle: "Refund recorded",
+    refundIssuedProviderMessage:
+      "A refund of %{amount} was recorded for %{serviceName}. Reason: %{reason}.",
+    refundServiceFallback: "your booking",
   },
   settings: {
     title: "Settings",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -979,6 +979,13 @@ export default {
     empty: "No tienes notificaciones",
     today: "HOY",
     yesterday: "AYER",
+    refundIssuedClientTitle: "Reembolso emitido",
+    refundIssuedClientMessage:
+      "Se emitió un reembolso de %{amount} por %{serviceName}. Motivo: %{reason}.",
+    refundIssuedProviderTitle: "Reembolso registrado",
+    refundIssuedProviderMessage:
+      "Se registró un reembolso de %{amount} por %{serviceName}. Motivo: %{reason}.",
+    refundServiceFallback: "tu reserva",
   },
   settings: {
     title: "Configuración",

--- a/services/notifications.ts
+++ b/services/notifications.ts
@@ -4,6 +4,8 @@ import { request } from './auth';
 export interface Notification {
   id: string;
   type: NotificationType;
+  /** Row in DB: refund to client vs supplier use different copy */
+  user_type?: 'client' | 'supplier';
   title: string;
   message: string;
   read: boolean;
@@ -15,6 +17,9 @@ export interface Notification {
     quoteId?: string;
     reviewId?: string;
     paymentId?: string;
+    refundAmount?: number;
+    reason?: string;
+    serviceName?: string;
     [key: string]: unknown;
   };
 }

--- a/utils/notificationDisplay.ts
+++ b/utils/notificationDisplay.ts
@@ -1,0 +1,55 @@
+import { getLocale, t } from '@/i18n';
+import type { Notification } from '@/services/notifications';
+
+function formatRefundCurrency(amount: number): string {
+  const locale = getLocale() === 'es' ? 'es-MX' : 'en-US';
+  return new Intl.NumberFormat(locale, { style: 'currency', currency: 'MXN' }).format(amount);
+}
+
+export type NotificationViewerRole = 'client' | 'provider';
+
+/**
+ * Localized title/body for known types; others pass through API strings.
+ */
+export function getLocalizedNotificationDisplay(
+  notification: Notification,
+  viewerRole: NotificationViewerRole,
+): { title: string; message: string } {
+  if (notification.type !== 'refund_issued') {
+    return { title: notification.title, message: notification.message };
+  }
+
+  const m = notification.metadata ?? {};
+  const rawAmount = m.refundAmount;
+  const amountNum = typeof rawAmount === 'number' ? rawAmount : Number(rawAmount);
+  const amountStr = Number.isFinite(amountNum) ? formatRefundCurrency(amountNum) : '';
+  const reason = typeof m.reason === 'string' ? m.reason : '';
+  const serviceName =
+    typeof m.serviceName === 'string' && m.serviceName.trim().length > 0
+      ? m.serviceName.trim()
+      : t('notifications.refundServiceFallback');
+
+  const refundRole: NotificationViewerRole =
+    notification.user_type === 'supplier' ? 'provider' : viewerRole;
+
+  if (refundRole === 'provider') {
+    return {
+      title: t('notifications.refundIssuedProviderTitle'),
+      message: t('notifications.refundIssuedProviderMessage', {
+        amount: amountStr,
+        serviceName,
+        reason,
+      }),
+    };
+  }
+
+  return {
+    title: t('notifications.refundIssuedClientTitle'),
+    message: t('notifications.refundIssuedClientMessage', {
+      amount: amountStr,
+      serviceName,
+      reason,
+    }),
+  };
+}
+

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
+/** Must match the Supabase project used by the API env you target (e.g. QA project when API is QA). */
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL?.trim() || '';
 const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY?.trim() || '';
 


### PR DESCRIPTION
- Point all EAS profiles and app.config extra default to QA API; add EXPO_PUBLIC_API_ENV on builds; add .env.example for QA-aligned env vars.
- Profile footer version label 3.0.7 (client and provider share ProfileFooter).
- Refund-related UX: reload notifications on tab focus (client + provider); add notificationDisplay with i18n for refund_issued; expose optional user_type on Notification type for supplier vs client copy.
- Supabase util: comment that URL/key must match API environment.
