### PR TITLE
fix(ui): theme-aware text for categories, favorites, and bookings

### DIFF
--- a/app/(tabs)/bookings.tsx
+++ b/app/(tabs)/bookings.tsx
@@ -370,7 +370,9 @@ export default function BookingsScreen() {
           {ordersPendingPayment.length > 0 && (
             <View style={styles.pendingPaymentSection}>
               <Text style={styles.pendingPaymentTitle}>{t('orders.pendingPaymentSection')}</Text>
-              <Text style={styles.pendingPaymentSubtitle}>{t('orders.pendingPaymentSectionSubtitle')}</Text>
+              <Text style={[styles.pendingPaymentSubtitle, { color: colors.textSecondary }]}>
+                {t('orders.pendingPaymentSectionSubtitle')}
+              </Text>
               {ordersPendingPayment.map((order) => (
                 <BookingCard
                   key={order.id}
@@ -393,7 +395,9 @@ export default function BookingsScreen() {
           ) : filteredOrders.length === 0 ? null : (
             <>
               {ordersPendingPayment.length > 0 && <View style={styles.sectionDivider} />}
-              <Text style={styles.reservationsSectionTitle}>{t('orders.reservationsSection')}</Text>
+              <Text style={[styles.reservationsSectionTitle, { color: colors.textPrimary }]}>
+                {t('orders.reservationsSection')}
+              </Text>
               {filteredOrders.map((order) => (
                 <BookingCard
                   key={order.id}
@@ -466,7 +470,6 @@ const styles = StyleSheet.create({
   },
   tabTextInactive: {
     fontWeight: '400',
-    color: '#FFFFFF',
   },
   content: {
     flex: 1,
@@ -486,7 +489,6 @@ const styles = StyleSheet.create({
   },
   pendingPaymentSubtitle: {
     fontSize: 13,
-    color: 'rgba(255,255,255,0.6)',
     marginBottom: 12,
   },
   sectionDivider: {
@@ -497,7 +499,6 @@ const styles = StyleSheet.create({
   reservationsSectionTitle: {
     fontSize: 15,
     fontWeight: '600',
-    color: '#fff',
     marginBottom: 12,
   },
   bookingCard: {

--- a/app/account/favorites.tsx
+++ b/app/account/favorites.tsx
@@ -157,7 +157,7 @@ export default function FavoritesScreen() {
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{t('profile.favorites')}</Text>
+          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t('profile.favorites')}</Text>
         </View>
         <View style={styles.centerContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
@@ -176,7 +176,7 @@ export default function FavoritesScreen() {
         >
           <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>{t('profile.favorites')}</Text>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t('profile.favorites')}</Text>
       </View>
 
       {favorites.length === 0 ? (
@@ -240,7 +240,9 @@ export default function FavoritesScreen() {
 
                 {/* Info in the middle */}
                 <View style={styles.providerInfo}>
-                  <Text style={styles.providerName}>{provider.business_name?.trim() || provider.full_name}</Text>
+                  <Text style={[styles.providerName, { color: colors.textPrimary }]}>
+                    {provider.business_name?.trim() || provider.full_name}
+                  </Text>
                   <Text style={[styles.providerService, { color: colors.primary }]}>
                     {getServiceName(provider)}
                   </Text>
@@ -304,7 +306,6 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontSize: 20,
     fontWeight: '600',
-    color: '#ffffff', // Hardcode white to match JSX
   },
   centerContainer: {
     flex: 1,
@@ -366,7 +367,6 @@ const styles = StyleSheet.create({
   providerName: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#ffffff', // Hardcode white
     marginBottom: 4,
   },
   // Service - Exact match: fontSize: '14px', color: secondary

--- a/components/CategoryCard.tsx
+++ b/components/CategoryCard.tsx
@@ -1,3 +1,4 @@
+import { useThemeColors } from '@/hooks/useThemeColors';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -17,12 +18,13 @@ const hexToRgba = (hex: string, opacity: number): string => {
 };
 
 export function CategoryCard({ name, emoji, color, onPress }: CategoryCardProps) {
+  const colors = useThemeColors();
   return (
     <TouchableOpacity style={styles.container} onPress={onPress}>
       <View style={[styles.iconContainer, { backgroundColor: hexToRgba(color, 0.2) }]}>
         <Text style={styles.emoji}>{emoji}</Text>
       </View>
-      <Text style={styles.name}>{name}</Text>
+      <Text style={[styles.name, { color: colors.textPrimary }]}>{name}</Text>
     </TouchableOpacity>
   );
 }
@@ -47,7 +49,6 @@ const styles = StyleSheet.create({
   name: {
     fontSize: 12,
     fontWeight: '500',
-    color: '#FFFFFF',
     textAlign: 'center',
   },
 });


### PR DESCRIPTION
- CategoryCard: use useThemeColors textPrimary for category labels instead of hardcoded white so names are readable on light backgrounds (MDB-353).
- Favorites: header title and provider name use theme primary text on cards.
- Bookings: reservations section title and pending-payment subtitle use theme text colors; remove misleading white default on inactive tab label style.
