### PR TITLE
fix(maintenance): enforce global maintenance lock modal in mobile app

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,26 +1,25 @@
 import { DarkTheme, DefaultTheme, ThemeProvider as NavigationThemeProvider } from "@react-navigation/native";
-import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { ActivityIndicator, AppState, type AppStateStatus, Platform, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
-import { MaintenanceScreen } from "@/components/MaintenanceScreen";
+import { MaintenanceModal } from "@/components/MaintenanceModal";
 import { initializeGoogleSignIn } from "@/config/google-signin";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import { ModeProvider } from "@/contexts/ModeContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { ApiError } from "@/services/auth";
-import { fetchPlatformStatus } from "@/services/platformStatus";
+import { fetchPlatformStatus, PLATFORM_STATUS_QUERY_KEY } from "@/services/platformStatus";
+import { queryClient } from "@/services/queryClient";
 import { useEffect } from "react";
 
 
 export const unstable_settings = {
   anchor: "(auth)",
 };
-
-const queryClient = new QueryClient();
 
 function RootLayoutNav() {
   const { isLoading } = useAuth();
@@ -33,10 +32,10 @@ function RootLayoutNav() {
     refetch: refetchPlatformStatus,
     isFetching: platformStatusFetching,
   } = useQuery({
-    queryKey: ["platform-status"],
+    queryKey: PLATFORM_STATUS_QUERY_KEY,
     queryFn: fetchPlatformStatus,
-    staleTime: 30_000,
-    refetchInterval: 60_000,
+    staleTime: 15_000,
+    refetchInterval: 20_000,
     retry: 1,
   });
 
@@ -68,16 +67,15 @@ function RootLayoutNav() {
     );
   }
 
-  if (maintenanceOn) {
-    return (
-      <MaintenanceScreen onRetry={() => void refetchPlatformStatus()} isChecking={platformStatusFetching} />
-    );
-  }
-
   const statusBarBackgroundColor = colorScheme === "dark" ? "#1a1a2e" : "#F9FAFB";
 
   return (
     <NavigationThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+      <MaintenanceModal
+        visible={maintenanceOn}
+        onRetry={() => void refetchPlatformStatus()}
+        isChecking={platformStatusFetching}
+      />
       <Stack
         screenOptions={{
           headerShown: false,

--- a/components/MaintenanceModal.tsx
+++ b/components/MaintenanceModal.tsx
@@ -1,0 +1,28 @@
+import { MaintenanceScreen } from '@/components/MaintenanceScreen';
+import React from 'react';
+import { Modal, Platform } from 'react-native';
+
+interface MaintenanceModalProps {
+  visible: boolean;
+  onRetry: () => void;
+  isChecking?: boolean;
+}
+
+/**
+ * Full-screen modal so maintenance blocks all navigation while still mounting the app tree.
+ */
+export function MaintenanceModal({ visible, onRetry, isChecking = false }: MaintenanceModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      animationType="fade"
+      presentationStyle="fullScreen"
+      statusBarTranslucent={Platform.OS === 'android'}
+      onRequestClose={() => {
+        /* Intentionally empty: maintenance must not be dismissed with Android back. */
+      }}
+    >
+      <MaintenanceScreen onRetry={onRetry} isChecking={isChecking} />
+    </Modal>
+  );
+}

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -1,6 +1,8 @@
 import { Platform } from 'react-native';
 
 import { t } from '@/i18n';
+import { PLATFORM_STATUS_QUERY_KEY } from '@/services/platformStatus';
+import { queryClient } from '@/services/queryClient';
 import { API_BASE, getApiBaseUrl } from '@/utils/apiConfig';
 import { authEvents } from '@/utils/authEvents';
 
@@ -445,6 +447,10 @@ export const request = async <T>(
           const retryCode = typeof retryData === 'object' && retryData && 'code' in retryData
             ? String(retryData.code)
             : '';
+          if (retryResponse.status === 503 && retryCode === 'maintenance_mode') {
+            queryClient.setQueryData(PLATFORM_STATUS_QUERY_KEY, { maintenance_mode: true });
+            throw new ApiError(t('errors.maintenanceMode'), 503, retryData);
+          }
           const isRetryTokenExpired = retryMessage.includes('invalid') && 
             (retryMessage.includes('expired') || retryMessage.includes('token'));
           const isRetryAuthError = retryResponse.status === 401 || 
@@ -489,11 +495,9 @@ export const request = async <T>(
           ? String((responseData as { code: unknown }).code)
           : '';
       if (response.status === 503 && errCodeEarly === 'maintenance_mode') {
+        queryClient.setQueryData(PLATFORM_STATUS_QUERY_KEY, { maintenance_mode: true });
         throw new ApiError(t('errors.maintenanceMode'), 503, responseData);
       }
-      // #region agent log
-      if (path.includes('validate-email')) fetch('http://127.0.0.1:7242/ingest/0bf175bf-b05a-422e-87c8-7c4bfaecaeeb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'auth.ts:request',message:'response not ok',data:{path,status:response.status,code:(responseData as {code?:string})?.code},timestamp:Date.now(),hypothesisId:'H2',runId:'validate-email'})}).catch(()=>{});
-      // #endregion
       const rawMessage = typeof responseData === 'object' && responseData && 'message' in responseData
         ? (responseData as { message: unknown }).message
         : undefined;
@@ -733,10 +737,6 @@ export const validateEmail = async (
     email: payload.email.trim().toLowerCase(),
     password: payload.password.trim(), // Ensure password is trimmed
   };
-  // #region agent log
-  fetch('http://127.0.0.1:7242/ingest/0bf175bf-b05a-422e-87c8-7c4bfaecaeeb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'auth.ts:validateEmail',message:'validateEmail called',data:{email:body.email,path:'/auth/validate-email'},timestamp:Date.now(),hypothesisId:'H1',runId:'validate-email'})}).catch(()=>{});
-  // #endregion
-
   return request<ValidateEmailResponse>(
     '/auth/validate-email',
     {

--- a/services/platformStatus.ts
+++ b/services/platformStatus.ts
@@ -4,23 +4,77 @@ export interface PlatformStatusResponse {
   maintenance_mode: boolean;
 }
 
+export const PLATFORM_STATUS_QUERY_KEY = ['platform-status'] as const;
+
+function coerceMaintenanceBoolean(value: unknown): boolean {
+  if (value === true || value === false) {
+    return value;
+  }
+  if (value === 1 || value === 0) {
+    return value === 1;
+  }
+  if (value === 'true' || value === 'false') {
+    return value === 'true';
+  }
+  return false;
+}
+
+function parsePlatformStatusPayload(data: unknown): PlatformStatusResponse | null {
+  if (typeof data !== 'object' || data === null) {
+    return null;
+  }
+  const record = data as Record<string, unknown>;
+  if ('maintenance_mode' in record) {
+    return { maintenance_mode: coerceMaintenanceBoolean(record.maintenance_mode) };
+  }
+  if ('maintenanceMode' in record) {
+    return { maintenance_mode: coerceMaintenanceBoolean(record.maintenanceMode) };
+  }
+  if ('data' in record) {
+    return parsePlatformStatusPayload(record.data);
+  }
+  return null;
+}
+
+function isMaintenance503Payload(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  return String((data as { code?: unknown }).code) === 'maintenance_mode';
+}
+
 /**
  * Public endpoint: no auth. Used to show maintenance UI before login.
  */
 export async function fetchPlatformStatus(): Promise<PlatformStatusResponse> {
   const url = `${API_BASE}/api/platform/status`;
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: { Accept: 'application/json' },
-  });
-  if (!response.ok) {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+  } catch {
     throw new Error('platform_status_failed');
   }
-  const data = (await response.json()) as unknown;
-  if (typeof data !== 'object' || data === null || !('maintenance_mode' in data)) {
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
     throw new Error('platform_status_invalid');
   }
-  return {
-    maintenance_mode: Boolean((data as { maintenance_mode: unknown }).maintenance_mode),
-  };
+
+  if (!response.ok) {
+    if (response.status === 503 && isMaintenance503Payload(raw)) {
+      return { maintenance_mode: true };
+    }
+    throw new Error('platform_status_failed');
+  }
+
+  const parsed = parsePlatformStatusPayload(raw);
+  if (!parsed) {
+    throw new Error('platform_status_invalid');
+  }
+  return parsed;
 }

--- a/services/queryClient.ts
+++ b/services/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();


### PR DESCRIPTION
Ensure maintenance mode from backoffice reliably blocks app usage by showing a full-screen modal, syncing React Query maintenance state when API returns 503 maintenance_mode, and hardening platform status parsing for resilient payload formats.
