### PR TITLE
feat(notifications): detail screen, quote fixes, and clearer CTAs

### DIFF
--- a/app/(provider-tabs)/notifications.tsx
+++ b/app/(provider-tabs)/notifications.tsx
@@ -3,7 +3,6 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { type Notification, type NotificationCategory, deleteAllNotifications, deleteNotification, fetchNotifications, getNotificationCategory, markAllNotificationsAsRead, markNotificationAsRead } from "@/services/notifications";
 import { getLocalizedNotificationDisplay } from "@/utils/notificationDisplay";
-import { fetchOrderDetail } from "@/services/orders";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
@@ -215,48 +214,7 @@ export default function ProviderNotificationsScreen() {
         }
       }
 
-      const meta = notification.metadata || {};
-      const type = notification.type;
-
-      switch (type) {
-        case "booking_confirmed":
-        case "booking_cancelled":
-        case "provider_on_way":
-        case "quote_approved":
-          if (meta.orderId) router.push(`/(provider-tabs)/jobs/${meta.orderId}`);
-          break;
-        case "new_booking_request":
-          router.push("/(provider-tabs)/requests");
-          break;
-        case "new_message":
-          if (meta.conversationId) {
-            router.push(`/chat/${meta.conversationId}`);
-          } else if (meta.orderId) {
-            fetchOrderDetail(meta.orderId)
-              .then((detail) => {
-                if (detail.conversation_id) router.push(`/chat/${detail.conversation_id}`);
-              })
-              .catch(() => {});
-          }
-          break;
-        case "payment_processed":
-        case "payment_received":
-        case "refund_issued":
-          router.push("/(provider-tabs)/earnings");
-          break;
-        case "rate_service":
-        case "new_review":
-          router.push("/(provider-tabs)/profile/reviews");
-          break;
-        case "quote_received":
-          if (meta.orderId) router.push(`/(provider-tabs)/jobs/${meta.orderId}`);
-          break;
-        case "offer":
-          router.push("/(provider-tabs)");
-          break;
-        default:
-          break;
-      }
+      router.push(`/notifications/${notification.id}`);
     },
     [router],
   );

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -8,7 +8,6 @@ import {
   markAllNotificationsAsRead,
 } from '@/services/notifications';
 import { getLocalizedNotificationDisplay } from '@/utils/notificationDisplay';
-import { fetchOrderDetail } from '@/services/orders';
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
@@ -208,43 +207,7 @@ export default function NotificationsScreen() {
         }
       }
 
-      // Navigate based on notification type
-      const metadata = notification.metadata || {};
-      switch (notification.type) {
-        case 'booking_confirmed':
-        case 'booking_cancelled':
-        case 'payment_processed':
-        case 'provider_on_way':
-        case 'quote_received':
-        case 'refund_issued':
-          if (metadata.orderId) {
-            router.push(`/booking/quote/${metadata.orderId}`);
-          }
-          break;
-        case 'new_message':
-          if (metadata.conversationId) {
-            router.push(`/chat/${metadata.conversationId}`);
-          } else if (metadata.orderId) {
-            fetchOrderDetail(metadata.orderId)
-              .then((detail) => {
-                if (detail.conversation_id) router.push(`/chat/${detail.conversation_id}`);
-              })
-              .catch(() => {});
-          }
-          break;
-        case 'rate_service':
-        case 'job_pending_review':
-        case 'job_completed':
-          if (metadata.orderId) {
-            router.push(`/orders/rate/${metadata.orderId}`);
-          }
-          break;
-        case 'offer':
-          router.push('/(tabs)/home');
-          break;
-        default:
-          break;
-      }
+      router.push(`/notifications/${notification.id}`);
     },
     [router]
   );

--- a/app/booking/quote/[orderId].tsx
+++ b/app/booking/quote/[orderId].tsx
@@ -621,13 +621,53 @@ export default function QuoteScreen() {
     );
   }
 
-  if (error || !orderData?.quote || !quote) {
+  if (error) {
     return (
       <View style={[styles.container, loadingTheme?.container]}>
         <View style={[styles.centerContainer, loadingTheme?.centerContainer]}>
-          <Text style={[styles.errorText, loadingTheme?.errorText]}>{error || 'Quote not found'}</Text>
+          <Text style={[styles.errorText, loadingTheme?.errorText]}>{error}</Text>
           <TouchableOpacity style={[styles.retryButton, loadingTheme?.retryButton]} onPress={loadData}>
-            <Text style={[styles.retryText, loadingTheme?.retryText]}>Retry</Text>
+            <Text style={[styles.retryText, loadingTheme?.retryText]}>{t('common.retry')}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+
+  if (orderData?.order && (!orderData.quote || !quote)) {
+    return (
+      <View style={[styles.container, loadingTheme?.container]}>
+        <View style={[styles.centerContainer, loadingTheme?.centerContainer]}>
+          <Text style={[styles.errorText, loadingTheme?.errorText, { color: themeColors.textSecondary }]}>
+            {t('quote.orderNoQuoteSummary')}
+          </Text>
+          {orderId ? (
+            <TouchableOpacity
+              style={[styles.retryButton, loadingTheme?.retryButton, { marginBottom: 12 }]}
+              onPress={() =>
+                router.replace(
+                  mode === 'provider' ? `/(provider-tabs)/jobs/${orderId}` : `/orders/${orderId}`
+                )
+              }
+            >
+              <Text style={[styles.retryText, loadingTheme?.retryText]}>{t('quote.viewBooking')}</Text>
+            </TouchableOpacity>
+          ) : null}
+          <TouchableOpacity style={[styles.retryButton, loadingTheme?.retryButton]} onPress={loadData}>
+            <Text style={[styles.retryText, loadingTheme?.retryText]}>{t('common.retry')}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+
+  if (!orderData?.quote || !quote) {
+    return (
+      <View style={[styles.container, loadingTheme?.container]}>
+        <View style={[styles.centerContainer, loadingTheme?.centerContainer]}>
+          <Text style={[styles.errorText, loadingTheme?.errorText]}>{t('quote.notFound')}</Text>
+          <TouchableOpacity style={[styles.retryButton, loadingTheme?.retryButton]} onPress={loadData}>
+            <Text style={[styles.retryText, loadingTheme?.retryText]}>{t('common.retry')}</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/app/notifications/[id].tsx
+++ b/app/notifications/[id].tsx
@@ -1,0 +1,286 @@
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { t, getLocale } from '@/i18n';
+import { useMode } from '@/contexts/ModeContext';
+import {
+  fetchNotifications,
+  getNotificationCategory,
+  type Notification,
+  type NotificationCategory,
+  type NotificationType,
+} from '@/services/notifications';
+import { getLocalizedNotificationDisplay } from '@/utils/notificationDisplay';
+import { resolveNotificationRelatedHref } from '@/utils/notificationNavigation';
+import { Ionicons } from '@expo/vector-icons';
+import type { Href } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const PROVIDER_CATEGORY_COLORS: Record<NotificationCategory, string> = {
+  jobs: '#8B5CF6',
+  payments: '#22C55E',
+  reviews: '#EAB308',
+  system: '#3B82F6',
+};
+
+const PROVIDER_CATEGORY_ICONS: Record<NotificationCategory, keyof typeof Ionicons.glyphMap> = {
+  jobs: 'briefcase',
+  payments: 'wallet',
+  reviews: 'star',
+  system: 'notifications',
+};
+
+function getClientEmoji(type: NotificationType): { icon: string; bg: string } {
+  switch (type) {
+    case 'booking_confirmed':
+      return { icon: '✅', bg: '#10B981' };
+    case 'booking_cancelled':
+      return { icon: '❌', bg: '#EF4444' };
+    case 'new_message':
+      return { icon: '💬', bg: '#3B82F6' };
+    case 'rate_service':
+      return { icon: '⭐', bg: '#F59E0B' };
+    case 'offer':
+      return { icon: '🎁', bg: '#EC4899' };
+    case 'payment_processed':
+    case 'payment_received':
+      return { icon: '💳', bg: '#10B981' };
+    case 'provider_on_way':
+      return { icon: '📍', bg: '#8B5CF6' };
+    case 'quote_received':
+    case 'quote_approved':
+      return { icon: '📋', bg: '#6366F1' };
+    case 'new_booking_request':
+      return { icon: '📩', bg: '#8B5CF6' };
+    case 'new_review':
+      return { icon: '⭐', bg: '#F59E0B' };
+    case 'refund_issued':
+      return { icon: '↩️', bg: '#10B981' };
+    default:
+      return { icon: '🔔', bg: '#6B7280' };
+  }
+}
+
+export default function NotificationDetailScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+  const { mode } = useMode();
+  const params = useLocalSearchParams<{ id: string | string[] }>();
+  const notificationId = typeof params.id === 'string' ? params.id : Array.isArray(params.id) ? params.id[0] : undefined;
+
+  const [notification, setNotification] = useState<Notification | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [openingRelated, setOpeningRelated] = useState(false);
+
+  const audience = mode === 'provider' ? 'provider' : 'client';
+
+  const load = useCallback(async () => {
+    if (!notificationId) {
+      setLoadError(t('notifications.detail.notFound'));
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const list = await fetchNotifications();
+      const found = list.find((n) => n.id === notificationId) ?? null;
+      setNotification(found);
+      if (!found) {
+        setLoadError(t('notifications.detail.notFound'));
+      }
+    } catch {
+      setLoadError(t('notifications.detail.loadError'));
+      setNotification(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [notificationId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const display = useMemo(() => {
+    if (!notification) return null;
+    return getLocalizedNotificationDisplay(notification, audience);
+  }, [notification, audience]);
+
+  const formattedDate = useMemo(() => {
+    if (!notification) return '';
+    const locale = getLocale() === 'es' ? 'es-ES' : 'en-US';
+    return new Date(notification.created_at).toLocaleString(locale, {
+      dateStyle: 'full',
+      timeStyle: 'short',
+    });
+  }, [notification]);
+
+  const providerCategory = useMemo(
+    () => (notification && mode === 'provider' ? getNotificationCategory(notification.type) : null),
+    [notification, mode]
+  );
+
+  const onOpenRelated = useCallback(async () => {
+    if (!notification) return;
+    setOpeningRelated(true);
+    try {
+      const href = await resolveNotificationRelatedHref(notification, mode);
+      if (href) {
+        router.push(href as Href);
+      } else {
+        Alert.alert(t('common.error'), t('notifications.detail.noRelated'));
+      }
+    } catch {
+      Alert.alert(t('common.error'), t('notifications.detail.loadError'));
+    } finally {
+      setOpeningRelated(false);
+    }
+  }, [notification, mode, router]);
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        header: {
+          paddingHorizontal: 16,
+          paddingBottom: 16,
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 12,
+          backgroundColor: colors.card,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.cardBorder,
+        },
+        backBtn: { width: 40, height: 40, justifyContent: 'center', alignItems: 'center' },
+        headerTitle: { flex: 1, fontSize: 18, fontWeight: '600', color: colors.textPrimary },
+        center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
+        scroll: { flex: 1 },
+        scrollContent: { padding: 24, paddingBottom: 40 + insets.bottom },
+        iconWrap: {
+          width: 72,
+          height: 72,
+          borderRadius: 16,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: 20,
+          alignSelf: 'center',
+        },
+        emoji: { fontSize: 36 },
+        title: { fontSize: 22, fontWeight: '700', color: colors.textPrimary, marginBottom: 12, textAlign: 'center' },
+        body: { fontSize: 16, lineHeight: 24, color: colors.textSecondary, marginBottom: 24, textAlign: 'center' },
+        dateLabel: { fontSize: 12, fontWeight: '600', color: colors.textTertiary, textTransform: 'uppercase', marginBottom: 4 },
+        dateValue: { fontSize: 15, color: colors.textSecondary, marginBottom: 20, textAlign: 'center' },
+        hint: {
+          fontSize: 14,
+          lineHeight: 20,
+          color: colors.textTertiary,
+          textAlign: 'center',
+          marginBottom: 16,
+          paddingHorizontal: 8,
+        },
+        primaryBtn: {
+          backgroundColor: colors.primary,
+          paddingVertical: 16,
+          borderRadius: 12,
+          alignItems: 'center',
+        },
+        primaryBtnDisabled: { opacity: 0.6 },
+        primaryBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '600' },
+        muted: { fontSize: 15, color: colors.textSecondary, textAlign: 'center' },
+      }),
+    [colors, insets.bottom]
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.header, { paddingTop: insets.top + 8 }]}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={styles.backBtn}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+        >
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {t('notifications.detail.screenTitle')}
+        </Text>
+        <View style={{ width: 40 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : loadError && !notification ? (
+        <View style={styles.center}>
+          <Text style={styles.muted}>{loadError}</Text>
+          <TouchableOpacity style={[styles.primaryBtn, { marginTop: 20, paddingHorizontal: 24 }]} onPress={() => void load()}>
+            <Text style={styles.primaryBtnText}>{t('common.retry')}</Text>
+          </TouchableOpacity>
+        </View>
+      ) : notification && display ? (
+        <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+          {mode === 'provider' && providerCategory ? (
+            <View
+              style={[
+                styles.iconWrap,
+                {
+                  backgroundColor: `${PROVIDER_CATEGORY_COLORS[providerCategory]}26`,
+                },
+              ]}
+            >
+              <Ionicons
+                name={PROVIDER_CATEGORY_ICONS[providerCategory]}
+                size={36}
+                color={PROVIDER_CATEGORY_COLORS[providerCategory]}
+              />
+            </View>
+          ) : (
+            <View style={[styles.iconWrap, { backgroundColor: `${getClientEmoji(notification.type).bg}26` }]}>
+              <Text style={styles.emoji}>{getClientEmoji(notification.type).icon}</Text>
+            </View>
+          )}
+
+          <Text style={styles.title}>{display.title}</Text>
+          <Text style={styles.body}>{display.message}</Text>
+
+          <Text style={styles.dateLabel}>{t('notifications.detail.dateLabel')}</Text>
+          <Text style={styles.dateValue}>{formattedDate}</Text>
+
+          <Text style={styles.hint}>{t('notifications.detail.openRelatedHint')}</Text>
+
+          <TouchableOpacity
+            style={[styles.primaryBtn, openingRelated && styles.primaryBtnDisabled]}
+            onPress={() => void onOpenRelated()}
+            disabled={openingRelated}
+            accessibilityRole="button"
+            accessibilityLabel={t('notifications.detail.openRelated')}
+            accessibilityHint={t('notifications.detail.openRelatedHint')}
+          >
+            {openingRelated ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.primaryBtnText}>{t('notifications.detail.openRelated')}</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      ) : (
+        <View style={styles.center}>
+          <Text style={styles.muted}>{t('notifications.detail.notFound')}</Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -13,6 +13,7 @@ export default {
     discard: "Discard",
     redirecting: "Redirecting...",
     loading: "Loading...",
+    retry: "Retry",
   },
   maintenance: {
     title: "Under maintenance",
@@ -498,6 +499,9 @@ export default {
     cancelRequestFailed: "Failed to cancel request",
     chatBack: "Chat Back",
     notFound: "Quote not found",
+    orderNoQuoteSummary:
+      "This booking has no quote breakdown (for example, instant book-and-pay). Open your booking to see status and details.",
+    viewBooking: "View booking",
     noAddress: "No address specified",
     noDate: "No date specified",
     durationHours: "{{count}} hr",
@@ -987,6 +991,16 @@ export default {
     refundIssuedProviderMessage:
       "A refund of %{amount} was recorded for %{serviceName}. Reason: %{reason}.",
     refundServiceFallback: "your booking",
+    detail: {
+      screenTitle: "Notification",
+      openRelated: "View in app",
+      openRelatedHint:
+        "Opens the screen that matches this alert—for example your booking, a quote, chat, ratings, or (for providers) jobs, requests, or earnings.",
+      notFound: "This notification is no longer available.",
+      loadError: "We could not load this notification.",
+      dateLabel: "Date",
+      noRelated: "This alert has no screen to open in the app.",
+    },
   },
   settings: {
     title: "Settings",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -13,6 +13,7 @@ export default {
     discard: "Descartar",
     redirecting: "Redirigiendo...",
     loading: "Cargando...",
+    retry: "Reintentar",
   },
   maintenance: {
     title: "En mantenimiento",
@@ -498,6 +499,9 @@ export default {
     cancelRequestFailed: "Error al cancelar la solicitud",
     chatBack: "Volver al chat",
     notFound: "Cotización no encontrada",
+    orderNoQuoteSummary:
+      "Esta reserva no incluye desglose de cotización (por ejemplo, reserva y pago directo). Abre la reserva para ver el estado y los detalles.",
+    viewBooking: "Ver reserva",
     noAddress: "Sin dirección",
     noDate: "Sin fecha",
     durationHours: "{{count}} hr",
@@ -987,6 +991,16 @@ export default {
     refundIssuedProviderMessage:
       "Se registró un reembolso de %{amount} por %{serviceName}. Motivo: %{reason}.",
     refundServiceFallback: "tu reserva",
+    detail: {
+      screenTitle: "Notificación",
+      openRelated: "Ver en la app",
+      openRelatedHint:
+        "Te lleva a la pantalla que corresponde a esta alerta: por ejemplo tu reserva, una cotización, el chat, valorar el servicio o (si eres proveedor) el trabajo, solicitudes o ingresos.",
+      notFound: "Esta notificación ya no está disponible.",
+      loadError: "No pudimos cargar esta notificación.",
+      dateLabel: "Fecha",
+      noRelated: "Esta alerta no tiene una pantalla para abrir en la app.",
+    },
   },
   settings: {
     title: "Configuración",

--- a/utils/notificationNavigation.ts
+++ b/utils/notificationNavigation.ts
@@ -1,0 +1,79 @@
+import type { Notification } from '@/services/notifications';
+import { fetchOrderDetail } from '@/services/orders';
+import type { UserMode } from '@/contexts/ModeContext';
+
+function syncHrefForNotification(notification: Notification, mode: UserMode): string | null {
+  const metadata = notification.metadata || {};
+  const type = notification.type as string;
+
+  if (mode === 'client') {
+    switch (notification.type) {
+      case 'quote_received':
+        return metadata.orderId ? `/booking/quote/${metadata.orderId}` : null;
+      case 'booking_confirmed':
+      case 'booking_cancelled':
+      case 'payment_processed':
+      case 'provider_on_way':
+      case 'refund_issued':
+        return metadata.orderId ? `/orders/${metadata.orderId}` : null;
+      case 'new_message':
+        return metadata.conversationId ? `/chat/${metadata.conversationId}` : null;
+      case 'rate_service':
+        return metadata.orderId ? `/orders/rate/${metadata.orderId}` : null;
+      case 'offer':
+        return '/(tabs)/home';
+      default:
+        if (type === 'job_pending_review' || type === 'job_completed') {
+          return metadata.orderId ? `/orders/rate/${metadata.orderId}` : null;
+        }
+        return null;
+    }
+  }
+
+  switch (notification.type) {
+    case 'booking_confirmed':
+    case 'booking_cancelled':
+    case 'provider_on_way':
+    case 'quote_approved':
+      return metadata.orderId ? `/(provider-tabs)/jobs/${metadata.orderId}` : null;
+    case 'new_booking_request':
+      return '/(provider-tabs)/requests';
+    case 'new_message':
+      return metadata.conversationId ? `/chat/${metadata.conversationId}` : null;
+    case 'payment_processed':
+    case 'payment_received':
+    case 'refund_issued':
+      return '/(provider-tabs)/earnings';
+    case 'rate_service':
+    case 'new_review':
+      return '/(provider-tabs)/profile/reviews';
+    case 'quote_received':
+      return metadata.orderId ? `/(provider-tabs)/jobs/${metadata.orderId}` : null;
+    case 'offer':
+      return '/(provider-tabs)';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolves a stack href for the content related to this notification (booking, chat, etc.).
+ */
+export async function resolveNotificationRelatedHref(
+  notification: Notification,
+  mode: UserMode
+): Promise<string | null> {
+  const metadata = notification.metadata || {};
+  if (notification.type === 'new_message' && !metadata.conversationId && metadata.orderId) {
+    try {
+      const detail = await fetchOrderDetail(metadata.orderId);
+      if (detail.conversation_id) {
+        return `/chat/${detail.conversation_id}`;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+  return syncHrefForNotification(notification, mode);
+}


### PR DESCRIPTION
- Add /notifications/[id] screen: load by id from list API, show title/body/date, and navigate to the correct in-app destination via notificationNavigation util.
- Client and provider notification lists open detail first; deep links resolved on Ver en la app / View in app with openRelatedHint copy (en/es).
- Fix book-and-pay orders without quote: list routes booking/payment alerts to /orders instead of quote screen; quote screen handles missing quote with CTA to order or provider job and uses i18n for retry/not found.
- Add common.retry and quote.orderNoQuoteSummary / viewBooking strings.

