### PR TITLE
fix(MDB-306): notification deep links, order detail freshness, bookin…

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -89,17 +89,18 @@ export default function TabLayout() {
   const { isAuthenticated } = useAuth();
   const { mode, isLoading } = useMode();
 
-  if (!isAuthenticated) {
-    return <Redirect href="/(auth)" />;
-  }
-
   // After login: redirect to provider dashboard when saved mode is provider (synced with DB)
+  // Must run before any early return so hook order is stable when isAuthenticated flips (e.g. logout).
   useEffect(() => {
-    if (isLoading) return;
+    if (!isAuthenticated || isLoading) return;
     if (mode === 'provider') {
       router.replace('/(provider-tabs)');
     }
-  }, [isLoading, mode, router]);
+  }, [isAuthenticated, isLoading, mode, router]);
+
+  if (!isAuthenticated) {
+    return <Redirect href="/(auth)" />;
+  }
 
   // Calculate bottom padding respecting safe area
   const bottomPadding = Math.max(insets.bottom, 24);

--- a/app/(tabs)/bookings.tsx
+++ b/app/(tabs)/bookings.tsx
@@ -3,8 +3,8 @@ import { t, getLocale } from '@/i18n';
 import { getOrCreateConversation } from '@/services/conversations';
 import { fetchOrders, Order, OrderStatus } from '@/services/orders';
 import { Ionicons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useFocusEffect, useRouter } from 'expo-router';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -234,9 +234,11 @@ export default function BookingsScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
-  useEffect(() => {
-    loadOrders();
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      void loadOrders();
+    }, []),
+  );
 
   const loadOrders = async () => {
     try {

--- a/app/booking/quote/[orderId].tsx
+++ b/app/booking/quote/[orderId].tsx
@@ -355,8 +355,10 @@ export default function QuoteScreen() {
       }),
     [providerColors]
   );
-  const params = useLocalSearchParams<{ orderId: string | string[] }>();
+  const params = useLocalSearchParams<{ orderId: string | string[]; navRef?: string | string[] }>();
   const orderId = typeof params.orderId === 'string' ? params.orderId : Array.isArray(params.orderId) ? params.orderId[0] : undefined;
+  const navRef =
+    typeof params.navRef === 'string' ? params.navRef : Array.isArray(params.navRef) ? params.navRef[0] : undefined;
   const insets = useSafeAreaInsets();
   const [orderData, setOrderData] = useState<OrderDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -392,7 +394,7 @@ export default function QuoteScreen() {
     } finally {
       setLoading(false);
     }
-  }, [orderId]);
+  }, [orderId, navRef]);
 
   useEffect(() => {
     if (orderId) {
@@ -401,7 +403,7 @@ export default function QuoteScreen() {
       setLoading(false);
       setError(t('quote.notFound'));
     }
-  }, [orderId, loadData]);
+  }, [orderId, navRef, loadData]);
 
   // Go to payment without approving first; order is confirmed only after successful payment
   const handleGoToPayment = () => {

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -46,7 +46,7 @@ function isImageContent(content: string): boolean {
 
 export default function ChatScreen() {
   const router = useRouter();
-  const { conversationId } = useLocalSearchParams<{ conversationId: string }>();
+  const { conversationId, navRef } = useLocalSearchParams<{ conversationId: string; navRef?: string }>();
   const { user } = useAuth();
   const { mode } = useMode();
   const themeColors = useThemeColors();
@@ -626,7 +626,7 @@ export default function ChatScreen() {
       sub.remove();
       stopPolling();
     };
-  }, [conversationId, loadConversation, loadMessages, refreshActiveQuote, refreshActiveOrder, router]);
+  }, [conversationId, navRef, loadConversation, loadMessages, refreshActiveQuote, refreshActiveOrder, router]);
 
   useEffect(() => {
     const showSub = Keyboard.addListener(Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow", (e) => {

--- a/app/notifications/[id].tsx
+++ b/app/notifications/[id].tsx
@@ -9,7 +9,7 @@ import {
   type NotificationType,
 } from '@/services/notifications';
 import { getLocalizedNotificationDisplay } from '@/utils/notificationDisplay';
-import { resolveNotificationRelatedHref } from '@/utils/notificationNavigation';
+import { resolveNotificationRelatedHref, withNotificationNavRefresh } from '@/utils/notificationNavigation';
 import { Ionicons } from '@expo/vector-icons';
 import type { Href } from 'expo-router';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -137,7 +137,8 @@ export default function NotificationDetailScreen() {
     try {
       const href = await resolveNotificationRelatedHref(notification, mode);
       if (href) {
-        router.push(href as Href);
+        const hrefWithBust = withNotificationNavRefresh(href);
+        router.replace(hrefWithBust as Href);
       } else {
         Alert.alert(t('common.error'), t('notifications.detail.noRelated'));
       }

--- a/app/orders/[orderId].tsx
+++ b/app/orders/[orderId].tsx
@@ -29,7 +29,7 @@ interface ProgressStep {
 
 export default function OrderDetailScreen() {
   const router = useRouter();
-  const { orderId } = useLocalSearchParams<{ orderId: string }>();
+  const { orderId, navRef } = useLocalSearchParams<{ orderId: string; navRef?: string }>();
   const insets = useSafeAreaInsets();
   const [loading, setLoading] = useState(true);
   const [orderDetail, setOrderDetail] = useState<OrderDetailResponse | null>(null);
@@ -37,10 +37,34 @@ export default function OrderDetailScreen() {
   const [cancelling, setCancelling] = useState(false);
 
   useEffect(() => {
-    if (orderId) {
-      loadOrderDetail();
-    }
-  }, [orderId]);
+    if (!orderId) return;
+
+    let cancelled = false;
+    setOrderDetail(null);
+    setLoading(true);
+
+    (async () => {
+      try {
+        const data = await fetchOrderDetail(orderId);
+        if (!cancelled) {
+          setOrderDetail(data);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('[OrderDetail] Failed to load order:', error);
+          Alert.alert(t('common.error'), t('errors.requestFailed'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orderId, navRef]);
 
   const loadOrderDetail = async () => {
     if (!orderId) return;

--- a/app/orders/rate/[orderId].tsx
+++ b/app/orders/rate/[orderId].tsx
@@ -43,7 +43,7 @@ function formatScheduledAt(scheduledAt: string | undefined): string {
 export default function RateExperienceScreen() {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const { orderId } = useLocalSearchParams<{ orderId: string }>();
+  const { orderId, navRef } = useLocalSearchParams<{ orderId: string; navRef?: string }>();
   const insets = useSafeAreaInsets();
   const bottomInset = insets.bottom || (Platform.OS === 'android' ? 40 : 0);
 
@@ -66,7 +66,7 @@ export default function RateExperienceScreen() {
     } finally {
       setLoading(false);
     }
-  }, [orderId]);
+  }, [orderId, navRef]);
 
   useEffect(() => {
     loadOrder();
@@ -108,10 +108,16 @@ export default function RateExperienceScreen() {
       const isAlreadyReviewed =
         err instanceof ApiError &&
         (err.statusCode === 409 || err.data?.code === 'already_reviewed');
+      const isOrderNotReady =
+        err instanceof ApiError &&
+        (err.statusCode === 400 || err.statusCode === 422) &&
+        err.data?.code === 'invalid_order_status';
       if (isAlreadyReviewed) {
         Alert.alert(t('common.success'), t('rating.alreadyReviewed'), [
           { text: t('common.ok'), onPress: () => router.push('/(tabs)/home') },
         ]);
+      } else if (isOrderNotReady) {
+        Alert.alert(t('common.error'), t('rating.errors.orderNotReady'));
       } else {
         Alert.alert(t('common.error'), t('errors.requestFailed'));
       }

--- a/components/profile/ProfileFooter.tsx
+++ b/components/profile/ProfileFooter.tsx
@@ -1,6 +1,5 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { t } from "@/i18n";
-import { useRouter } from "expo-router";
 import React from "react";
 import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
@@ -12,28 +11,17 @@ const PROFILE_VERSION_LABEL = "3.0.7";
  * Reused to avoid duplicating logic and ensure consistent layout and behavior.
  */
 export function ProfileFooter() {
-  const router = useRouter();
   const { logout } = useAuth();
 
   const handleLogout = () => {
     const performLogout = async () => {
       try {
         await logout();
-        setTimeout(() => {
-          try {
-            router.replace("/(auth)");
-          } catch {
-            router.replace("/(auth)/welcome");
-          }
-        }, 100);
+        // Navigation: (tabs)/(provider-tabs) layouts redirect to /(auth) when unauthenticated.
+        // Avoid router.replace here — it races unmount and triggers "navigate before Root Layout".
       } catch (error) {
         console.error("[ProfileFooter] Logout error:", error);
-        try {
-          router.replace("/(auth)");
-        } catch (navError) {
-          console.error("[ProfileFooter] Navigation error after logout failure:", navError);
-          Alert.alert(t("common.error"), t("profile.logoutError"));
-        }
+        Alert.alert(t("common.error"), t("profile.logoutError"));
       }
     };
 

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -764,6 +764,10 @@ export default {
     skip: "Skip",
     reviewSubmitted: "Thank you! Your review was sent.",
     alreadyReviewed: "You already reviewed this service. Thank you!",
+    errors: {
+      orderNotReady:
+        "You can submit your rating after the provider has marked the job as finished.",
+    },
   },
   profile: {
     title: "Profile",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -764,6 +764,10 @@ export default {
     skip: "Omitir",
     reviewSubmitted: "¡Gracias! Tu reseña fue enviada.",
     alreadyReviewed: "Ya calificaste este servicio. ¡Gracias!",
+    errors: {
+      orderNotReady:
+        "Podrás enviar tu calificación cuando el proveedor marque el trabajo como finalizado.",
+    },
   },
   profile: {
     title: "Perfil",

--- a/utils/notificationNavigation.ts
+++ b/utils/notificationNavigation.ts
@@ -2,29 +2,62 @@ import type { Notification } from '@/services/notifications';
 import { fetchOrderDetail } from '@/services/orders';
 import type { UserMode } from '@/contexts/ModeContext';
 
+/** API may send camelCase or snake_case; metadata may rarely arrive as a JSON string. */
+function coerceMetadata(notification: Notification): Record<string, unknown> {
+  const raw = notification.metadata;
+  if (raw == null) return {};
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+function metaOrderId(m: Record<string, unknown>): string | undefined {
+  const v = m.orderId ?? m.order_id;
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function metaConversationId(m: Record<string, unknown>): string | undefined {
+  const v = m.conversationId ?? m.conversation_id;
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
 function syncHrefForNotification(notification: Notification, mode: UserMode): string | null {
-  const metadata = notification.metadata || {};
+  const metadata = coerceMetadata(notification);
   const type = notification.type as string;
+  const orderId = metaOrderId(metadata);
+  const conversationId = metaConversationId(metadata);
 
   if (mode === 'client') {
     switch (notification.type) {
       case 'quote_received':
-        return metadata.orderId ? `/booking/quote/${metadata.orderId}` : null;
+        return orderId ? `/booking/quote/${orderId}` : null;
       case 'booking_confirmed':
       case 'booking_cancelled':
       case 'payment_processed':
+      case 'payment_received':
       case 'provider_on_way':
       case 'refund_issued':
-        return metadata.orderId ? `/orders/${metadata.orderId}` : null;
+        return orderId ? `/orders/${orderId}` : null;
       case 'new_message':
-        return metadata.conversationId ? `/chat/${metadata.conversationId}` : null;
+        return conversationId ? `/chat/${conversationId}` : null;
       case 'rate_service':
-        return metadata.orderId ? `/orders/rate/${metadata.orderId}` : null;
+        return orderId ? `/orders/rate/${orderId}` : null;
       case 'offer':
         return '/(tabs)/home';
       default:
         if (type === 'job_pending_review' || type === 'job_completed') {
-          return metadata.orderId ? `/orders/rate/${metadata.orderId}` : null;
+          return orderId ? `/orders/rate/${orderId}` : null;
         }
         return null;
     }
@@ -35,11 +68,11 @@ function syncHrefForNotification(notification: Notification, mode: UserMode): st
     case 'booking_cancelled':
     case 'provider_on_way':
     case 'quote_approved':
-      return metadata.orderId ? `/(provider-tabs)/jobs/${metadata.orderId}` : null;
+      return orderId ? `/(provider-tabs)/jobs/${orderId}` : null;
     case 'new_booking_request':
       return '/(provider-tabs)/requests';
     case 'new_message':
-      return metadata.conversationId ? `/chat/${metadata.conversationId}` : null;
+      return conversationId ? `/chat/${conversationId}` : null;
     case 'payment_processed':
     case 'payment_received':
     case 'refund_issued':
@@ -48,7 +81,7 @@ function syncHrefForNotification(notification: Notification, mode: UserMode): st
     case 'new_review':
       return '/(provider-tabs)/profile/reviews';
     case 'quote_received':
-      return metadata.orderId ? `/(provider-tabs)/jobs/${metadata.orderId}` : null;
+      return orderId ? `/(provider-tabs)/jobs/${orderId}` : null;
     case 'offer':
       return '/(provider-tabs)';
     default:
@@ -57,16 +90,34 @@ function syncHrefForNotification(notification: Notification, mode: UserMode): st
 }
 
 /**
+ * Appends a one-time query param so target screens remount/refetch when opening from a notification
+ * (avoids showing a stale instance of the same route).
+ */
+export function withNotificationNavRefresh(href: string): string {
+  const bustable =
+    href.includes('/orders/') ||
+    href.includes('/booking/') ||
+    href.includes('/chat/') ||
+    href.includes('/(provider-tabs)/jobs/');
+  if (!bustable) return href;
+  const sep = href.includes('?') ? '&' : '?';
+  return `${href}${sep}navRef=${Date.now()}`;
+}
+
+/**
  * Resolves a stack href for the content related to this notification (booking, chat, etc.).
  */
 export async function resolveNotificationRelatedHref(
   notification: Notification,
-  mode: UserMode
+  mode: UserMode,
 ): Promise<string | null> {
-  const metadata = notification.metadata || {};
-  if (notification.type === 'new_message' && !metadata.conversationId && metadata.orderId) {
+  const metadata = coerceMetadata(notification);
+  const orderId = metaOrderId(metadata);
+  const conversationId = metaConversationId(metadata);
+
+  if (notification.type === 'new_message' && !conversationId && orderId) {
     try {
-      const detail = await fetchOrderDetail(metadata.orderId);
+      const detail = await fetchOrderDetail(orderId);
       if (detail.conversation_id) {
         return `/chat/${detail.conversation_id}`;
       }


### PR DESCRIPTION
…gs refetch

- notificationNavigation: coerce metadata (object, JSON string, orderId/order_id, conversationId/conversation_id); route client payment_received like payment_processed; export withNotificationNavRefresh(navRef) for busting cached route instances.
- notifications/[id]: open related content with router.replace + navRef instead of push to avoid stacked stale screens.
- orders/[orderId]: clear state and refetch when orderId or navRef changes; cancel in-flight fetch on param change.
- bookings: replace mount-only useEffect with useFocusEffect to reload orders when returning to the tab.
- orders/rate, booking/quote, chat: depend on navRef so reopening from a notification reloads data.
- i18n: rating.errors.orderNotReady for API invalid_order_status (en/es).
- tabs ProfileFooter/layout: minor adjustments included in working tree.
