### PR TITLE
fix(ui): light theme tokens and switch-mode contrast (MDB-391)

### DIFF
--- a/app/(provider-tabs)/jobs/complete.tsx
+++ b/app/(provider-tabs)/jobs/complete.tsx
@@ -287,9 +287,9 @@ export default function CompleteJobScreen() {
   if (!data) {
     return (
       <View style={[styles.container, styles.centered, { paddingTop: insets.top, backgroundColor: colors.background }]}>
-        <Text style={styles.errorText}>{t("providerDashboard.completeJob.errors.loadFailed")}</Text>
-        <TouchableOpacity style={styles.backBtn} onPress={goBack} activeOpacity={0.7}>
-          <Ionicons name="arrow-back" size={20} color="rgba(255,255,255,0.6)" />
+        <Text style={[styles.errorText, { color: colors.textSecondary }]}>{t("providerDashboard.completeJob.errors.loadFailed")}</Text>
+        <TouchableOpacity style={[styles.backBtn, { backgroundColor: colors.surfaceSecondary }]} onPress={goBack} activeOpacity={0.7}>
+          <Ionicons name="arrow-back" size={20} color={colors.icon} />
         </TouchableOpacity>
       </View>
     );
@@ -299,15 +299,15 @@ export default function CompleteJobScreen() {
     return (
       <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
         <View style={styles.header}>
-          <TouchableOpacity style={styles.backBtn} onPress={goBack} activeOpacity={0.7}>
-            <Ionicons name="arrow-back" size={24} color="rgba(255,255,255,0.6)" />
+          <TouchableOpacity style={[styles.backBtn, { backgroundColor: colors.surfaceSecondary }]} onPress={goBack} activeOpacity={0.7}>
+            <Ionicons name="arrow-back" size={24} color={colors.icon} />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{t("providerDashboard.completeJob.title")}</Text>
+          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("providerDashboard.completeJob.title")}</Text>
         </View>
         <View style={[styles.centered, styles.flexGrow]}>
           <View style={styles.successCard}>
             <Ionicons name="checkmark-circle" size={48} color={GREEN} style={styles.successIcon} />
-            <Text style={styles.successTitle}>{t("providerDashboard.completeJob.alreadyCompleted")}</Text>
+            <Text style={[styles.successTitle, { color: colors.textPrimary }]}>{t("providerDashboard.completeJob.alreadyCompleted")}</Text>
           </View>
           <TouchableOpacity
             style={styles.submitBtn}
@@ -333,16 +333,16 @@ export default function CompleteJobScreen() {
     return (
       <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
         <View style={styles.header}>
-          <TouchableOpacity style={styles.backBtn} onPress={goBack} activeOpacity={0.7}>
-            <Ionicons name="arrow-back" size={24} color="rgba(255,255,255,0.6)" />
+          <TouchableOpacity style={[styles.backBtn, { backgroundColor: colors.surfaceSecondary }]} onPress={goBack} activeOpacity={0.7}>
+            <Ionicons name="arrow-back" size={24} color={colors.icon} />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{t("providerDashboard.completeJob.title")}</Text>
+          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("providerDashboard.completeJob.title")}</Text>
         </View>
         <View style={[styles.centered, styles.flexGrow]}>
           <View style={styles.successCard}>
             <Ionicons name="play-circle" size={48} color={PURPLE_END} style={styles.successIcon} />
-            <Text style={styles.successTitle}>{t("providerDashboard.completeJob.startJobFirst")}</Text>
-            <Text style={styles.successSubtitle}>{t("providerDashboard.completeJob.startJobFirstDesc")}</Text>
+            <Text style={[styles.successTitle, { color: colors.textPrimary }]}>{t("providerDashboard.completeJob.startJobFirst")}</Text>
+            <Text style={[styles.successSubtitle, { color: colors.textSecondary }]}>{t("providerDashboard.completeJob.startJobFirstDesc")}</Text>
           </View>
           <TouchableOpacity
             style={styles.submitBtn}
@@ -362,10 +362,10 @@ export default function CompleteJobScreen() {
     <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
       {/* Header */}
       <View style={styles.header}>
-        <TouchableOpacity style={styles.backBtn} onPress={goBack} activeOpacity={0.7}>
-          <Ionicons name="arrow-back" size={24} color="rgba(255,255,255,0.6)" />
+        <TouchableOpacity style={[styles.backBtn, { backgroundColor: colors.surfaceSecondary }]} onPress={goBack} activeOpacity={0.7}>
+          <Ionicons name="arrow-back" size={24} color={colors.icon} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>{t("providerDashboard.completeJob.title")}</Text>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("providerDashboard.completeJob.title")}</Text>
       </View>
 
       <ScrollView
@@ -377,14 +377,14 @@ export default function CompleteJobScreen() {
         {/* Success Card */}
         <View style={styles.successCard}>
           <Ionicons name="checkmark-circle" size={48} color={GREEN} style={styles.successIcon} />
-          <Text style={styles.successTitle}>{t("providerDashboard.completeJob.jobCompleted")}</Text>
-          <Text style={styles.successDuration}>
+          <Text style={[styles.successTitle, { color: colors.textPrimary }]}>{t("providerDashboard.completeJob.jobCompleted")}</Text>
+          <Text style={[styles.successDuration, { color: colors.textSecondary }]}>
             {t("providerDashboard.completeJob.totalDuration", { duration: durationLabel })}
           </Text>
         </View>
 
         {/* Work Photos Section */}
-        <Text style={styles.sectionLabel}>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
           {t("providerDashboard.completeJob.workPhotos")}
         </Text>
         <View style={styles.photosGrid}>
@@ -411,14 +411,18 @@ export default function CompleteJobScreen() {
             </>
           )}
           {photos.length < 10 && (
-            <TouchableOpacity style={styles.addPhotoBtn} onPress={handlePhotoAction} activeOpacity={0.7}>
-              <Ionicons name="add" size={28} color="rgba(255,255,255,0.3)" />
+            <TouchableOpacity
+              style={[styles.addPhotoBtn, { borderColor: colors.border, backgroundColor: colors.surfaceSecondary }]}
+              onPress={handlePhotoAction}
+              activeOpacity={0.7}
+            >
+              <Ionicons name="add" size={28} color={colors.iconSecondary} />
             </TouchableOpacity>
           )}
         </View>
 
         {/* Work Summary */}
-        <Text style={styles.sectionLabel}>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
           {t("providerDashboard.completeJob.workSummary")}
         </Text>
         <TextInput
@@ -433,7 +437,7 @@ export default function CompleteJobScreen() {
         />
 
         {/* Final Breakdown */}
-        <Text style={styles.sectionLabel}>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
           {t("providerDashboard.completeJob.finalBreakdown")}
         </Text>
         <BreakdownCard
@@ -460,8 +464,8 @@ export default function CompleteJobScreen() {
             </Text>
           )}
         </TouchableOpacity>
-        <TouchableOpacity style={styles.cashBtn} activeOpacity={0.7}>
-          <Text style={styles.cashBtnText}>
+        <TouchableOpacity style={[styles.cashBtn, { backgroundColor: colors.surfaceSecondary }]} activeOpacity={0.7}>
+          <Text style={[styles.cashBtnText, { color: colors.primary }]}>
             {t("providerDashboard.completeJob.requestCashPayment")}
           </Text>
         </TouchableOpacity>
@@ -490,7 +494,7 @@ const BreakdownCard = React.memo(function BreakdownCard({
         {lineItems.map((item, idx) => (
           <View key={`item-${idx}`} style={styles.breakdownRow}>
             <View style={styles.breakdownLabelRow}>
-              <Text style={styles.breakdownItemName}>{item.description}</Text>
+              <Text style={[styles.breakdownItemName, { color: colors.textSecondary }]}>{item.description}</Text>
               {item.isExtra && (
                 <View style={styles.extraBadge}>
                   <Text style={styles.extraBadgeText}>
@@ -499,24 +503,24 @@ const BreakdownCard = React.memo(function BreakdownCard({
                 </View>
               )}
             </View>
-            <Text style={styles.breakdownItemPrice}>{formatCurrency(item.amount)}</Text>
+            <Text style={[styles.breakdownItemPrice, { color: colors.textPrimary }]}>{formatCurrency(item.amount)}</Text>
           </View>
         ))}
       </View>
 
-      <View style={styles.breakdownDivider} />
+      <View style={[styles.breakdownDivider, { backgroundColor: colors.border }]} />
 
       <View style={styles.breakdownRow}>
-        <Text style={styles.breakdownSubLabel}>
+        <Text style={[styles.breakdownSubLabel, { color: colors.textSecondary }]}>
           {t("providerDashboard.completeJob.subtotal")}
         </Text>
-        <Text style={styles.breakdownSubValue}>{formatCurrency(subtotal)}</Text>
+        <Text style={[styles.breakdownSubValue, { color: colors.textPrimary }]}>{formatCurrency(subtotal)}</Text>
       </View>
 
       {discount && discount.amount > 0 && (
         <View style={styles.breakdownRow}>
           <View style={styles.breakdownLabelRow}>
-            <Text style={styles.breakdownSubLabel}>
+            <Text style={[styles.breakdownSubLabel, { color: colors.textSecondary }]}>
               {t("providerDashboard.completeJob.discount")}
             </Text>
             <View style={styles.discountBadge}>
@@ -529,10 +533,10 @@ const BreakdownCard = React.memo(function BreakdownCard({
         </View>
       )}
 
-      <View style={styles.totalDivider} />
+      <View style={[styles.totalDivider, { backgroundColor: colors.border }]} />
 
       <View style={styles.breakdownRow}>
-        <Text style={styles.totalLabel}>
+        <Text style={[styles.totalLabel, { color: colors.textPrimary }]}>
           {t("providerDashboard.completeJob.total")}
         </Text>
         <Text style={styles.totalValue}>{formatCurrency(total)}</Text>

--- a/app/(provider-tabs)/jobs/in-progress.tsx
+++ b/app/(provider-tabs)/jobs/in-progress.tsx
@@ -1,3 +1,4 @@
+import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import {
@@ -56,7 +57,7 @@ function formatElapsedTime(seconds: number): string {
   return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 }
 
-function PulseDot() {
+function PulseDot({ isLight }: { isLight?: boolean }) {
   const opacity = useRef(new RNAnimated.Value(0.6)).current;
   useEffect(() => {
     const anim = RNAnimated.loop(
@@ -68,14 +69,23 @@ function PulseDot() {
     anim.start();
     return () => anim.stop();
   }, [opacity]);
-  return <RNAnimated.View style={[styles.pulseDotBase, { opacity }]} />;
+  return (
+    <RNAnimated.View
+      style={[
+        styles.pulseDotBase,
+        { backgroundColor: isLight ? "#7C3AED" : PURPLE_TEXT, opacity },
+      ]}
+    />
+  );
 }
 
 export default function InProgressScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme();
   const colors = useThemeColors();
+  const isLight = colorScheme === "light";
 
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<JobInProgressData | null>(null);
@@ -283,9 +293,9 @@ export default function InProgressScreen() {
   if (!data) {
     return (
       <View style={[styles.container, styles.centered, { paddingTop: insets.top, backgroundColor: colors.background }]}>
-        <Text style={styles.errorText}>{t("providerDashboard.inProgress.errors.loadFailed")}</Text>
-        <TouchableOpacity style={styles.backBtn} onPress={goBack} activeOpacity={0.7}>
-          <Ionicons name="arrow-back" size={20} color="rgba(255,255,255,0.6)" />
+        <Text style={[styles.errorText, { color: colors.textSecondary }]}>{t("providerDashboard.inProgress.errors.loadFailed")}</Text>
+        <TouchableOpacity style={[styles.backBtn, { backgroundColor: colors.surfaceSecondary }]} onPress={goBack} activeOpacity={0.7}>
+          <Ionicons name="arrow-back" size={20} color={colors.icon} />
         </TouchableOpacity>
       </View>
     );
@@ -294,15 +304,25 @@ export default function InProgressScreen() {
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom, backgroundColor: colors.background }]}>
       {/* Status Banner */}
-      <View style={[styles.banner, { paddingTop: insets.top + 24 }]}>
+      <View
+        style={[
+          styles.banner,
+          { paddingTop: insets.top + 24 },
+          isLight ? { backgroundColor: "rgba(139, 92, 246, 0.12)" } : null,
+        ]}
+      >
         <View style={styles.bannerStatusRow}>
-          <PulseDot />
-          <Text style={styles.bannerStatusText}>{t("providerDashboard.inProgress.title")}</Text>
+          <PulseDot isLight={isLight} />
+          <Text style={[styles.bannerStatusText, { color: isLight ? "#5B21B6" : PURPLE_TEXT }]}>
+            {t("providerDashboard.inProgress.title")}
+          </Text>
         </View>
         <View style={styles.bannerTimerRow}>
           <View>
-            <Text style={styles.bannerElapsedLabel}>{t("providerDashboard.inProgress.elapsedTime")}</Text>
-            <Text style={styles.bannerTimer}>{formatElapsedTime(elapsedSeconds)}</Text>
+            <Text style={[styles.bannerElapsedLabel, { color: colors.textSecondary }]}>
+              {t("providerDashboard.inProgress.elapsedTime")}
+            </Text>
+            <Text style={[styles.bannerTimer, { color: colors.textPrimary }]}>{formatElapsedTime(elapsedSeconds)}</Text>
           </View>
           <View style={styles.timerCircle}>
             <Text style={styles.timerEmoji}>⏱️</Text>
@@ -310,10 +330,12 @@ export default function InProgressScreen() {
         </View>
         <View style={styles.progressSection}>
           <View style={styles.progressLabelRow}>
-            <Text style={styles.progressLabel}>{t("providerDashboard.inProgress.estimatedProgress")}</Text>
-            <Text style={styles.progressLabel}>{displayProgress}%</Text>
+            <Text style={[styles.progressLabel, { color: colors.textSecondary }]}>
+              {t("providerDashboard.inProgress.estimatedProgress")}
+            </Text>
+            <Text style={[styles.progressLabel, { color: colors.textSecondary }]}>{displayProgress}%</Text>
           </View>
-          <View style={styles.progressBarBg}>
+          <View style={[styles.progressBarBg, { backgroundColor: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.1)" }]}>
             <LinearGradient
               colors={[PURPLE_GRADIENT_START, PURPLE_GRADIENT_END]}
               start={{ x: 0, y: 0 }}
@@ -328,11 +350,11 @@ export default function InProgressScreen() {
         {/* Client Info */}
         <View style={[styles.clientCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
           <View style={styles.clientAvatar}>
-            <Ionicons name="person" size={24} color="rgba(255,255,255,0.6)" />
+            <Ionicons name="person" size={24} color={colors.icon} />
           </View>
           <View style={styles.clientInfo}>
-            <Text style={styles.clientName}>{data.client.fullName}</Text>
-            <Text style={styles.clientService}>{data.order.serviceName}</Text>
+            <Text style={[styles.clientName, { color: colors.textPrimary }]}>{data.client.fullName}</Text>
+            <Text style={[styles.clientService, { color: colors.textSecondary }]}>{data.order.serviceName}</Text>
           </View>
           <TouchableOpacity
             style={styles.actionIconBtn}
@@ -352,13 +374,14 @@ export default function InProgressScreen() {
         </View>
 
         {/* Task Checklist */}
-        <Text style={styles.sectionLabel}>{t("providerDashboard.inProgress.taskList")}</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>{t("providerDashboard.inProgress.taskList")}</Text>
         <View style={styles.taskList}>
           {tasks.map((task) => (
             <TouchableOpacity
               key={task.id}
               style={[
                 styles.taskItem,
+                { backgroundColor: colors.card, borderColor: colors.cardBorder },
                 task.status === "in_progress" && styles.taskItemActive,
               ]}
               onPress={() => handleToggleTask(task)}
@@ -380,8 +403,9 @@ export default function InProgressScreen() {
               <Text
                 style={[
                   styles.taskText,
-                  task.status === "completed" && styles.taskTextCompleted,
-                  task.status === "in_progress" && styles.taskTextActive,
+                  { color: colors.textSecondary },
+                  task.status === "completed" && [styles.taskTextCompleted, { color: colors.textTertiary }],
+                  task.status === "in_progress" && [styles.taskTextActive, { color: colors.textPrimary }],
                 ]}
               >
                 {task.description}
@@ -396,33 +420,49 @@ export default function InProgressScreen() {
         </View>
 
         {/* Quick Actions */}
-        <Text style={styles.sectionLabel}>{t("providerDashboard.inProgress.quickActions")}</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>{t("providerDashboard.inProgress.quickActions")}</Text>
         <View style={styles.quickActionsGrid}>
-          <TouchableOpacity style={styles.quickActionBtn} onPress={handleTakePhoto} activeOpacity={0.7}>
+          <TouchableOpacity
+            style={[styles.quickActionBtn, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+            onPress={handleTakePhoto}
+            activeOpacity={0.7}
+          >
             <Text style={styles.quickActionIcon}>📷</Text>
             <View style={styles.quickActionLabelWrap}>
-              <Text style={styles.quickActionLabel}>{t("providerDashboard.inProgress.takePhoto")}</Text>
+              <Text style={[styles.quickActionLabel, { color: colors.textPrimary }]}>{t("providerDashboard.inProgress.takePhoto")}</Text>
               {sessionPhotoCount > 0 && (
                 <Text style={styles.quickActionBadge}>{sessionPhotoCount}</Text>
               )}
             </View>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.quickActionBtn} onPress={handleAddNote} activeOpacity={0.7}>
+          <TouchableOpacity
+            style={[styles.quickActionBtn, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+            onPress={handleAddNote}
+            activeOpacity={0.7}
+          >
             <Text style={styles.quickActionIcon}>📝</Text>
             <View style={styles.quickActionLabelWrap}>
-              <Text style={styles.quickActionLabel}>{t("providerDashboard.inProgress.addNote")}</Text>
+              <Text style={[styles.quickActionLabel, { color: colors.textPrimary }]}>{t("providerDashboard.inProgress.addNote")}</Text>
               {sessionNoteCount > 0 && (
                 <Text style={styles.quickActionBadge}>{sessionNoteCount}</Text>
               )}
             </View>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.quickActionBtn} onPress={handleExtraCharge} activeOpacity={0.7}>
+          <TouchableOpacity
+            style={[styles.quickActionBtn, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+            onPress={handleExtraCharge}
+            activeOpacity={0.7}
+          >
             <Text style={styles.quickActionIcon}>💰</Text>
-            <Text style={styles.quickActionLabel}>{t("providerDashboard.inProgress.extraCharge")}</Text>
+            <Text style={[styles.quickActionLabel, { color: colors.textPrimary }]}>{t("providerDashboard.inProgress.extraCharge")}</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.quickActionBtn} onPress={handleExtendTime} activeOpacity={0.7}>
+          <TouchableOpacity
+            style={[styles.quickActionBtn, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+            onPress={handleExtendTime}
+            activeOpacity={0.7}
+          >
             <Text style={styles.quickActionIcon}>⏰</Text>
-            <Text style={styles.quickActionLabel}>{t("providerDashboard.inProgress.extendTime")}</Text>
+            <Text style={[styles.quickActionLabel, { color: colors.textPrimary }]}>{t("providerDashboard.inProgress.extendTime")}</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -431,19 +471,30 @@ export default function InProgressScreen() {
       <Modal visible={noteModalVisible} transparent animationType="fade">
         <View style={styles.modalOverlay}>
           <View style={[styles.modalCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-            <Text style={styles.modalTitle}>{t("providerDashboard.inProgress.addNote")}</Text>
+            <Text style={[styles.modalTitle, { color: colors.textPrimary }]}>{t("providerDashboard.inProgress.addNote")}</Text>
             <TextInput
-              style={styles.modalInput}
+              style={[
+                styles.modalInput,
+                {
+                  color: colors.textPrimary,
+                  backgroundColor: colors.surfaceSecondary,
+                  borderColor: colors.border,
+                },
+              ]}
               placeholder={t("providerDashboard.inProgress.notePlaceholder")}
-              placeholderTextColor="rgba(255,255,255,0.4)"
+              placeholderTextColor={colors.textTertiary}
               value={noteText}
               onChangeText={setNoteText}
               multiline
               numberOfLines={3}
             />
             <View style={styles.modalActions}>
-              <TouchableOpacity style={styles.modalBtnSecondary} onPress={() => { setNoteModalVisible(false); setNoteText(""); }} activeOpacity={0.7}>
-                <Text style={styles.modalBtnSecondaryText}>{t("common.cancel")}</Text>
+              <TouchableOpacity
+                style={[styles.modalBtnSecondary, { backgroundColor: colors.surfaceSecondary }]}
+                onPress={() => { setNoteModalVisible(false); setNoteText(""); }}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.modalBtnSecondaryText, { color: colors.textSecondary }]}>{t("common.cancel")}</Text>
               </TouchableOpacity>
               <TouchableOpacity style={styles.modalBtnPrimary} onPress={handleSaveNote} activeOpacity={0.7}>
                 <Text style={styles.modalBtnPrimaryText}>{t("common.save")}</Text>
@@ -457,8 +508,8 @@ export default function InProgressScreen() {
       <Modal visible={extraChargeModalVisible} transparent animationType="fade">
         <View style={styles.modalOverlay}>
           <View style={[styles.modalCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-            <Text style={styles.modalTitle}>{t("providerDashboard.inProgress.extraCharge")}</Text>
-            <Text style={styles.modalPlaceholderText}>{t("providerDashboard.inProgress.comingSoon")}</Text>
+            <Text style={[styles.modalTitle, { color: colors.textPrimary }]}>{t("providerDashboard.inProgress.extraCharge")}</Text>
+            <Text style={[styles.modalPlaceholderText, { color: colors.textSecondary }]}>{t("providerDashboard.inProgress.comingSoon")}</Text>
             <TouchableOpacity style={styles.modalBtnPrimary} onPress={() => setExtraChargeModalVisible(false)} activeOpacity={0.7}>
               <Text style={styles.modalBtnPrimaryText}>{t("common.ok")}</Text>
             </TouchableOpacity>
@@ -470,8 +521,8 @@ export default function InProgressScreen() {
       <Modal visible={extendTimeModalVisible} transparent animationType="fade">
         <View style={styles.modalOverlay}>
           <View style={[styles.modalCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-            <Text style={styles.modalTitle}>{t("providerDashboard.inProgress.extendTime")}</Text>
-            <Text style={styles.modalPlaceholderText}>{t("providerDashboard.inProgress.comingSoon")}</Text>
+            <Text style={[styles.modalTitle, { color: colors.textPrimary }]}>{t("providerDashboard.inProgress.extendTime")}</Text>
+            <Text style={[styles.modalPlaceholderText, { color: colors.textSecondary }]}>{t("providerDashboard.inProgress.comingSoon")}</Text>
             <TouchableOpacity style={styles.modalBtnPrimary} onPress={() => setExtendTimeModalVisible(false)} activeOpacity={0.7}>
               <Text style={styles.modalBtnPrimaryText}>{t("common.ok")}</Text>
             </TouchableOpacity>
@@ -527,7 +578,6 @@ const styles = StyleSheet.create({
     width: 12,
     height: 12,
     borderRadius: 6,
-    backgroundColor: PURPLE_TEXT,
   },
   pulseDot: {
     width: 12,

--- a/app/(provider-tabs)/messages.tsx
+++ b/app/(provider-tabs)/messages.tsx
@@ -12,7 +12,6 @@ import {
   ActivityIndicator,
   Alert,
   FlatList,
-  Image,
   Modal,
   Platform,
   RefreshControl,
@@ -23,12 +22,8 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { ThemeColors } from '@/utils/themeStyles';
 
-const UNREAD_BG = 'rgba(139, 92, 246, 0.1)';
-const UNREAD_BORDER = 'rgba(139, 92, 246, 0.3)';
-const AVATAR_BG = 'rgba(61, 51, 112, 0.5)';
-const FILTER_ACTIVE_BG = 'rgba(99, 102, 241, 0.9)';
-const FILTER_INACTIVE_BG = 'rgba(255,255,255,0.05)';
 const PURPLE_GRADIENT = ['#6366F1', '#8B5CF6'];
 const STATUS_COLORS: Record<string, string> = {
   in_progress: '#8B5CF6',
@@ -79,6 +74,299 @@ function formatTime(dateString: string | null): string {
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
+function createProviderInboxStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: c.screenBackground,
+    },
+    header: {
+      paddingHorizontal: 20,
+      paddingBottom: 16,
+    },
+    headerRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 16,
+    },
+    headerTitle: {
+      fontSize: 20,
+      fontWeight: '700',
+      color: c.textPrimary,
+    },
+    iconButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 12,
+      backgroundColor: c.surfaceSecondary,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 1,
+      borderColor: c.cardBorder,
+    },
+    searchWrap: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      height: 44,
+      paddingHorizontal: 12,
+      borderRadius: 12,
+      backgroundColor: c.surfaceSecondary,
+      marginBottom: 12,
+      borderWidth: 1,
+      borderColor: c.cardBorder,
+    },
+    searchInput: {
+      flex: 1,
+      fontSize: 14,
+      color: c.textPrimary,
+      paddingVertical: 0,
+    },
+    filters: {
+      flexDirection: 'row',
+      gap: 8,
+    },
+    filterPill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 999,
+      backgroundColor: c.surfaceSecondary,
+      borderWidth: 1,
+      borderColor: c.cardBorder,
+    },
+    filterPillActive: {
+      backgroundColor: c.primary,
+      borderColor: c.primary,
+    },
+    filterLabel: {
+      fontSize: 12,
+      fontWeight: '500',
+      color: c.textSecondary,
+    },
+    filterLabelActive: {
+      color: '#FFFFFF',
+    },
+    filterCount: {
+      paddingHorizontal: 6,
+      paddingVertical: 2,
+      borderRadius: 999,
+      backgroundColor: c.border,
+    },
+    filterCountActive: {
+      backgroundColor: 'rgba(255,255,255,0.25)',
+    },
+    filterCountText: {
+      fontSize: 10,
+      color: c.textSecondary,
+    },
+    filterCountTextActive: {
+      color: '#FFFFFF',
+    },
+    listContent: {
+      paddingHorizontal: 20,
+      paddingTop: 8,
+    },
+    card: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      padding: 12,
+      borderRadius: 12,
+      borderWidth: 1,
+      marginBottom: 8,
+    },
+    cardTouchable: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+    },
+    menuButton: {
+      padding: 8,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    cardUnread: {},
+    cardLast: {
+      marginBottom: 0,
+    },
+    avatarWrap: {
+      position: 'relative',
+    },
+    avatar: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+    },
+    avatarPlaceholder: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+      backgroundColor: c.surfaceSecondary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    avatarEmoji: {
+      fontSize: 20,
+    },
+    onlineIndicator: {
+      position: 'absolute',
+      bottom: 0,
+      right: 0,
+      width: 14,
+      height: 14,
+      borderRadius: 7,
+      backgroundColor: '#22C55E',
+      borderWidth: 2,
+    },
+    content: {
+      flex: 1,
+      minWidth: 0,
+    },
+    row1: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 2,
+    },
+    name: {
+      fontSize: 14,
+      fontWeight: '500',
+      flex: 1,
+      color: c.textPrimary,
+    },
+    nameUnread: {},
+    time: {
+      fontSize: 12,
+      color: c.textTertiary,
+    },
+    timeUnread: {
+      color: c.primary,
+    },
+    row2: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    preview: {
+      fontSize: 12,
+      flex: 1,
+      marginRight: 8,
+      color: c.textSecondary,
+    },
+    previewUnread: {
+      color: c.textPrimary,
+      fontWeight: '500',
+    },
+    badges: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    statusBadge: {
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      borderRadius: 999,
+    },
+    statusText: {
+      fontSize: 10,
+      fontWeight: '500',
+    },
+    unreadBadge: {
+      minWidth: 20,
+      height: 20,
+      borderRadius: 10,
+      backgroundColor: c.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: 4,
+    },
+    unreadText: {
+      fontSize: 10,
+      fontWeight: '700',
+      color: '#FFFFFF',
+    },
+    center: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    emptyTitle: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: c.textPrimary,
+      marginTop: 16,
+    },
+    emptySubtitle: {
+      fontSize: 14,
+      color: c.textSecondary,
+      textAlign: 'center',
+      marginTop: 8,
+      paddingHorizontal: 24,
+    },
+    errorText: {
+      fontSize: 16,
+      color: '#EF4444',
+      textAlign: 'center',
+      marginBottom: 16,
+    },
+    retryButton: {
+      backgroundColor: c.primary,
+      paddingHorizontal: 24,
+      paddingVertical: 12,
+      borderRadius: 8,
+    },
+    retryText: {
+      color: '#FFFFFF',
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    optionsOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 24,
+    },
+    optionsBox: {
+      borderRadius: 12,
+      paddingVertical: 8,
+      minWidth: 220,
+      borderWidth: 1,
+      backgroundColor: c.card,
+      borderColor: c.cardBorder,
+    },
+    optionsTitle: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: c.textPrimary,
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+    },
+    optionsButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      paddingHorizontal: 16,
+      paddingVertical: 14,
+    },
+    optionsButtonText: {
+      fontSize: 16,
+      color: c.textSecondary,
+    },
+    optionsButtonTextDestructive: {
+      fontSize: 16,
+      color: '#EF4444',
+      fontWeight: '500',
+    },
+  });
+}
+
 function getStatusLabel(statusKey: string): string {
   switch (statusKey) {
     case 'in_progress':
@@ -101,6 +389,7 @@ export default function ProviderInboxScreen() {
   const { user } = useAuth();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const styles = useMemo(() => createProviderInboxStyles(colors), [colors]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -134,7 +423,7 @@ export default function ProviderInboxScreen() {
         return new Date(b.last_message_at).getTime() - new Date(a.last_message_at).getTime();
       });
       setConversations(sorted);
-    } catch (err) {
+    } catch {
       setError(t('providerDashboard.inbox.failedToLoad'));
     } finally {
       setLoading(false);
@@ -284,8 +573,8 @@ export default function ProviderInboxScreen() {
       const statusLabel = statusKey ? getStatusLabel(statusKey) : '';
       const isOnline = false; // TODO: from backend when available
       const cardStyle = {
-        backgroundColor: unread ? UNREAD_BG : colors.card,
-        borderColor: unread ? UNREAD_BORDER : colors.cardBorder,
+        backgroundColor: unread ? `${colors.primary}14` : colors.card,
+        borderColor: unread ? `${colors.primary}38` : colors.cardBorder,
       };
 
       return (
@@ -314,18 +603,15 @@ export default function ProviderInboxScreen() {
             </View>
             <View style={styles.content}>
               <View style={styles.row1}>
-                <Text style={[styles.name, unread && styles.nameUnread, { color: colors.textPrimary }]} numberOfLines={1}>
+                <Text style={[styles.name, unread && styles.nameUnread]} numberOfLines={1}>
                   {item.other_user_name}
                 </Text>
-                <Text style={[styles.time, unread && styles.timeUnread, { color: colors.textTertiary }]}>
+                <Text style={[styles.time, unread && styles.timeUnread]}>
                   {formatTime(item.last_message_at)}
                 </Text>
               </View>
               <View style={styles.row2}>
-                <Text
-                  style={[styles.preview, unread && styles.previewUnread, { color: colors.textSecondary }]}
-                  numberOfLines={1}
-                >
+                <Text style={[styles.preview, unread && styles.previewUnread]} numberOfLines={1}>
                   {item.last_message || t('chat.noMessages')}
                 </Text>
                 <View style={styles.badges}>
@@ -356,14 +642,21 @@ export default function ProviderInboxScreen() {
         </View>
       );
     },
-    [filteredConversations.length, handleConversationPress, colors],
+    [
+      filteredConversations.length,
+      handleConversationPress,
+      handleLongPressConversation,
+      handleMenuPress,
+      colors,
+      styles,
+    ],
   );
 
   if (loading) {
     return (
-      <View style={[styles.container, { paddingTop: insets.top + 24, backgroundColor: colors.background }]}>
+      <View style={[styles.container, { paddingTop: insets.top + 24 }]}>
         <View style={styles.header}>
-          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t('providerDashboard.inbox.title')}</Text>
+          <Text style={styles.headerTitle}>{t('providerDashboard.inbox.title')}</Text>
         </View>
         <View style={styles.center}>
           <ActivityIndicator size="large" color={colors.primary} />
@@ -373,24 +666,24 @@ export default function ProviderInboxScreen() {
   }
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top + 24, backgroundColor: colors.background }]}>
+    <View style={[styles.container, { paddingTop: insets.top + 24 }]}>
       <View style={styles.header}>
         <View style={styles.headerRow}>
-          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t('providerDashboard.inbox.title')}</Text>
+          <Text style={styles.headerTitle}>{t('providerDashboard.inbox.title')}</Text>
           <TouchableOpacity
             style={styles.iconButton}
             onPress={() => setSearchVisible((v) => !v)}
           >
-            <Ionicons name="search" size={20} color="rgba(255,255,255,0.6)" />
+            <Ionicons name="search" size={20} color={colors.icon} />
           </TouchableOpacity>
         </View>
         {searchVisible && (
           <View style={styles.searchWrap}>
-            <Ionicons name="search" size={18} color="rgba(255,255,255,0.4)" />
+            <Ionicons name="search" size={18} color={colors.iconSecondary} />
             <TextInput
               style={styles.searchInput}
               placeholder={t('providerDashboard.inbox.searchPlaceholder')}
-              placeholderTextColor="rgba(255,255,255,0.3)"
+              placeholderTextColor={colors.textTertiary}
               value={searchQuery}
               onChangeText={setSearchQuery}
               autoCapitalize="none"
@@ -433,7 +726,7 @@ export default function ProviderInboxScreen() {
         </View>
       ) : filteredConversations.length === 0 ? (
         <View style={styles.center}>
-          <Ionicons name="chatbubbles-outline" size={64} color="rgba(255,255,255,0.3)" />
+          <Ionicons name="chatbubbles-outline" size={64} color={colors.textTertiary} />
           <Text style={styles.emptyTitle}>{t('providerDashboard.inbox.emptyTitle')}</Text>
           <Text style={styles.emptySubtitle}>{t('providerDashboard.inbox.emptySubtitle')}</Text>
         </View>
@@ -451,7 +744,7 @@ export default function ProviderInboxScreen() {
               refreshing={refreshing}
               onRefresh={onRefresh}
               colors={PURPLE_GRADIENT}
-              tintColor="#8B5CF6"
+              tintColor={colors.primary}
             />
           }
         />
@@ -459,8 +752,8 @@ export default function ProviderInboxScreen() {
 
       <Modal visible={optionsConversation !== null} transparent animationType="fade" onRequestClose={closeOptionsMenu}>
         <TouchableOpacity style={styles.optionsOverlay} activeOpacity={1} onPress={closeOptionsMenu}>
-          <View style={[styles.optionsBox, { backgroundColor: colors.card, borderColor: colors.cardBorder }]} onStartShouldSetResponder={() => true}>
-            <Text style={[styles.optionsTitle, { color: colors.textPrimary }]}>{t('chat.options')}</Text>
+          <View style={styles.optionsBox} onStartShouldSetResponder={() => true}>
+            <Text style={styles.optionsTitle}>{t('chat.options')}</Text>
             <TouchableOpacity style={styles.optionsButton} onPress={handleOptionDeleteChat}>
               <Ionicons name="trash-outline" size={20} color="#EF4444" />
               <Text style={styles.optionsButtonTextDestructive}>{t('chat.deleteChat')}</Text>
@@ -474,276 +767,3 @@ export default function ProviderInboxScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  header: {
-    paddingHorizontal: 20,
-    paddingBottom: 16,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 16,
-  },
-  headerTitle: {
-    fontSize: 20,
-    fontWeight: '700',
-  },
-  iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 12,
-    backgroundColor: FILTER_INACTIVE_BG,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  searchWrap: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    height: 44,
-    paddingHorizontal: 12,
-    borderRadius: 12,
-    backgroundColor: FILTER_INACTIVE_BG,
-    marginBottom: 12,
-  },
-  searchInput: {
-    flex: 1,
-    fontSize: 14,
-    color: '#FFFFFF',
-    paddingVertical: 0,
-  },
-  filters: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  filterPill: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderRadius: 999,
-    backgroundColor: FILTER_INACTIVE_BG,
-  },
-  filterPillActive: {
-    backgroundColor: FILTER_ACTIVE_BG,
-  },
-  filterLabel: {
-    fontSize: 12,
-    fontWeight: '500',
-    color: 'rgba(255,255,255,0.5)',
-  },
-  filterLabelActive: {
-    color: '#FFFFFF',
-  },
-  filterCount: {
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 999,
-    backgroundColor: 'rgba(255,255,255,0.1)',
-  },
-  filterCountActive: {
-    backgroundColor: 'rgba(255,255,255,0.2)',
-  },
-  filterCountText: {
-    fontSize: 10,
-    color: 'rgba(255,255,255,0.7)',
-  },
-  filterCountTextActive: {
-    color: '#FFFFFF',
-  },
-  listContent: {
-    paddingHorizontal: 20,
-    paddingTop: 8,
-  },
-  card: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    padding: 12,
-    borderRadius: 12,
-    borderWidth: 1,
-    marginBottom: 8,
-  },
-  cardTouchable: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  menuButton: {
-    padding: 8,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  cardUnread: {},
-  cardLast: {
-    marginBottom: 0,
-  },
-  avatarWrap: {
-    position: 'relative',
-  },
-  avatar: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-  },
-  avatarPlaceholder: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    backgroundColor: AVATAR_BG,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarEmoji: {
-    fontSize: 20,
-  },
-  onlineIndicator: {
-    position: 'absolute',
-    bottom: 0,
-    right: 0,
-    width: 14,
-    height: 14,
-    borderRadius: 7,
-    backgroundColor: '#22C55E',
-    borderWidth: 2,
-  },
-  content: {
-    flex: 1,
-    minWidth: 0,
-  },
-  row1: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 2,
-  },
-  name: {
-    fontSize: 14,
-    fontWeight: '500',
-    flex: 1,
-  },
-  nameUnread: {},
-  time: {
-    fontSize: 12,
-  },
-  timeUnread: {
-    color: 'rgba(167, 139, 250, 1)',
-  },
-  row2: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  preview: {
-    fontSize: 12,
-    flex: 1,
-    marginRight: 8,
-  },
-  previewUnread: {},
-  badges: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  statusBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 999,
-  },
-  statusText: {
-    fontSize: 10,
-    fontWeight: '500',
-  },
-  unreadBadge: {
-    minWidth: 20,
-    height: 20,
-    borderRadius: 10,
-    backgroundColor: FILTER_ACTIVE_BG,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 4,
-  },
-  unreadText: {
-    fontSize: 10,
-    fontWeight: '700',
-    color: '#FFFFFF',
-  },
-  center: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-  },
-  emptyTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#FFFFFF',
-    marginTop: 16,
-  },
-  emptySubtitle: {
-    fontSize: 14,
-    color: 'rgba(255,255,255,0.5)',
-    textAlign: 'center',
-    marginTop: 8,
-    paddingHorizontal: 24,
-  },
-  errorText: {
-    fontSize: 16,
-    color: '#EF4444',
-    textAlign: 'center',
-    marginBottom: 16,
-  },
-  retryButton: {
-    backgroundColor: FILTER_ACTIVE_BG,
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
-  },
-  retryText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  optionsOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
-  },
-  optionsBox: {
-    borderRadius: 12,
-    paddingVertical: 8,
-    minWidth: 220,
-    borderWidth: 1,
-  },
-  optionsTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  optionsButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-  },
-  optionsButtonText: {
-    fontSize: 16,
-    color: 'rgba(255,255,255,0.6)',
-  },
-  optionsButtonTextDestructive: {
-    fontSize: 16,
-    color: '#EF4444',
-    fontWeight: '500',
-  },
-});

--- a/app/(provider-tabs)/profile/availability.tsx
+++ b/app/(provider-tabs)/profile/availability.tsx
@@ -202,13 +202,13 @@ export default function ProviderAvailabilityScreen() {
     return (
       <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.cardBorder }]}>
-          <TouchableOpacity style={styles.backButton} onPress={handleBack} accessibilityLabel={t("common.back")}>
-            <Text style={styles.backArrow}>←</Text>
+          <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surfaceSecondary }]} onPress={handleBack} accessibilityLabel={t("common.back")}>
+            <Text style={[styles.backArrow, { color: colors.icon }]}>←</Text>
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{t("providerDashboard.availabilityConfig.title")}</Text>
+          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("providerDashboard.availabilityConfig.title")}</Text>
         </View>
         <View style={styles.loadingContainer}>
-          <Text style={styles.errorText}>{t("providerDashboard.availabilityConfig.errors.loadFailed")}</Text>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.errors.loadFailed")}</Text>
           <TouchableOpacity
             style={styles.retryButton}
             onPress={() => refetch()}
@@ -231,10 +231,10 @@ export default function ProviderAvailabilityScreen() {
     return (
       <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
         <View style={[styles.header, { borderBottomColor: colors.cardBorder }]}>
-          <TouchableOpacity style={styles.backButton} onPress={handleBack}>
-            <Text style={styles.backArrow}>←</Text>
+          <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surfaceSecondary }]} onPress={handleBack}>
+            <Text style={[styles.backArrow, { color: colors.icon }]}>←</Text>
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{t("providerDashboard.availabilityConfig.title")}</Text>
+          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("providerDashboard.availabilityConfig.title")}</Text>
         </View>
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#8B5CF6" />
@@ -247,10 +247,10 @@ export default function ProviderAvailabilityScreen() {
     <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
       {/* Back header with Save */}
       <View style={[styles.header, { borderBottomColor: colors.cardBorder }]}>
-        <TouchableOpacity style={styles.backButton} onPress={handleBack} accessibilityLabel={t("common.back")}>
-          <Text style={styles.backArrow}>←</Text>
+        <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surfaceSecondary }]} onPress={handleBack} accessibilityLabel={t("common.back")}>
+          <Text style={[styles.backArrow, { color: colors.icon }]}>←</Text>
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>{t("providerDashboard.availabilityConfig.title")}</Text>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("providerDashboard.availabilityConfig.title")}</Text>
         <TouchableOpacity
           style={styles.saveButton}
           onPress={handleSave}
@@ -271,7 +271,7 @@ export default function ProviderAvailabilityScreen() {
         showsVerticalScrollIndicator={false}
       >
         {/* Work days */}
-        <Text style={styles.sectionLabel}>{t("providerDashboard.availabilityConfig.workDays")}</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.workDays")}</Text>
         <View style={styles.daysRow}>
           {DAY_KEYS.map((key, idx) => {
             const isActive = activeDays.includes(idx);
@@ -280,7 +280,7 @@ export default function ProviderAvailabilityScreen() {
                 key={key}
                 onPress={() => toggleDay(idx)}
                 activeOpacity={0.7}
-                style={[styles.dayButtonWrap, !isActive && styles.dayButton]}
+                style={[styles.dayButtonWrap, !isActive && [styles.dayButton, { backgroundColor: colors.surfaceSecondary }]]}
               >
                 {isActive ? (
                   <LinearGradient
@@ -294,7 +294,7 @@ export default function ProviderAvailabilityScreen() {
                     </Text>
                   </LinearGradient>
                 ) : (
-                  <Text style={styles.dayButtonText}>
+                  <Text style={[styles.dayButtonText, { color: colors.textSecondary }]}>
                     {t(`providerDashboard.availabilityConfig.${key}`)}
                   </Text>
                 )}
@@ -304,35 +304,35 @@ export default function ProviderAvailabilityScreen() {
         </View>
 
         {/* Schedule per day (first active day as template for simplicity; full UI would expand per day) */}
-        <Text style={styles.sectionLabel}>{t("providerDashboard.availabilityConfig.schedule")}</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.schedule")}</Text>
         <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
           {[0, 1, 2, 3, 4, 5, 6].map((dayIndex) => {
             const slots = scheduleConfig[String(dayIndex)] ?? [];
             if (slots.length === 0) return null;
             return (
               <View key={dayIndex} style={styles.dayScheduleBlock}>
-                <Text style={styles.dayScheduleLabel}>
+                <Text style={[styles.dayScheduleLabel, { color: colors.textSecondary }]}>
                   {t(`providerDashboard.availabilityConfig.${DAY_KEYS[dayIndex]}`)}
                 </Text>
                 {slots.map((slot, slotIndex) => (
                   <View key={slotIndex} style={styles.timeRow}>
                     <View style={styles.timeField}>
-                      <Text style={styles.timeFieldLabel}>{t("providerDashboard.availabilityConfig.start")}</Text>
+                      <Text style={[styles.timeFieldLabel, { color: colors.textTertiary }]}>{t("providerDashboard.availabilityConfig.start")}</Text>
                       <TouchableOpacity
-                        style={styles.timeValue}
+                        style={[styles.timeValue, { backgroundColor: colors.surfaceSecondary }]}
                         onPress={() => setTimePicker({ dayIndex, slotIndex, field: "start" })}
                       >
-                        <Text style={styles.timeValueText}>{formatToDisplay(slot.start)}</Text>
+                        <Text style={[styles.timeValueText, { color: colors.textPrimary }]}>{formatToDisplay(slot.start)}</Text>
                       </TouchableOpacity>
                     </View>
-                    <Text style={styles.timeArrow}>→</Text>
+                    <Text style={[styles.timeArrow, { color: colors.textTertiary }]}>→</Text>
                     <View style={styles.timeField}>
-                      <Text style={styles.timeFieldLabel}>{t("providerDashboard.availabilityConfig.end")}</Text>
+                      <Text style={[styles.timeFieldLabel, { color: colors.textTertiary }]}>{t("providerDashboard.availabilityConfig.end")}</Text>
                       <TouchableOpacity
-                        style={styles.timeValue}
+                        style={[styles.timeValue, { backgroundColor: colors.surfaceSecondary }]}
                         onPress={() => setTimePicker({ dayIndex, slotIndex, field: "end" })}
                       >
-                        <Text style={styles.timeValueText}>{formatToDisplay(slot.end)}</Text>
+                        <Text style={[styles.timeValueText, { color: colors.textPrimary }]}>{formatToDisplay(slot.end)}</Text>
                       </TouchableOpacity>
                     </View>
                     {slots.length > 1 && (
@@ -355,64 +355,64 @@ export default function ProviderAvailabilityScreen() {
         </View>
 
         {/* Buffer & Max jobs */}
-        <Text style={styles.sectionLabel}>{t("providerDashboard.availabilityConfig.bufferTime")}</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.bufferTime")}</Text>
         <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
           <View style={styles.bufferRow}>
-            <Text style={styles.bufferLabel}>
+            <Text style={[styles.bufferLabel, { color: colors.textPrimary }]}>
               {t("providerDashboard.availabilityConfig.bufferMinutes", { minutes: bufferMinutes })}
             </Text>
             <View style={styles.stepperRow}>
               <TouchableOpacity
-                style={styles.stepperButton}
+                style={[styles.stepperButton, { backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setBufferMinutes((m) => Math.max(0, m - 15))}
               >
-                <Text style={styles.stepperText}>−</Text>
+                <Text style={[styles.stepperText, { color: colors.textSecondary }]}>−</Text>
               </TouchableOpacity>
-              <Text style={styles.stepperValue}>{bufferMinutes}</Text>
+              <Text style={[styles.stepperValue, { color: colors.textPrimary }]}>{bufferMinutes}</Text>
               <TouchableOpacity
-                style={styles.stepperButton}
+                style={[styles.stepperButton, { backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setBufferMinutes((m) => Math.min(480, m + 15))}
               >
-                <Text style={styles.stepperText}>+</Text>
+                <Text style={[styles.stepperText, { color: colors.textSecondary }]}>+</Text>
               </TouchableOpacity>
             </View>
           </View>
         </View>
 
-        <Text style={styles.sectionLabel}>{t("providerDashboard.availabilityConfig.maxJobsPerDay")}</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.maxJobsPerDay")}</Text>
         <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
           <View style={styles.bufferRow}>
-            <Text style={styles.bufferLabel}>{maxJobsPerDay}</Text>
+            <Text style={[styles.bufferLabel, { color: colors.textPrimary }]}>{maxJobsPerDay}</Text>
             <View style={styles.stepperRow}>
               <TouchableOpacity
-                style={styles.stepperButton}
+                style={[styles.stepperButton, { backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setMaxJobsPerDay((n) => Math.max(1, n - 1))}
               >
-                <Text style={styles.stepperText}>−</Text>
+                <Text style={[styles.stepperText, { color: colors.textSecondary }]}>−</Text>
               </TouchableOpacity>
-              <Text style={styles.stepperValue}>{maxJobsPerDay}</Text>
+              <Text style={[styles.stepperValue, { color: colors.textPrimary }]}>{maxJobsPerDay}</Text>
               <TouchableOpacity
-                style={styles.stepperButton}
+                style={[styles.stepperButton, { backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setMaxJobsPerDay((n) => Math.min(50, n + 1))}
               >
-                <Text style={styles.stepperText}>+</Text>
+                <Text style={[styles.stepperText, { color: colors.textSecondary }]}>+</Text>
               </TouchableOpacity>
             </View>
           </View>
         </View>
 
         {/* Blocked dates */}
-        <Text style={styles.sectionLabel}>{t("providerDashboard.availabilityConfig.specialDays")}</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.specialDays")}</Text>
         <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
           {blockedDates.map((bd, idx) => (
             <View key={idx} style={styles.blockedRow}>
               <View style={styles.blockedInfo}>
                 <Text style={styles.blockedEmoji}>🏖️</Text>
                 <View>
-                  <Text style={styles.blockedTitle}>
+                  <Text style={[styles.blockedTitle, { color: colors.textPrimary }]}>
                     {bd.label || t("providerDashboard.availabilityConfig.specialDays")}
                   </Text>
-                  <Text style={styles.blockedDateRangeText}>
+                  <Text style={[styles.blockedDateRangeText, { color: colors.textSecondary }]}>
                     {bd.startDate} – {bd.endDate}
                   </Text>
                 </View>
@@ -478,11 +478,11 @@ export default function ProviderAvailabilityScreen() {
       <Modal visible={blockedDateModal} transparent animationType="fade">
         <View style={styles.modalOverlay}>
           <View style={[styles.modalContent, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-            <Text style={styles.modalTitle}>{t("providerDashboard.availabilityConfig.addBlockedDates")}</Text>
+            <Text style={[styles.modalTitle, { color: colors.textPrimary }]}>{t("providerDashboard.availabilityConfig.addBlockedDates")}</Text>
 
-            <Text style={styles.modalLabel}>{t("providerDashboard.availabilityConfig.startDateLabel")}</Text>
+            <Text style={[styles.modalLabel, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.startDateLabel")}</Text>
             {isWeb ? (
-              <View style={[styles.modalDateField, { borderColor: colors.cardBorder }]}>
+              <View style={[styles.modalDateField, { borderColor: colors.cardBorder, backgroundColor: colors.surfaceSecondary }]}>
                 {React.createElement("input", {
                   type: "date",
                   value: blockedStart.toISOString().slice(0, 10),
@@ -498,11 +498,11 @@ export default function ProviderAvailabilityScreen() {
               </View>
             ) : (
               <TouchableOpacity
-                style={[styles.modalDateField, { borderColor: colors.cardBorder }]}
+                style={[styles.modalDateField, { borderColor: colors.cardBorder, backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setBlockedDatePickerField("start")}
                 activeOpacity={0.7}
               >
-                <Text style={styles.modalDateFieldText}>{formatDateForDisplay(blockedStart)}</Text>
+                <Text style={[styles.modalDateFieldText, { color: colors.textPrimary }]}>{formatDateForDisplay(blockedStart)}</Text>
                 <Ionicons name="calendar-outline" size={20} color="#A78BFA" />
               </TouchableOpacity>
             )}
@@ -526,9 +526,9 @@ export default function ProviderAvailabilityScreen() {
               </>
             )}
 
-            <Text style={[styles.modalLabel, styles.modalLabelSpaced]}>{t("providerDashboard.availabilityConfig.endDateLabel")}</Text>
+            <Text style={[styles.modalLabel, styles.modalLabelSpaced, { color: colors.textSecondary }]}>{t("providerDashboard.availabilityConfig.endDateLabel")}</Text>
             {isWeb ? (
-              <View style={[styles.modalDateField, { borderColor: colors.cardBorder }]}>
+              <View style={[styles.modalDateField, { borderColor: colors.cardBorder, backgroundColor: colors.surfaceSecondary }]}>
                 {React.createElement("input", {
                   type: "date",
                   value: blockedEnd.toISOString().slice(0, 10),
@@ -542,11 +542,11 @@ export default function ProviderAvailabilityScreen() {
               </View>
             ) : (
               <TouchableOpacity
-                style={[styles.modalDateField, { borderColor: colors.cardBorder }]}
+                style={[styles.modalDateField, { borderColor: colors.cardBorder, backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setBlockedDatePickerField("end")}
                 activeOpacity={0.7}
               >
-                <Text style={styles.modalDateFieldText}>{formatDateForDisplay(blockedEnd)}</Text>
+                <Text style={[styles.modalDateFieldText, { color: colors.textPrimary }]}>{formatDateForDisplay(blockedEnd)}</Text>
                 <Ionicons name="calendar-outline" size={20} color="#A78BFA" />
               </TouchableOpacity>
             )}

--- a/app/(provider-tabs)/profile/payment-methods.tsx
+++ b/app/(provider-tabs)/profile/payment-methods.tsx
@@ -28,7 +28,6 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const CARD_BORDER_PRIMARY = "rgba(34, 197, 94, 0.3)";
-const SECTION_HEADER = "rgba(255,255,255,0.4)";
 const GRADIENT_START = "#6366F1";
 const GRADIENT_MID = "#8B5CF6";
 const GRADIENT_END = "#EC4899";
@@ -117,15 +116,15 @@ export default function ProviderPaymentMethodsScreen() {
     <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
       <View style={styles.header}>
         <TouchableOpacity
-          style={styles.backButton}
+          style={[styles.backButton, { backgroundColor: colors.surfaceSecondary }]}
           onPress={() => router.back()}
           activeOpacity={0.8}
           accessibilityLabel={t("providerDashboard.providerSettings.back")}
           accessibilityRole="button"
         >
-          <Ionicons name="chevron-back" size={24} color="rgba(255,255,255,0.6)" />
+          <Ionicons name="chevron-back" size={24} color={colors.icon} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>
           {t("providerDashboard.paymentMethods.title")}
         </Text>
       </View>
@@ -183,7 +182,7 @@ export default function ProviderPaymentMethodsScreen() {
         </LinearGradient>
 
         {/* Bank accounts */}
-        <Text style={styles.sectionTitle}>
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
           {t("providerDashboard.paymentMethods.bankAccountsSection")}
         </Text>
         <View style={styles.bankList}>
@@ -208,7 +207,7 @@ export default function ProviderPaymentMethodsScreen() {
         </View>
 
         {/* Payout frequency */}
-        <Text style={styles.sectionTitle}>
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
           {t("providerDashboard.paymentMethods.payoutFrequency")}
         </Text>
         <View style={[styles.frequencyCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
@@ -224,6 +223,7 @@ export default function ProviderPaymentMethodsScreen() {
                 key={key}
                 style={[
                   styles.frequencyButton,
+                  { backgroundColor: payoutFrequency === key ? "transparent" : colors.surfaceSecondary },
                   payoutFrequency === key && styles.frequencyButtonActive,
                 ]}
                 onPress={() => setPayoutFrequency(key)}
@@ -240,6 +240,7 @@ export default function ProviderPaymentMethodsScreen() {
                 <Text
                   style={[
                     styles.frequencyButtonText,
+                    { color: payoutFrequency === key ? "#FFFFFF" : colors.textSecondary },
                     payoutFrequency === key && styles.frequencyButtonTextActive,
                   ]}
                 >
@@ -248,37 +249,37 @@ export default function ProviderPaymentMethodsScreen() {
               </TouchableOpacity>
             ))}
           </View>
-          <Text style={styles.frequencyNote}>
+          <Text style={[styles.frequencyNote, { color: colors.textTertiary }]}>
             {t("providerDashboard.paymentMethods.payoutProcessedNote")}
           </Text>
         </View>
 
         {/* Minimum withdrawal */}
-        <Text style={styles.sectionTitle}>
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
           {t("providerDashboard.paymentMethods.minWithdrawal")}
         </Text>
         <View style={[styles.minWithdrawalCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
           <View style={styles.minWithdrawalRow}>
-            <Text style={styles.currencyPrefix}>$</Text>
+            <Text style={[styles.currencyPrefix, { color: colors.textTertiary }]}>$</Text>
             <TextInput
-              style={styles.minWithdrawalInput}
+              style={[styles.minWithdrawalInput, { color: colors.textPrimary }]}
               value={minWithdrawal}
               onChangeText={setMinWithdrawal}
               keyboardType="numeric"
               placeholder="100"
-              placeholderTextColor="rgba(255,255,255,0.3)"
+              placeholderTextColor={colors.textTertiary}
             />
-            <Text style={styles.currencySuffix}>
+            <Text style={[styles.currencySuffix, { color: colors.textTertiary }]}>
               {t("providerDashboard.paymentMethods.currency")}
             </Text>
           </View>
-          <Text style={styles.minWithdrawalHint}>
+          <Text style={[styles.minWithdrawalHint, { color: colors.textTertiary }]}>
             {t("providerDashboard.paymentMethods.minWithdrawalHint")}
           </Text>
         </View>
 
         {/* Recent payouts */}
-        <Text style={styles.sectionTitle}>
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
           {t("providerDashboard.paymentMethods.recentPayouts")}
         </Text>
         {transactionsQuery.isLoading ? (
@@ -287,7 +288,7 @@ export default function ProviderPaymentMethodsScreen() {
           </View>
         ) : transactions.length === 0 ? (
           <View style={[styles.payoutItem, { backgroundColor: colors.card }]}>
-            <Text style={styles.noPayouts}>
+            <Text style={[styles.noPayouts, { color: colors.textSecondary }]}>
               {t("providerDashboard.paymentMethods.noPayouts")}
             </Text>
           </View>
@@ -324,12 +325,12 @@ function BankAccountCard({
         account.primary && styles.bankCardPrimary,
       ]}
     >
-      <View style={styles.bankIconBox}>
-        <Ionicons name="business-outline" size={24} color="rgba(255,255,255,0.6)" />
+      <View style={[styles.bankIconBox, { backgroundColor: themeColors.surfaceSecondary }]}>
+        <Ionicons name="business-outline" size={24} color={themeColors.icon} />
       </View>
       <View style={styles.bankCardBody}>
         <View style={styles.bankCardTitleRow}>
-          <Text style={styles.bankName}>{account.bankName}</Text>
+          <Text style={[styles.bankName, { color: themeColors.textPrimary }]}>{account.bankName}</Text>
           {account.primary && (
             <View style={styles.primaryBadge}>
               <Text style={styles.primaryBadgeText}>
@@ -338,10 +339,10 @@ function BankAccountCard({
             </View>
           )}
         </View>
-        <Text style={styles.bankMasked}>{account.maskedClabe}</Text>
+        <Text style={[styles.bankMasked, { color: themeColors.textSecondary }]}>{account.maskedClabe}</Text>
       </View>
       <TouchableOpacity hitSlop={12}>
-        <Ionicons name="ellipsis-vertical" size={20} color="rgba(255,255,255,0.3)" />
+        <Ionicons name="ellipsis-vertical" size={20} color={themeColors.iconSecondary} />
       </TouchableOpacity>
     </View>
   );
@@ -363,10 +364,10 @@ function PayoutItem({
           <Ionicons name="checkmark" size={14} color="#22C55E" />
         </View>
         <View>
-          <Text style={styles.payoutDate}>
+          <Text style={[styles.payoutDate, { color: themeColors.textPrimary }]}>
             {formatPayoutDate(transaction.date)}
           </Text>
-          <Text style={styles.payoutDestination}>
+          <Text style={[styles.payoutDestination, { color: themeColors.textSecondary }]}>
             {destinationLabel || "—"}
           </Text>
         </View>
@@ -394,14 +395,12 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 12,
-    backgroundColor: "rgba(255,255,255,0.05)",
     alignItems: "center",
     justifyContent: "center",
   },
   headerTitle: {
     fontSize: 18,
     fontWeight: "700",
-    color: "#fff",
   },
   scroll: { flex: 1 },
   scrollContent: {
@@ -451,7 +450,6 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     fontSize: 12,
-    color: SECTION_HEADER,
     textTransform: "uppercase",
     letterSpacing: 1.2,
     marginBottom: 12,
@@ -478,13 +476,12 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 12,
-    backgroundColor: "rgba(255,255,255,0.05)",
     alignItems: "center",
     justifyContent: "center",
   },
   bankCardBody: { flex: 1 },
   bankCardTitleRow: { flexDirection: "row", alignItems: "center", gap: 8 },
-  bankName: { fontSize: 14, fontWeight: "500", color: "#fff" as const },
+  bankName: { fontSize: 14, fontWeight: "500" },
   primaryBadge: {
     paddingHorizontal: 8,
     paddingVertical: 2,
@@ -498,7 +495,6 @@ const styles = StyleSheet.create({
   },
   bankMasked: {
     fontSize: 14,
-    color: "rgba(255,255,255,0.4)",
     marginTop: 2,
   },
   addAccountButton: {
@@ -532,7 +528,6 @@ const styles = StyleSheet.create({
     overflow: "hidden",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "rgba(255,255,255,0.05)",
   },
   frequencyButtonActive: {
     backgroundColor: "transparent",
@@ -543,14 +538,12 @@ const styles = StyleSheet.create({
   frequencyButtonText: {
     fontSize: 12,
     fontWeight: "500",
-    color: "rgba(255,255,255,0.5)",
   },
   frequencyButtonTextActive: {
     color: "#fff",
   },
   frequencyNote: {
     fontSize: 12,
-    color: "rgba(255,255,255,0.4)",
   },
   minWithdrawalCard: {
     padding: 16,
@@ -563,18 +556,16 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 12,
   },
-  currencyPrefix: { fontSize: 18, color: "rgba(255,255,255,0.4)" },
+  currencyPrefix: { fontSize: 18 },
   minWithdrawalInput: {
     flex: 1,
     fontSize: 18,
     fontWeight: "500",
-    color: "#fff",
     padding: 0,
   },
-  currencySuffix: { fontSize: 14, color: "rgba(255,255,255,0.4)" },
+  currencySuffix: { fontSize: 14 },
   minWithdrawalHint: {
     fontSize: 12,
-    color: "rgba(255,255,255,0.3)",
     marginTop: 8,
   },
   payoutItem: {
@@ -594,16 +585,14 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  payoutDate: { fontSize: 14, color: "#fff", fontWeight: "500" },
+  payoutDate: { fontSize: 14, fontWeight: "500" },
   payoutDestination: {
     fontSize: 12,
-    color: "rgba(255,255,255,0.4)",
     marginTop: 2,
   },
   payoutAmount: { fontSize: 14, fontWeight: "500", color: "#22C55E" },
   noPayouts: {
     fontSize: 14,
-    color: "rgba(255,255,255,0.4)",
     paddingVertical: 16,
   },
 });

--- a/app/(provider-tabs)/profile/portfolio.tsx
+++ b/app/(provider-tabs)/profile/portfolio.tsx
@@ -144,14 +144,14 @@ export default function ProviderPortfolioScreen() {
       {/* Back header */}
       <View style={styles.header}>
         <TouchableOpacity
-          style={styles.backButton}
+          style={[styles.backButton, { backgroundColor: colors.surfaceSecondary }]}
           onPress={() => router.back()}
           accessibilityLabel={t("common.back")}
           accessibilityRole="button"
         >
-          <Ionicons name="chevron-back" size={22} color="rgba(255,255,255,0.6)" />
+          <Ionicons name="chevron-back" size={22} color={colors.icon} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>{t("providerDashboard.portfolio.title")}</Text>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("providerDashboard.portfolio.title")}</Text>
         <TouchableOpacity onPress={handleAdd} style={styles.addButton} activeOpacity={0.8}>
           <Text style={styles.addButtonText}>+ {t("providerDashboard.portfolio.addButton")}</Text>
         </TouchableOpacity>
@@ -166,8 +166,8 @@ export default function ProviderPortfolioScreen() {
         <View style={styles.statsRow}>
           {statRows.map((row, idx) => (
             <View key={idx} style={[styles.statCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-              <Text style={styles.statValue}>{row.value}</Text>
-              <Text style={styles.statLabel}>{t(row.labelKey)}</Text>
+              <Text style={[styles.statValue, { color: colors.textPrimary }]}>{row.value}</Text>
+              <Text style={[styles.statLabel, { color: colors.textSecondary }]}>{t(row.labelKey)}</Text>
             </View>
           ))}
         </View>
@@ -201,11 +201,11 @@ export default function ProviderPortfolioScreen() {
             ) : (
               <TouchableOpacity
                 key={opt.key}
-                style={styles.filterPill}
+                style={[styles.filterPill, { backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setFilter(opt.key)}
                 activeOpacity={0.8}
               >
-                <Text style={styles.filterPillText}>{t(opt.labelKey)}</Text>
+                <Text style={[styles.filterPillText, { color: colors.textSecondary }]}>{t(opt.labelKey)}</Text>
               </TouchableOpacity>
             )
           )}
@@ -219,10 +219,10 @@ export default function ProviderPortfolioScreen() {
           /* Empty state */
           <View style={[styles.uploadCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
             <Text style={styles.uploadEmoji}>📷</Text>
-            <Text style={styles.uploadTitle}>
+            <Text style={[styles.uploadTitle, { color: colors.textPrimary }]}>
               {t("providerDashboard.portfolio.uploadTitle")}
             </Text>
-            <Text style={styles.uploadSubtitle}>
+            <Text style={[styles.uploadSubtitle, { color: colors.textSecondary }]}>
               {t("providerDashboard.portfolio.uploadSubtitle")}
             </Text>
             <TouchableOpacity
@@ -283,10 +283,10 @@ export default function ProviderPortfolioScreen() {
         {!isLoading && projects.length > 0 && (
           <View style={[styles.uploadCard, styles.uploadCardDashed, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
             <Text style={styles.uploadEmoji}>📷</Text>
-            <Text style={styles.uploadTitle}>
+            <Text style={[styles.uploadTitle, { color: colors.textPrimary }]}>
               {t("providerDashboard.portfolio.uploadTitle")}
             </Text>
-            <Text style={styles.uploadSubtitle}>
+            <Text style={[styles.uploadSubtitle, { color: colors.textSecondary }]}>
               {t("providerDashboard.portfolio.uploadSubtitle")}
             </Text>
             <TouchableOpacity
@@ -330,9 +330,9 @@ export default function ProviderPortfolioScreen() {
           >
             <View style={styles.modalHeader}>
               <TouchableOpacity onPress={handleCloseDetail} style={styles.modalCloseBtn}>
-                <Ionicons name="close" size={24} color="#fff" />
+                <Ionicons name="close" size={24} color={colors.textPrimary} />
               </TouchableOpacity>
-              <Text style={styles.modalTitle}>
+              <Text style={[styles.modalTitle, { color: colors.textPrimary }]}>
                 {t("providerDashboard.portfolio.projectDetail")}
               </Text>
               <View style={styles.modalHeaderRight} />
@@ -371,9 +371,9 @@ export default function ProviderPortfolioScreen() {
                     })
                   )}
                 </View>
-                <Text style={styles.detailTitle}>{detailData.project.title}</Text>
+                <Text style={[styles.detailTitle, { color: colors.textPrimary }]}>{detailData.project.title}</Text>
                 {detailData.project.description ? (
-                  <Text style={styles.detailDescription}>
+                  <Text style={[styles.detailDescription, { color: colors.textSecondary }]}>
                     {detailData.project.description}
                   </Text>
                 ) : null}
@@ -386,16 +386,16 @@ export default function ProviderPortfolioScreen() {
                 ) : null}
                 <View style={styles.detailActions}>
                   <TouchableOpacity
-                    style={styles.detailActionButton}
+                    style={[styles.detailActionButton, { backgroundColor: colors.surfaceSecondary }]}
                     onPress={() => handleEdit(detailData.project.id)}
                   >
                     <Ionicons name="pencil-outline" size={20} color="#A78BFA" />
-                    <Text style={styles.detailActionText}>
+                    <Text style={[styles.detailActionText, { color: colors.primary }]}>
                       {t("providerDashboard.portfolio.editProject")}
                     </Text>
                   </TouchableOpacity>
                   <TouchableOpacity
-                    style={[styles.detailActionButton, styles.detailActionDelete]}
+                    style={[styles.detailActionButton, styles.detailActionDelete, { backgroundColor: colors.surfaceSecondary }]}
                     onPress={() => handleDelete(detailData.project)}
                   >
                     <Ionicons name="trash-outline" size={20} color="#F87171" />

--- a/app/(provider-tabs)/profile/security.tsx
+++ b/app/(provider-tabs)/profile/security.tsx
@@ -215,7 +215,7 @@ export default function ProviderSecurityScreen() {
     return (
       <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
         <View style={styles.header}>
-          <TouchableOpacity style={styles.backButton} onPress={() => router.back()} activeOpacity={0.8}>
+          <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surfaceSecondary }]} onPress={() => router.back()} activeOpacity={0.8}>
             <Ionicons name="chevron-back" size={24} color={colors.textSecondary} />
           </TouchableOpacity>
           <Text style={[styles.title, { color: colors.textPrimary }]}>{t(`${I18N}.title`)}</Text>
@@ -230,14 +230,14 @@ export default function ProviderSecurityScreen() {
   return (
     <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
       <View style={styles.header}>
-        <TouchableOpacity style={styles.backButton} onPress={() => router.back()} activeOpacity={0.8}>
+        <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surfaceSecondary }]} onPress={() => router.back()} activeOpacity={0.8}>
           <Ionicons name="chevron-back" size={24} color={colors.textSecondary} />
         </TouchableOpacity>
         <Text style={[styles.title, { color: colors.textPrimary }]}>{t(`${I18N}.title`)}</Text>
         {updating && <ActivityIndicator size="small" color={colors.primary} style={{ marginLeft: 'auto' }} />}
       </View>
 
-      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+      <ScrollView style={[styles.scroll, { backgroundColor: colors.background }]} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Password Section */}
         <Text style={[styles.sectionTitle, { color: colors.textTertiary }]}>{t(`${I18N}.sectionPassword`)}</Text>
         <TouchableOpacity style={[styles.card, { backgroundColor: colors.card, borderColor: colors.cardBorder }]} activeOpacity={0.8} onPress={handleChangePassword}>

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -5,14 +5,234 @@ import { t } from "@/i18n";
 import { Conversation, deleteConversation, fetchConversations } from "@/services/conversations";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect, useRouter } from "expo-router";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { AppState, AppStateStatus, ActivityIndicator, Alert, FlatList, Image, Modal, Platform, RefreshControl, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AppState, AppStateStatus, ActivityIndicator, Alert, FlatList, Modal, Platform, RefreshControl, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function ConversationsListScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: colors.screenBackground,
+        },
+        header: {
+          paddingHorizontal: 20,
+          paddingBottom: 20,
+          backgroundColor: colors.card,
+        },
+        headerTitle: {
+          fontSize: 28,
+          fontWeight: "700",
+          color: colors.textPrimary,
+        },
+        centerContainer: {
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          padding: 20,
+          backgroundColor: colors.screenBackground,
+        },
+        listWrapper: {
+          flex: 1,
+          backgroundColor: colors.screenBackground,
+        },
+        listContainer: {
+          flex: 1,
+          backgroundColor: colors.screenBackground,
+        },
+        listContent: {
+          paddingHorizontal: 20,
+          paddingVertical: 20,
+          backgroundColor: colors.screenBackground,
+        },
+        conversationItem: {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 14,
+          paddingVertical: 14,
+          paddingHorizontal: 0,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.cardBorder,
+          backgroundColor: colors.screenBackground,
+        },
+        conversationRowTouchable: {
+          flex: 1,
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 14,
+        },
+        menuButton: {
+          padding: 8,
+          justifyContent: "center",
+          alignItems: "center",
+        },
+        conversationItemNoBorder: {
+          borderBottomWidth: 0,
+        },
+        avatarContainer: {
+          position: "relative",
+        },
+        avatar: {
+          width: 56,
+          height: 56,
+          borderRadius: 28,
+        },
+        avatarPlaceholder: {
+          width: 56,
+          height: 56,
+          borderRadius: 28,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: colors.surfaceSecondary,
+        },
+        avatarEmoji: {
+          fontSize: 24,
+        },
+        onlineIndicator: {
+          position: "absolute",
+          bottom: 2,
+          right: 2,
+          width: 14,
+          height: 14,
+          borderRadius: 7,
+          borderWidth: 3,
+          backgroundColor: "#10b981",
+          borderColor: colors.screenBackground,
+        },
+        unreadBadge: {
+          minWidth: 20,
+          height: 20,
+          borderRadius: 10,
+          justifyContent: "center",
+          alignItems: "center",
+          paddingHorizontal: 6,
+          backgroundColor: colors.primary,
+        },
+        unreadBadgeCircular: {
+          width: 20,
+          minWidth: 20,
+          paddingHorizontal: 0,
+        },
+        unreadText: {
+          color: "#FFFFFF",
+          fontSize: 11,
+          fontWeight: "600",
+        },
+        conversationContent: {
+          flex: 1,
+          justifyContent: "center",
+        },
+        conversationHeader: {
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 4,
+        },
+        userName: {
+          fontSize: 16,
+          fontWeight: "600",
+          color: colors.textPrimary,
+        },
+        timeText: {
+          fontSize: 12,
+          color: colors.textTertiary,
+        },
+        timeTextUnread: {
+          color: colors.primary,
+        },
+        lastMessageRow: {
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "center",
+        },
+        lastMessage: {
+          fontSize: 14,
+          flex: 1,
+          marginRight: 8,
+          maxWidth: 200,
+          color: colors.textTertiary,
+        },
+        lastMessageUnread: {
+          color: colors.textPrimary,
+          fontWeight: "500",
+        },
+        emptyTitle: {
+          fontSize: 18,
+          fontWeight: "600",
+          marginTop: 16,
+          color: colors.textPrimary,
+        },
+        emptySubtitle: {
+          fontSize: 14,
+          textAlign: "center",
+          marginTop: 8,
+          paddingHorizontal: 40,
+          color: colors.textTertiary,
+        },
+        errorText: {
+          fontSize: 16,
+          textAlign: "center",
+          marginBottom: 16,
+          color: "#EF4444",
+        },
+        retryButton: {
+          backgroundColor: colors.primary,
+          paddingHorizontal: 24,
+          paddingVertical: 12,
+          borderRadius: 8,
+          marginTop: 8,
+        },
+        retryText: {
+          color: "#FFFFFF",
+          fontSize: 16,
+          fontWeight: "600",
+        },
+        optionsOverlay: {
+          flex: 1,
+          backgroundColor: "rgba(0,0,0,0.5)",
+          justifyContent: "center",
+          alignItems: "center",
+          padding: 24,
+        },
+        optionsBox: {
+          backgroundColor: colors.card,
+          borderRadius: 12,
+          paddingVertical: 8,
+          minWidth: 220,
+          borderWidth: 1,
+          borderColor: colors.cardBorder,
+        },
+        optionsTitle: {
+          fontSize: 16,
+          fontWeight: "600",
+          color: colors.textPrimary,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+        },
+        optionsButton: {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 10,
+          paddingHorizontal: 16,
+          paddingVertical: 14,
+        },
+        optionsButtonText: {
+          fontSize: 16,
+          color: colors.textSecondary,
+        },
+        optionsButtonTextDestructive: {
+          fontSize: 16,
+          color: "#EF4444",
+          fontWeight: "500",
+        },
+      }),
+    [colors]
+  );
   const { isAuthenticated } = useAuth();
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -242,7 +462,7 @@ export default function ConversationsListScreen() {
       const showBorder = index < 4;
 
       return (
-        <View style={[styles.conversationItem, !showBorder && styles.conversationItemNoBorder, { backgroundColor: colors.background, borderBottomColor: colors.cardBorder }]}>
+        <View style={[styles.conversationItem, !showBorder && styles.conversationItemNoBorder]}>
           <TouchableOpacity style={styles.conversationRowTouchable} onPress={() => handleConversationPress(item.id)} onLongPress={() => handleLongPressConversation(item)} activeOpacity={0.7}>
             <View style={styles.avatarContainer}>
               <ProviderAvatar
@@ -255,11 +475,11 @@ export default function ConversationsListScreen() {
             </View>
             <View style={styles.conversationContent}>
               <View style={styles.conversationHeader}>
-                <Text style={[styles.userName, { color: colors.textPrimary }]}>{item.other_user_name}</Text>
-                <Text style={[styles.timeText, { color: item.unread_count > 0 ? colors.primary : colors.textTertiary }]}>{formatTime(item.last_message_at)}</Text>
+                <Text style={styles.userName}>{item.other_user_name}</Text>
+                <Text style={[styles.timeText, item.unread_count > 0 && styles.timeTextUnread]}>{formatTime(item.last_message_at)}</Text>
               </View>
               <View style={styles.lastMessageRow}>
-                <Text style={[styles.lastMessage, { color: item.unread_count > 0 ? colors.textPrimary : colors.textTertiary }, item.unread_count > 0 && { fontWeight: "500" }]} numberOfLines={1}>
+                <Text style={[styles.lastMessage, item.unread_count > 0 && styles.lastMessageUnread]} numberOfLines={1}>
                   {item.last_message || t("chat.noMessages")}
                 </Text>
                 {item.unread_count > 0 && (
@@ -283,19 +503,11 @@ export default function ConversationsListScreen() {
 
   if (loading) {
     return (
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <View
-          style={[
-            styles.header,
-            {
-              paddingTop: insets.top + 20,
-              backgroundColor: colors.card,
-            },
-          ]}
-        >
-          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("chat.messages")}</Text>
+      <View style={styles.container}>
+        <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
+          <Text style={styles.headerTitle}>{t("chat.messages")}</Text>
         </View>
-        <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <View style={styles.centerContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </View>
@@ -303,39 +515,30 @@ export default function ConversationsListScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      {/* Header - Exact match to JSX: padding: '50px 20px 20px', backgroundColor: colors.bgCard */}
-      <View
-        style={[
-          styles.header,
-          {
-            paddingTop: insets.top + 20,
-            backgroundColor: colors.card,
-          },
-        ]}
-      >
-        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("chat.messages")}</Text>
+    <View style={styles.container}>
+      <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
+        <Text style={styles.headerTitle}>{t("chat.messages")}</Text>
       </View>
 
       {error ?
-        <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
-          <Text style={[styles.errorText, { color: "#EF4444" }]}>{error}</Text>
+        <View style={styles.centerContainer}>
+          <Text style={styles.errorText}>{error}</Text>
           <TouchableOpacity style={styles.retryButton} onPress={loadConversations}>
             <Text style={styles.retryText}>{t("chat.retry")}</Text>
           </TouchableOpacity>
         </View>
       : conversations.length === 0 ?
-        <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <View style={styles.centerContainer}>
           <Ionicons name="chatbubbles-outline" size={64} color={colors.textTertiary} />
-          <Text style={[styles.emptyTitle, { color: colors.textPrimary }]}>{t("chat.noMessages")}</Text>
-          <Text style={[styles.emptySubtitle, { color: colors.textTertiary }]}>{t("chat.noMessagesDesc")}</Text>
+          <Text style={styles.emptyTitle}>{t("chat.noMessages")}</Text>
+          <Text style={styles.emptySubtitle}>{t("chat.noMessagesDesc")}</Text>
         </View>
-      : <View style={{ flex: 1, backgroundColor: colors.background }}>
+      : <View style={styles.listWrapper}>
           <FlatList
             data={conversations}
             keyExtractor={(item) => item?.id || `conversation-${Math.random()}`}
             renderItem={renderConversation}
-            contentContainerStyle={{ paddingHorizontal: 20, paddingVertical: 20, paddingBottom: 100 + insets.bottom, backgroundColor: colors.background }}
+            contentContainerStyle={[styles.listContent, { paddingBottom: 100 + insets.bottom }]}
             refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[colors.primary]} />}
           />
         </View>
@@ -358,230 +561,3 @@ export default function ConversationsListScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#1a1a2e", // Hardcode dark background like Home
-  },
-  // Header: padding: '50px 20px 20px' from JSX (50px top, 20px horizontal, 20px bottom)
-  header: {
-    paddingHorizontal: 20,
-    paddingBottom: 20,
-    backgroundColor: "#252542", // Hardcode dark header
-    // paddingTop will be set dynamically with safe area
-  },
-  // Title: fontSize: '28px', fontWeight: '700' from JSX
-  headerTitle: {
-    fontSize: 28,
-    fontWeight: "700",
-    color: "#FFFFFF", // Hardcode white text
-  },
-  centerContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 20,
-    backgroundColor: "#1a1a2e", // Hardcode dark background
-  },
-  listWrapper: {
-    flex: 1,
-    backgroundColor: "#1a1a2e", // Hardcode dark background wrapper for FlashList
-  },
-  listContainer: {
-    flex: 1,
-    backgroundColor: "#1a1a2e", // Hardcode dark background for FlashList style prop
-  },
-  // List: padding: '20px' from JSX
-  listContent: {
-    paddingHorizontal: 20,
-    paddingVertical: 20,
-    backgroundColor: "#1a1a2e", // Hardcode dark background
-  },
-  // Item: gap: '14px', padding: '14px 0' from JSX - gap must be exact
-  conversationItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 14, // Exact gap from JSX
-    paddingVertical: 14,
-    paddingHorizontal: 0, // No horizontal padding on item itself
-    borderBottomWidth: 1,
-    borderBottomColor: "#374151", // Hardcode dark border
-    backgroundColor: "#1a1a2e", // Hardcode dark background for each item
-  },
-  conversationRowTouchable: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 14,
-  },
-  menuButton: {
-    padding: 8,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  conversationItemNoBorder: {
-    borderBottomWidth: 0,
-  },
-  avatarContainer: {
-    position: "relative",
-  },
-  // Avatar: width: '56px', height: '56px', borderRadius: '50%' from JSX
-  avatar: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-  },
-  avatarPlaceholder: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    justifyContent: "center",
-    alignItems: "center",
-    backgroundColor: "#252542", // Hardcode dark header background
-  },
-  avatarEmoji: {
-    fontSize: 24,
-  },
-  // Online indicator: width: '14px', height: '14px', bottom: '2px', right: '2px', border: '3px solid' from JSX
-  onlineIndicator: {
-    position: "absolute",
-    bottom: 2,
-    right: 2,
-    width: 14,
-    height: 14,
-    borderRadius: 7,
-    borderWidth: 3,
-    backgroundColor: "#10b981", // Hardcode secondary color
-    borderColor: "#1a1a2e", // Hardcode dark background
-  },
-  // Badge: minWidth: '20px', height: '20px', borderRadius: '50%', fontSize: '11px', fontWeight: '600' from JSX
-  unreadBadge: {
-    minWidth: 20,
-    height: 20,
-    borderRadius: 10,
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 6,
-    backgroundColor: "#3b82f6", // Hardcode primary color
-  },
-  unreadBadgeCircular: {
-    width: 20,
-    minWidth: 20,
-    paddingHorizontal: 0,
-  },
-  unreadText: {
-    color: "#FFFFFF",
-    fontSize: 11,
-    fontWeight: "600",
-  },
-  conversationContent: {
-    flex: 1,
-    justifyContent: "center",
-  },
-  // Header row: marginBottom: '4px' from JSX
-  conversationHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 4,
-  },
-  // Name: fontSize: '16px', fontWeight: '600' from JSX
-  userName: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: "#FFFFFF", // Hardcode white text
-  },
-  // Time: fontSize: '12px' from JSX
-  timeText: {
-    fontSize: 12,
-    color: "#9ca3af", // Hardcode secondary text
-  },
-  timeTextUnread: {
-    color: "#3b82f6", // Hardcode primary color for unread
-  },
-  lastMessageRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  // Message: fontSize: '14px', maxWidth: '200px' from JSX
-  lastMessage: {
-    fontSize: 14,
-    flex: 1,
-    marginRight: 8,
-    maxWidth: 200,
-    color: "#9ca3af", // Hardcode secondary text
-  },
-  lastMessageUnread: {
-    color: "#FFFFFF", // Hardcode white text for unread
-    fontWeight: "500",
-  },
-  emptyTitle: {
-    fontSize: 18,
-    fontWeight: "600",
-    marginTop: 16,
-    color: "#FFFFFF", // Hardcode white text
-  },
-  emptySubtitle: {
-    fontSize: 14,
-    textAlign: "center",
-    marginTop: 8,
-    paddingHorizontal: 40,
-    color: "#9ca3af", // Hardcode secondary text
-  },
-  errorText: {
-    fontSize: 16,
-    textAlign: "center",
-    marginBottom: 16,
-    color: "#EF4444", // Hardcode error color
-  },
-  retryButton: {
-    backgroundColor: "#3b82f6",
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
-    marginTop: 8,
-  },
-  retryText: {
-    color: "#FFFFFF",
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  optionsOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.5)",
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 24,
-  },
-  optionsBox: {
-    backgroundColor: "#252542",
-    borderRadius: 12,
-    paddingVertical: 8,
-    minWidth: 220,
-  },
-  optionsTitle: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: "#FFFFFF",
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  optionsButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-  },
-  optionsButtonText: {
-    fontSize: 16,
-    color: "#9ca3af",
-  },
-  optionsButtonTextDestructive: {
-    fontSize: 16,
-    color: "#EF4444",
-    fontWeight: "500",
-  },
-});

--- a/app/account/payment-methods.tsx
+++ b/app/account/payment-methods.tsx
@@ -8,9 +8,8 @@ import {
   setDefaultPaymentMethod,
   type PaymentMethod as ApiPaymentMethod,
 } from '@/services/payments';
-import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Modal,
@@ -22,6 +21,354 @@ import {
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
+import type { ThemeColors } from '@/utils/themeStyles';
+
+const SECONDARY_GREEN = '#10b981';
+const DANGER_RED = '#ef4444';
+
+function createPaymentMethodsStyles(theme: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.screenBackground,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 20,
+      paddingBottom: 20,
+      gap: 16,
+      backgroundColor: theme.screenBackground,
+    },
+    backButton: {
+      padding: 4,
+    },
+    backArrow: {
+      fontSize: 24,
+      color: theme.textPrimary,
+    },
+    title: {
+      flex: 1,
+      fontSize: 20,
+      fontWeight: '600',
+      color: theme.textPrimary,
+    },
+    placeholder: {
+      width: 32,
+    },
+    content: {
+      flex: 1,
+      backgroundColor: theme.screenBackground,
+    },
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: theme.screenBackground,
+    },
+    securityBadge: {
+      marginHorizontal: 20,
+      marginBottom: 20,
+      padding: 14,
+      paddingHorizontal: 16,
+      backgroundColor: `${SECONDARY_GREEN}18`,
+      borderRadius: 12,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      borderWidth: 1,
+      borderColor: `${SECONDARY_GREEN}40`,
+    },
+    shieldIcon: {
+      fontSize: 20,
+    },
+    securityBadgeContent: {
+      flex: 1,
+    },
+    securityBadgeTitle: {
+      color: SECONDARY_GREEN,
+      fontSize: 13,
+      fontWeight: '600',
+      marginBottom: 2,
+    },
+    securityBadgeText: {
+      color: theme.textSecondary,
+      fontSize: 11,
+    },
+    sectionTitleContainer: {
+      paddingHorizontal: 20,
+      paddingBottom: 12,
+    },
+    sectionTitle: {
+      color: theme.textSecondary,
+      fontSize: 12,
+      fontWeight: '600',
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
+    paymentMethodsContainer: {
+      paddingHorizontal: 20,
+    },
+    cardItem: {
+      borderRadius: 14,
+      padding: 16,
+      marginBottom: 12,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 14,
+      backgroundColor: theme.card,
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    cardItemSelected: {
+      borderWidth: 2,
+      borderColor: theme.primary,
+    },
+    cardIconContainer: {
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.2,
+      shadowRadius: 8,
+      elevation: 3,
+    },
+    cardIcon: {
+      width: 56,
+      height: 40,
+      borderRadius: 8,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cardIconText: {
+      color: '#ffffff',
+      fontSize: 10,
+      fontWeight: '700',
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    cardInfo: {
+      flex: 1,
+    },
+    cardHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      marginBottom: 4,
+    },
+    cardNumber: {
+      color: theme.textPrimary,
+      fontSize: 15,
+      fontWeight: '600',
+    },
+    cardDetails: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    cardExpiry: {
+      color: theme.textSecondary,
+      fontSize: 13,
+    },
+    defaultBadge: {
+      backgroundColor: `${SECONDARY_GREEN}25`,
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      borderRadius: 4,
+    },
+    defaultBadgeText: {
+      color: SECONDARY_GREEN,
+      fontSize: 10,
+      fontWeight: '600',
+    },
+    chevron: {
+      color: theme.textSecondary,
+      fontSize: 18,
+    },
+    chevronRotated: {
+      transform: [{ rotate: '90deg' }],
+    },
+    expandedActions: {
+      flexDirection: 'row',
+      gap: 10,
+      marginTop: -8,
+      marginBottom: 16,
+      paddingHorizontal: 4,
+    },
+    actionButtonPrimary: {
+      flex: 1,
+      padding: 12,
+      backgroundColor: `${theme.primary}22`,
+      borderRadius: 10,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 6,
+    },
+    actionButtonDanger: {
+      flex: 1,
+      padding: 12,
+      backgroundColor: `${DANGER_RED}22`,
+      borderRadius: 10,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 6,
+    },
+    actionButtonTextPrimary: {
+      color: theme.primary,
+      fontSize: 13,
+      fontWeight: '600',
+    },
+    actionButtonTextDanger: {
+      color: DANGER_RED,
+      fontSize: 13,
+      fontWeight: '600',
+    },
+    addCardButton: {
+      backgroundColor: 'transparent',
+      borderRadius: 14,
+      padding: 20,
+      paddingHorizontal: 16,
+      marginBottom: 20,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 14,
+      borderWidth: 2,
+      borderStyle: 'dashed',
+      borderColor: theme.border,
+    },
+    addCardIcon: {
+      width: 56,
+      height: 40,
+      backgroundColor: theme.surfaceSecondary,
+      borderRadius: 8,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    addCardIconText: {
+      color: theme.primary,
+      fontSize: 24,
+      fontWeight: '300',
+    },
+    addCardInfo: {
+      flex: 1,
+    },
+    addCardTitle: {
+      color: theme.primary,
+      fontSize: 15,
+      fontWeight: '600',
+      marginBottom: 2,
+    },
+    addCardSubtitle: {
+      color: theme.textSecondary,
+      fontSize: 12,
+    },
+    acceptedSection: {
+      padding: 20,
+      borderTopWidth: 1,
+      borderTopColor: theme.border,
+      marginTop: 10,
+    },
+    acceptedTitle: {
+      color: theme.textSecondary,
+      fontSize: 12,
+      marginBottom: 12,
+      textAlign: 'center',
+    },
+    acceptedCards: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      gap: 12,
+      flexWrap: 'wrap',
+    },
+    acceptedCard: {
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      backgroundColor: theme.card,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    acceptedCardText: {
+      color: theme.textSecondary,
+      fontSize: 11,
+      fontWeight: '600',
+    },
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.7)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    deleteModalContent: {
+      width: '100%',
+      borderRadius: 20,
+      padding: 24,
+      alignItems: 'center',
+      margin: 20,
+      backgroundColor: theme.card,
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    deleteIconContainer: {
+      width: 60,
+      height: 60,
+      backgroundColor: `${DANGER_RED}22`,
+      borderRadius: 30,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 16,
+    },
+    deleteIcon: {
+      fontSize: 28,
+    },
+    deleteModalTitle: {
+      color: theme.textPrimary,
+      fontSize: 18,
+      fontWeight: '700',
+      marginBottom: 8,
+      textAlign: 'center',
+    },
+    deleteModalText: {
+      color: theme.textSecondary,
+      fontSize: 14,
+      marginBottom: 24,
+      textAlign: 'center',
+      lineHeight: 20,
+    },
+    deleteModalButtons: {
+      flexDirection: 'row',
+      gap: 12,
+      width: '100%',
+    },
+    modalButtonCancel: {
+      flex: 1,
+      padding: 18,
+      backgroundColor: theme.surfaceSecondary,
+      borderRadius: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    modalButtonTextCancel: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.textPrimary,
+    },
+    modalButtonDelete: {
+      flex: 1,
+      padding: 16,
+      backgroundColor: DANGER_RED,
+      borderRadius: 12,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    modalButtonTextDelete: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: '#ffffff',
+    },
+  });
+}
+
+type PaymentMethodsScreenStyles = ReturnType<typeof createPaymentMethodsStyles>;
 
 interface PaymentMethod {
   id: string;
@@ -32,9 +379,14 @@ interface PaymentMethod {
   isDefault: boolean;
 }
 
-// Card Icon Component with gradients
-const CardIcon: React.FC<{ type: 'visa' | 'mastercard' | 'paypal' }> = ({ type }) => {
-  const getGradientColors = () => {
+function CardIcon({
+  type,
+  styles,
+}: {
+  type: 'visa' | 'mastercard' | 'paypal';
+  styles: PaymentMethodsScreenStyles;
+}) {
+  const getGradientColors = (): [string, string] => {
     switch (type) {
       case 'visa':
         return ['#1A1F71', '#3b5998'];
@@ -72,11 +424,12 @@ const CardIcon: React.FC<{ type: 'visa' | 'mastercard' | 'paypal' }> = ({ type }
       </LinearGradient>
     </View>
   );
-};
+}
 
 export default function PaymentMethodsScreen() {
   const router = useRouter();
-  const colors = useThemeColors();
+  const theme = useThemeColors();
+  const styles = useMemo(() => createPaymentMethodsStyles(theme), [theme]);
   const insets = useSafeAreaInsets();
 
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
@@ -175,23 +528,23 @@ export default function PaymentMethodsScreen() {
   };
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['bottom']}>
+    <SafeAreaView style={styles.container} edges={['bottom']}>
       {/* Header */}
-      <View style={[styles.header, { paddingTop: insets.top + 20, backgroundColor: colors.background }]}>
+      <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-          <Text style={[styles.backArrow, { color: colors.textPrimary }]}>←</Text>
+          <Text style={styles.backArrow}>←</Text>
         </TouchableOpacity>
-        <Text style={[styles.title, { color: colors.textPrimary }]}>{t('paymentMethods.title')}</Text>
+        <Text style={styles.title}>{t('paymentMethods.title')}</Text>
         <View style={styles.placeholder} />
       </View>
 
       {loadingMethods ? (
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.primary} />
+          <ActivityIndicator size="large" color={theme.primary} />
         </View>
       ) : (
-        <ScrollView 
-          style={[styles.content, { backgroundColor: colors.background }]} 
+        <ScrollView
+          style={styles.content}
           contentContainerStyle={{ paddingBottom: 20 }}
           showsVerticalScrollIndicator={false}
         >
@@ -216,23 +569,19 @@ export default function PaymentMethodsScreen() {
               {/* Card Item */}
               <TouchableOpacity
                 onPress={() => setSelectedCardId(selectedCardId === method.id ? null : method.id)}
-                style={[
-                  styles.cardItem,
-                  { backgroundColor: colors.card },
-                  selectedCardId === method.id && [styles.cardItemSelected, { borderColor: colors.primary }],
-                ]}
+                style={[styles.cardItem, selectedCardId === method.id && styles.cardItemSelected]}
                 activeOpacity={0.7}
               >
-                <CardIcon type={method.type} />
+                <CardIcon type={method.type} styles={styles} />
                 <View style={styles.cardInfo}>
                   <View style={styles.cardHeader}>
-                    <Text style={[styles.cardNumber, { color: colors.textPrimary }]}>
+                    <Text style={styles.cardNumber}>
                       {method.last4 ? `•••• •••• •••• ${method.last4}` : method.email}
                     </Text>
                   </View>
                   <View style={styles.cardDetails}>
                     {method.expiry && (
-                      <Text style={[styles.cardExpiry, { color: colors.textSecondary }]}>
+                      <Text style={styles.cardExpiry}>
                         {t('paymentMethods.expires')} {method.expiry}
                       </Text>
                     )}
@@ -243,15 +592,7 @@ export default function PaymentMethodsScreen() {
                     )}
                   </View>
                 </View>
-                <Text
-                  style={[
-                    styles.chevron,
-                    { color: colors.textSecondary },
-                    selectedCardId === method.id && styles.chevronRotated,
-                  ]}
-                >
-                  ›
-                </Text>
+                <Text style={[styles.chevron, selectedCardId === method.id && styles.chevronRotated]}>›</Text>
               </TouchableOpacity>
 
               {/* Expanded Actions */}
@@ -279,17 +620,13 @@ export default function PaymentMethodsScreen() {
           ))}
 
           {/* Add New Card Button */}
-          <TouchableOpacity
-            onPress={() => setShowAddCard(true)}
-            style={[styles.addCardButton, { borderColor: colors.border }]}
-            activeOpacity={0.7}
-          >
-            <View style={[styles.addCardIcon, { backgroundColor: colors.surfaceSecondary }]}>
-              <Text style={[styles.addCardIconText, { color: colors.primary }]}>+</Text>
+          <TouchableOpacity onPress={() => setShowAddCard(true)} style={styles.addCardButton} activeOpacity={0.7}>
+            <View style={styles.addCardIcon}>
+              <Text style={styles.addCardIconText}>+</Text>
             </View>
             <View style={styles.addCardInfo}>
-              <Text style={[styles.addCardTitle, { color: colors.primary }]}>{t('paymentMethods.addNewCard')}</Text>
-              <Text style={[styles.addCardSubtitle, { color: colors.textSecondary }]}>{t('paymentMethods.creditOrDebit')}</Text>
+              <Text style={styles.addCardTitle}>{t('paymentMethods.addNewCard')}</Text>
+              <Text style={styles.addCardSubtitle}>{t('paymentMethods.creditOrDebit')}</Text>
             </View>
           </TouchableOpacity>
         </View>
@@ -299,8 +636,8 @@ export default function PaymentMethodsScreen() {
           <Text style={styles.acceptedTitle}>{t('paymentMethods.accepted')}</Text>
           <View style={styles.acceptedCards}>
             {['Visa', 'Mastercard', 'PayPal', 'Amex'].map((brand) => (
-              <View key={brand} style={[styles.acceptedCard, { backgroundColor: colors.card }]}>
-                <Text style={[styles.acceptedCardText, { color: colors.textSecondary }]}>{brand}</Text>
+              <View key={brand} style={styles.acceptedCard}>
+                <Text style={styles.acceptedCardText}>{brand}</Text>
               </View>
             ))}
           </View>
@@ -324,19 +661,19 @@ export default function PaymentMethodsScreen() {
         onRequestClose={() => setShowDeleteConfirm(null)}
       >
         <View style={styles.modalOverlay}>
-          <View style={[styles.deleteModalContent, { backgroundColor: colors.card }]}>
+          <View style={styles.deleteModalContent}>
             <View style={styles.deleteIconContainer}>
               <Text style={styles.deleteIcon}>🗑️</Text>
             </View>
-            <Text style={[styles.deleteModalTitle, { color: colors.textPrimary }]}>{t('paymentMethods.deleteCard')}</Text>
-            <Text style={[styles.deleteModalText, { color: colors.textSecondary }]}>{t('paymentMethods.deleteConfirm')}</Text>
+            <Text style={styles.deleteModalTitle}>{t('paymentMethods.deleteCard')}</Text>
+            <Text style={styles.deleteModalText}>{t('paymentMethods.deleteConfirm')}</Text>
             <View style={styles.deleteModalButtons}>
               <TouchableOpacity
                 onPress={() => setShowDeleteConfirm(null)}
-                style={[styles.modalButtonCancel, { backgroundColor: colors.surfaceSecondary }]}
+                style={styles.modalButtonCancel}
                 activeOpacity={0.7}
               >
-                <Text style={[styles.modalButtonTextCancel, { color: colors.textPrimary }]}>{t('common.cancel')}</Text>
+                <Text style={styles.modalButtonTextCancel}>{t('common.cancel')}</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 onPress={() => showDeleteConfirm && handleDelete(showDeleteConfirm)}
@@ -361,334 +698,4 @@ export default function PaymentMethodsScreen() {
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingBottom: 20,
-    gap: 16,
-  },
-  backButton: {
-    padding: 4,
-  },
-  backArrow: {
-    color: '#ffffff',
-    fontSize: 24,
-  },
-  title: {
-    flex: 1,
-    color: '#ffffff',
-    fontSize: 20,
-    fontWeight: '600',
-  },
-  placeholder: {
-    width: 32,
-  },
-  content: {
-    flex: 1,
-  },
-  securityBadge: {
-    marginHorizontal: 20,
-    marginBottom: 20,
-    padding: 14,
-    paddingHorizontal: 16,
-    backgroundColor: '#10b98115',
-    borderRadius: 12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    borderWidth: 1,
-    borderColor: '#10b98130',
-  },
-  shieldIcon: {
-    fontSize: 20,
-  },
-  securityBadgeContent: {
-    flex: 1,
-  },
-  securityBadgeTitle: {
-    color: '#10b981',
-    fontSize: 13,
-    fontWeight: '600',
-    marginBottom: 2,
-  },
-  securityBadgeText: {
-    color: '#9ca3af',
-    fontSize: 11,
-  },
-  sectionTitleContainer: {
-    paddingHorizontal: 20,
-    paddingBottom: 12,
-  },
-  sectionTitle: {
-    color: '#9ca3af',
-    fontSize: 12,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-  },
-  paymentMethodsContainer: {
-    paddingHorizontal: 20,
-  },
-  cardItem: {
-    backgroundColor: '#252542',
-    borderRadius: 14,
-    padding: 16,
-    marginBottom: 12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 14,
-    borderWidth: 2,
-    borderColor: 'transparent',
-  },
-  cardItemSelected: {
-    borderColor: '#3b82f6',
-  },
-  cardIconContainer: {
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    elevation: 3,
-  },
-  cardIcon: {
-    width: 56,
-    height: 40,
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  cardIconText: {
-    color: '#ffffff',
-    fontSize: 10,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  cardInfo: {
-    flex: 1,
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 4,
-  },
-  cardNumber: {
-    color: '#ffffff',
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  cardDetails: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  cardExpiry: {
-    color: '#9ca3af',
-    fontSize: 13,
-  },
-  defaultBadge: {
-    backgroundColor: '#10b98120',
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 4,
-  },
-  defaultBadgeText: {
-    color: '#10b981',
-    fontSize: 10,
-    fontWeight: '600',
-  },
-  chevron: {
-    color: '#9ca3af',
-    fontSize: 18,
-  },
-  chevronRotated: {
-    transform: [{ rotate: '90deg' }],
-  },
-  expandedActions: {
-    flexDirection: 'row',
-    gap: 10,
-    marginTop: -8,
-    marginBottom: 16,
-    paddingHorizontal: 4,
-  },
-  actionButtonPrimary: {
-    flex: 1,
-    padding: 12,
-    backgroundColor: '#3b82f620',
-    borderRadius: 10,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-  },
-  actionButtonDanger: {
-    flex: 1,
-    padding: 12,
-    backgroundColor: '#ef444420',
-    borderRadius: 10,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-  },
-  actionButtonTextPrimary: {
-    color: '#3b82f6',
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  actionButtonTextDanger: {
-    color: '#ef4444',
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  addCardButton: {
-    backgroundColor: 'transparent',
-    borderRadius: 14,
-    padding: 20,
-    paddingHorizontal: 16,
-    marginBottom: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 14,
-    borderWidth: 2,
-    borderStyle: 'dashed',
-    borderColor: '#374151',
-  },
-  addCardIcon: {
-    width: 56,
-    height: 40,
-    backgroundColor: '#2d2d4a',
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  addCardIconText: {
-    color: '#3b82f6',
-    fontSize: 24,
-    fontWeight: '300',
-  },
-  addCardInfo: {
-    flex: 1,
-  },
-  addCardTitle: {
-    color: '#3b82f6',
-    fontSize: 15,
-    fontWeight: '600',
-    marginBottom: 2,
-  },
-  addCardSubtitle: {
-    color: '#9ca3af',
-    fontSize: 12,
-  },
-  acceptedSection: {
-    padding: 20,
-    borderTopWidth: 1,
-    borderTopColor: '#374151',
-    marginTop: 10,
-  },
-  acceptedTitle: {
-    color: '#9ca3af',
-    fontSize: 12,
-    marginBottom: 12,
-    textAlign: 'center',
-  },
-  acceptedCards: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    gap: 12,
-  },
-  acceptedCard: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    backgroundColor: '#252542',
-    borderRadius: 8,
-  },
-  acceptedCardText: {
-    color: '#9ca3af',
-    fontSize: 11,
-    fontWeight: '600',
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.7)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  modalButtonCancel: {
-    flex: 1,
-    padding: 18,
-    backgroundColor: '#252542',
-    borderRadius: 14,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  modalButtonTextCancel: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#ffffff',
-  },
-  deleteModalContent: {
-    width: '100%',
-    backgroundColor: '#252542',
-    borderRadius: 20,
-    padding: 24,
-    alignItems: 'center',
-    margin: 20,
-  },
-  deleteIconContainer: {
-    width: 60,
-    height: 60,
-    backgroundColor: '#ef444420',
-    borderRadius: 30,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 16,
-  },
-  deleteIcon: {
-    fontSize: 28,
-  },
-  deleteModalTitle: {
-    color: '#ffffff',
-    fontSize: 18,
-    fontWeight: '700',
-    marginBottom: 8,
-    textAlign: 'center',
-  },
-  deleteModalText: {
-    color: '#9ca3af',
-    fontSize: 14,
-    marginBottom: 24,
-    textAlign: 'center',
-    lineHeight: 20,
-  },
-  deleteModalButtons: {
-    flexDirection: 'row',
-    gap: 12,
-    width: '100%',
-  },
-  modalButtonDelete: {
-    flex: 1,
-    padding: 16,
-    backgroundColor: '#ef4444',
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  modalButtonTextDelete: {
-    fontSize: 15,
-    fontWeight: '700',
-    color: '#ffffff',
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});
 

--- a/app/account/security.tsx
+++ b/app/account/security.tsx
@@ -236,7 +236,7 @@ export default function ClientSecurityScreen() {
         {updating ? <ActivityIndicator size="small" color={colors.primary} style={{ width: 32 }} /> : <View style={styles.headerPlaceholder} />}
       </View>
 
-      <ScrollView style={styles.scroll} contentContainerStyle={[styles.scrollContent, { paddingBottom: 40 + insets.bottom }]} showsVerticalScrollIndicator={false}>
+      <ScrollView style={[styles.scroll, { backgroundColor: colors.background }]} contentContainerStyle={[styles.scrollContent, { paddingBottom: 40 + insets.bottom }]} showsVerticalScrollIndicator={false}>
         <Text style={[styles.sectionTitle, { color: colors.textTertiary }]}>{t(`${I18N}.sectionPassword`)}</Text>
         <TouchableOpacity style={[styles.card, { backgroundColor: colors.card, borderColor: colors.cardBorder }]} activeOpacity={0.8} onPress={handleChangePassword}>
           <View style={[styles.iconBox, { backgroundColor: `${colors.primary}20` }]}>

--- a/app/booking/address.tsx
+++ b/app/booking/address.tsx
@@ -27,7 +27,7 @@ export default function BookingAddressScreen() {
   const themeColors = useThemeColors();
   const colors = useMemo(
     () => ({
-      bg: themeColors.background,
+      bg: themeColors.screenBackground,
       bgCard: themeColors.card,
       bgInput: themeColors.surfaceSecondary,
       primary: themeColors.primary,
@@ -36,8 +36,10 @@ export default function BookingAddressScreen() {
       danger: '#ef4444',
       purple: themeColors.primary,
       pink: '#ec4899',
+      textPrimary: themeColors.textPrimary,
       textSecondary: themeColors.textSecondary,
       border: themeColors.border,
+      cardBorder: themeColors.cardBorder,
       white: '#ffffff',
     }),
     [themeColors]
@@ -68,11 +70,11 @@ export default function BookingAddressScreen() {
           alignItems: 'center',
           justifyContent: 'center',
         },
-        backArrow: { fontSize: 24, color: colors.white },
+        backArrow: { fontSize: 24, color: colors.textPrimary },
         headerTitle: {
           fontSize: 20,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
         },
         scrollView: { flex: 1 },
         mapContainer: {
@@ -83,6 +85,8 @@ export default function BookingAddressScreen() {
           borderRadius: 16,
           overflow: 'hidden',
           position: 'relative',
+          borderWidth: 1,
+          borderColor: colors.cardBorder,
         },
         mapContent: {
           flex: 1,
@@ -100,7 +104,7 @@ export default function BookingAddressScreen() {
         sectionTitle: {
           fontSize: 16,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
           marginBottom: 16,
         },
         addressCard: {
@@ -111,10 +115,11 @@ export default function BookingAddressScreen() {
           flexDirection: 'row',
           alignItems: 'center',
           gap: 14,
-          borderWidth: 2,
-          borderColor: 'transparent',
+          borderWidth: 1,
+          borderColor: colors.cardBorder,
         },
         addressCardSelected: {
+          borderWidth: 2,
           borderColor: colors.primary,
           backgroundColor: `${colors.primary}20`,
         },
@@ -137,7 +142,7 @@ export default function BookingAddressScreen() {
         addressName: {
           fontSize: 16,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
         },
         defaultBadge: {
           backgroundColor: `${colors.secondary}20`,
@@ -198,7 +203,7 @@ export default function BookingAddressScreen() {
         emptyText: {
           fontSize: 18,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
           marginTop: 16,
           marginBottom: 8,
         },
@@ -227,6 +232,19 @@ export default function BookingAddressScreen() {
           paddingHorizontal: 20,
           paddingTop: 20,
           backgroundColor: colors.bg,
+          borderTopWidth: 1,
+          borderTopColor: colors.border,
+          ...Platform.select({
+            ios: {
+              shadowColor: '#000',
+              shadowOffset: { width: 0, height: -2 },
+              shadowOpacity: 0.08,
+              shadowRadius: 4,
+            },
+            android: {
+              elevation: 6,
+            },
+          }),
         },
         continueButton: {
           width: '100%',
@@ -291,7 +309,7 @@ export default function BookingAddressScreen() {
           marginBottom: 20,
         },
         modalTitle: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 20,
           fontWeight: '700',
           marginBottom: 24,
@@ -319,7 +337,7 @@ export default function BookingAddressScreen() {
           borderWidth: 1,
           borderColor: colors.border,
           borderRadius: 12,
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 15,
         },
         typeButtons: { flexDirection: 'row', gap: 12 },
@@ -339,7 +357,7 @@ export default function BookingAddressScreen() {
           borderColor: colors.primary,
         },
         typeButtonIcon: { fontSize: 20 },
-        typeButtonText: { color: colors.white, fontSize: 14 },
+        typeButtonText: { color: colors.textPrimary, fontSize: 14 },
         typeButtonTextActive: {
           color: colors.primary,
           fontWeight: '600',
@@ -365,7 +383,7 @@ export default function BookingAddressScreen() {
           borderColor: colors.primary,
         },
         defaultToggleText: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 15,
         },
         modalButtons: {
@@ -395,7 +413,7 @@ export default function BookingAddressScreen() {
         modalButtonTextCancel: {
           fontSize: 16,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
         },
         modalButtonTextConfirm: {
           fontSize: 16,

--- a/app/booking/date-time.tsx
+++ b/app/booking/date-time.tsx
@@ -62,7 +62,7 @@ export default function BookingDateTimeScreen() {
   const themeColors = useThemeColors();
   const colors = useMemo(
     () => ({
-      bg: themeColors.background,
+      bg: themeColors.screenBackground,
       bgCard: themeColors.card,
       bgInput: themeColors.surfaceSecondary,
       primary: themeColors.primary,
@@ -71,6 +71,7 @@ export default function BookingDateTimeScreen() {
       danger: '#ef4444',
       purple: themeColors.primary,
       pink: '#ec4899',
+      textPrimary: themeColors.textPrimary,
       textSecondary: themeColors.textSecondary,
       border: themeColors.border,
       white: '#ffffff',
@@ -106,7 +107,7 @@ export default function BookingDateTimeScreen() {
         headerTitle: {
           fontSize: 20,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
         },
         scrollView: {
           flex: 1,
@@ -118,7 +119,7 @@ export default function BookingDateTimeScreen() {
         sectionTitleCentered: {
           fontSize: 16,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
           marginBottom: 16,
           textAlign: 'center',
         },
@@ -299,7 +300,7 @@ export default function BookingDateTimeScreen() {
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-          <Ionicons name="arrow-back" size={24} color={colors.white} />
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>{t('booking.selectDateTime')}</Text>
         <View style={{ width: 40 }} />
@@ -325,7 +326,7 @@ export default function BookingDateTimeScreen() {
             <View style={styles.durationInfoCard}>
               <Ionicons name="time-outline" size={20} color={colors.secondary} />
               <Text style={styles.durationInfoText}>
-                {getServiceDurationHours(service)} {getServiceDurationHours(service) === 1 ? 'hora' : 'horas'}
+                {t('quote.durationHours', { count: getServiceDurationHours(service) })}
               </Text>
             </View>
           </View>

--- a/app/booking/payment/[orderId].tsx
+++ b/app/booking/payment/[orderId].tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -27,15 +28,17 @@ export default function PaymentScreen() {
   const themeColors = useThemeColors();
   const colors = useMemo(
     () => ({
-      bg: themeColors.background,
+      bg: themeColors.screenBackground,
       bgCard: themeColors.card,
       bgInput: themeColors.surfaceSecondary,
       primary: themeColors.primary,
       secondary: '#10b981',
       accent: '#f59e0b',
       danger: '#ef4444',
+      textPrimary: themeColors.textPrimary,
       textSecondary: themeColors.textSecondary,
       border: themeColors.border,
+      cardBorder: themeColors.cardBorder,
       white: '#ffffff',
     }),
     [themeColors]
@@ -62,13 +65,13 @@ export default function PaymentScreen() {
           alignItems: 'center',
           justifyContent: 'center',
         },
-        headerTitle: { fontSize: 20, fontWeight: '600', color: colors.white },
+        headerTitle: { fontSize: 20, fontWeight: '600', color: colors.textPrimary },
         content: { flex: 1 },
         totalContainer: { alignItems: 'center', paddingVertical: 20 },
         totalLabel: { fontSize: 14, color: colors.textSecondary, marginBottom: 8 },
-        totalAmount: { fontSize: 42, fontWeight: '700', color: colors.white },
+        totalAmount: { fontSize: 42, fontWeight: '700', color: colors.textPrimary },
         section: { paddingHorizontal: 20, marginBottom: 20 },
-        sectionTitle: { fontSize: 16, fontWeight: '600', color: colors.white, marginBottom: 16 },
+        sectionTitle: { fontSize: 16, fontWeight: '600', color: colors.textPrimary, marginBottom: 16 },
         emptyState: { padding: 20, alignItems: 'center' },
         emptyStateText: { color: colors.textSecondary, fontSize: 14 },
         paymentMethodCard: {
@@ -78,10 +81,11 @@ export default function PaymentScreen() {
           borderRadius: 14,
           padding: 16,
           marginBottom: 12,
-          borderWidth: 2,
-          borderColor: 'transparent',
+          borderWidth: 1,
+          borderColor: colors.cardBorder,
         },
         paymentMethodCardSelected: {
+          borderWidth: 2,
           backgroundColor: `${colors.primary}20`,
           borderColor: colors.primary,
         },
@@ -99,7 +103,7 @@ export default function PaymentScreen() {
         paymentMethodLabel: {
           fontSize: 15,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
           marginBottom: 4,
         },
         paymentMethodSubtitle: { fontSize: 13, color: colors.textSecondary },
@@ -129,7 +133,24 @@ export default function PaymentScreen() {
           gap: 10,
         },
         securityText: { fontSize: 12, color: colors.textSecondary },
-        footer: { paddingHorizontal: 20, paddingTop: 20, backgroundColor: colors.bg },
+        footer: {
+          paddingHorizontal: 20,
+          paddingTop: 20,
+          backgroundColor: colors.bg,
+          borderTopWidth: 1,
+          borderTopColor: colors.border,
+          ...Platform.select({
+            ios: {
+              shadowColor: '#000',
+              shadowOffset: { width: 0, height: -2 },
+              shadowOpacity: 0.08,
+              shadowRadius: 4,
+            },
+            android: {
+              elevation: 6,
+            },
+          }),
+        },
         confirmButton: {
           backgroundColor: colors.secondary,
           borderRadius: 14,
@@ -338,7 +359,7 @@ export default function PaymentScreen() {
       {/* Header */}
       <View style={styles.header}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-          <Ionicons name="arrow-back" size={24} color={colors.white} />
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>{t('payment.title')}</Text>
         <View style={{ width: 40 }} />

--- a/app/booking/success/[orderId].tsx
+++ b/app/booking/success/[orderId].tsx
@@ -80,13 +80,15 @@ export default function BookingSuccessScreen() {
   const themeColors = useThemeColors();
   const colors = useMemo(
     () => ({
-      bg: themeColors.background,
+      bg: themeColors.screenBackground,
       bgCard: themeColors.card,
       bgInput: themeColors.surfaceSecondary,
       primary: themeColors.primary,
       secondary: '#10b981',
+      textPrimary: themeColors.textPrimary,
       textSecondary: themeColors.textSecondary,
       border: themeColors.border,
+      cardBorder: themeColors.cardBorder,
       white: '#ffffff',
     }),
     [themeColors]
@@ -138,7 +140,7 @@ export default function BookingSuccessScreen() {
         title: {
           fontSize: 28,
           fontWeight: '700',
-          color: colors.white,
+          color: colors.textPrimary,
           textAlign: 'center',
           marginBottom: 12,
         },
@@ -156,6 +158,8 @@ export default function BookingSuccessScreen() {
           borderRadius: 16,
           padding: 20,
           marginBottom: 32,
+          borderWidth: 1,
+          borderColor: colors.cardBorder,
         },
         providerInfo: {
           flexDirection: 'row',
@@ -177,7 +181,7 @@ export default function BookingSuccessScreen() {
         providerName: {
           fontSize: 16,
           fontWeight: '600',
-          color: colors.white,
+          color: colors.textPrimary,
           marginBottom: 2,
         },
         serviceName: { fontSize: 14, color: colors.secondary },
@@ -201,7 +205,7 @@ export default function BookingSuccessScreen() {
         detailValueWrap: { flex: 1, minWidth: 0 },
         detailValue: {
           fontSize: 14,
-          color: colors.white,
+          color: colors.textPrimary,
           fontWeight: '500',
         },
         codeLabel: {
@@ -246,7 +250,7 @@ export default function BookingSuccessScreen() {
           justifyContent: 'center',
         },
         secondaryButtonText: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 16,
           fontWeight: '500',
           textAlign: 'center',

--- a/app/booking/summary.tsx
+++ b/app/booking/summary.tsx
@@ -16,7 +16,7 @@ export default function BookingSummaryScreen() {
   const themeColors = useThemeColors();
   const colors = useMemo(
     () => ({
-      bg: themeColors.background,
+      bg: themeColors.screenBackground,
       bgCard: themeColors.card,
       bgInput: themeColors.surfaceSecondary,
       primary: themeColors.primary,
@@ -25,8 +25,10 @@ export default function BookingSummaryScreen() {
       danger: '#ef4444',
       purple: themeColors.primary,
       pink: '#ec4899',
+      textPrimary: themeColors.textPrimary,
       textSecondary: themeColors.textSecondary,
       border: themeColors.border,
+      cardBorder: themeColors.cardBorder,
       white: '#ffffff',
     }),
     [themeColors]
@@ -56,7 +58,7 @@ export default function BookingSummaryScreen() {
         },
         backButton: { padding: 4 },
         headerTitle: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 20,
           fontWeight: "600",
         },
@@ -73,9 +75,11 @@ export default function BookingSummaryScreen() {
           padding: 16,
           marginHorizontal: 20,
           marginBottom: 16,
+          borderWidth: 1,
+          borderColor: colors.cardBorder,
         },
         cardTitle: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 16,
           fontWeight: "600",
           marginBottom: 16,
@@ -107,7 +111,7 @@ export default function BookingSummaryScreen() {
           marginBottom: 4,
         },
         providerName: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 18,
           fontWeight: "600",
         },
@@ -131,7 +135,7 @@ export default function BookingSummaryScreen() {
           fontSize: 14,
         },
         detailValue: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 14,
           textAlign: "right",
           maxWidth: 180,
@@ -144,7 +148,7 @@ export default function BookingSummaryScreen() {
           borderWidth: 1,
           borderColor: colors.border,
           borderRadius: 12,
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 14,
           minHeight: 80,
           textAlignVertical: "top",
@@ -159,7 +163,7 @@ export default function BookingSummaryScreen() {
           fontSize: 14,
         },
         priceValue: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 14,
         },
         discountLabel: { color: colors.secondary },
@@ -176,7 +180,7 @@ export default function BookingSummaryScreen() {
           alignItems: "center",
         },
         totalLabel: {
-          color: colors.white,
+          color: colors.textPrimary,
           fontSize: 16,
           fontWeight: "600",
         },
@@ -195,6 +199,17 @@ export default function BookingSummaryScreen() {
           backgroundColor: colors.bg,
           borderTopWidth: 1,
           borderTopColor: colors.border,
+          ...Platform.select({
+            ios: {
+              shadowColor: "#000",
+              shadowOffset: { width: 0, height: -2 },
+              shadowOpacity: 0.08,
+              shadowRadius: 4,
+            },
+            android: {
+              elevation: 6,
+            },
+          }),
         },
         ctaButton: {
           width: "100%",
@@ -413,7 +428,7 @@ export default function BookingSummaryScreen() {
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-          <Ionicons name="arrow-back" size={24} color={colors.white} />
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>{t("booking.confirmReservation")}</Text>
       </View>

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { useMode } from "@/contexts/ModeContext";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { ProviderAvatar } from "@/components/ProviderAvatar";
@@ -49,6 +50,7 @@ export default function ChatScreen() {
   const { conversationId, navRef } = useLocalSearchParams<{ conversationId: string; navRef?: string }>();
   const { user } = useAuth();
   const { mode } = useMode();
+  const colorScheme = useColorScheme();
   const themeColors = useThemeColors();
   const insets = useSafeAreaInsets();
   const isProvider = mode === "provider";
@@ -114,7 +116,11 @@ export default function ChatScreen() {
           backgroundColor: "#8B5CF6",
         },
         quoteHeaderBtnView: { backgroundColor: "rgba(139, 92, 246, 0.25)" },
-        quoteHeaderBtnText: { fontSize: 11, fontWeight: "600", color: "#FFFFFF" },
+        quoteHeaderBtnText: {
+          fontSize: 11,
+          fontWeight: "600",
+          color: colorScheme === "light" ? "#5B21B6" : "#FFFFFF",
+        },
         quoteBanner: {
           flexDirection: "row",
           alignItems: "center",
@@ -137,7 +143,11 @@ export default function ChatScreen() {
         },
         quoteBannerContent: { flex: 1 },
         quoteBannerTitle: { fontSize: 14, fontWeight: "600", color: colors.textPrimary },
-        quoteBannerSub: { fontSize: 12, color: colors.textMuted40, marginTop: 2 },
+        quoteBannerSub: {
+          fontSize: 12,
+          color: colorScheme === "light" ? colors.textSecondary : colors.textMuted40,
+          marginTop: 2,
+        },
         headerAvatar: { width: 40, height: 40, borderRadius: 20 },
         headerAvatarPlaceholder: {
           width: 40,
@@ -181,11 +191,15 @@ export default function ChatScreen() {
           borderRadius: 999,
           backgroundColor: "rgba(139, 92, 246, 0.3)",
         },
-        jobBannerBadgeText: { fontSize: 10, fontWeight: "600", color: "#C4B5FD" },
+        jobBannerBadgeText: {
+          fontSize: 10,
+          fontWeight: "600",
+          color: colorScheme === "light" ? "#5B21B6" : "#C4B5FD",
+        },
         dateContainer: { alignItems: "center", marginBottom: 12 },
         dateText: {
           fontSize: 10,
-          color: colors.textMuted,
+          color: colorScheme === "light" ? colors.textSecondary : colors.textMuted,
           backgroundColor: colors.chipBg,
           paddingHorizontal: 12,
           paddingVertical: 4,
@@ -227,7 +241,7 @@ export default function ChatScreen() {
         bubbleReceived: { backgroundColor: colors.receivedBubble },
         bubbleSent: { backgroundColor: "#8B5CF6", borderTopLeftRadius: 16, borderTopRightRadius: 4 },
         bubbleText: { fontSize: 14, color: colors.textSecondary },
-        bubbleTextSent: { color: colors.textPrimary },
+        bubbleTextSent: { color: "#FFFFFF" },
         bubbleTime: { fontSize: 10, color: colors.textMuted, marginTop: 4, marginLeft: 8 },
         bubbleTimeRight: { marginLeft: 0, marginRight: 8, textAlign: "right" },
         imageInBubble: { width: 200, height: 160, borderRadius: 12 },
@@ -244,7 +258,10 @@ export default function ChatScreen() {
           borderRadius: 999,
           backgroundColor: colors.chipBg,
         },
-        quickActionChipText: { fontSize: 12, color: colors.textMuted40 },
+        quickActionChipText: {
+          fontSize: 12,
+          color: colorScheme === "light" ? colors.textSecondary : colors.textMuted40,
+        },
         inputWrap: {
           flexDirection: "row",
           alignItems: "center",
@@ -283,7 +300,7 @@ export default function ChatScreen() {
         sendBtnDisabled: { backgroundColor: colors.border, opacity: 0.6 },
         errorText: { fontSize: 14, color: "#EF4444", marginBottom: 12 },
         retryBtn: { backgroundColor: "#8B5CF6", paddingHorizontal: 20, paddingVertical: 10, borderRadius: 8 },
-        retryText: { color: colors.textPrimary, fontSize: 14, fontWeight: "600" },
+        retryText: { color: "#FFFFFF", fontSize: 14, fontWeight: "600" },
         imageModalOverlay: {
           flex: 1,
           backgroundColor: "rgba(0,0,0,0.9)",
@@ -292,7 +309,7 @@ export default function ChatScreen() {
         },
         imageModalImage: { width: "100%", height: "80%" },
       }),
-    [colors]
+    [colors, colorScheme]
   );
 
   const clientStyles = React.useMemo(
@@ -322,7 +339,7 @@ export default function ChatScreen() {
           alignItems: "center",
         },
         quoteBannerContent: { flex: 1 },
-        quoteBannerTitle: { fontSize: 14, fontWeight: "600", color: "#FFFFFF" },
+        quoteBannerTitle: { fontSize: 14, fontWeight: "600", color: colors.textPrimary },
         quoteBannerSub: { fontSize: 12, color: colors.textSecondary, marginTop: 2 },
         header: {
           flexDirection: "row",
@@ -923,7 +940,7 @@ export default function ChatScreen() {
                 ${getQuoteDisplayTotal(activeQuote!).toFixed(2)} • {t(`chat.quoteStatus_${activeQuote!.status}`)}
               </Text>
             </View>
-            <Ionicons name="chevron-forward" size={18} color="rgba(255,255,255,0.4)" />
+            <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
           </TouchableOpacity>
         )}
         <KeyboardAvoidingView style={clientStyles.flex} behavior={Platform.OS === "ios" ? "padding" : undefined} keyboardVerticalOffset={Platform.OS === "ios" ? insets.top + 80 : 0} enabled={Platform.OS === "ios"}>
@@ -1000,7 +1017,11 @@ export default function ChatScreen() {
           onPress={showQuoteBanner ? handleViewQuote : hasActiveOrder ? handleViewOrder : hasActiveQuote ? handleViewQuote : handleCreateQuote}
           style={[styles.quoteHeaderBtn, (hasActiveOrder || hasActiveQuote) && styles.quoteHeaderBtnView]}
         >
-          <Ionicons name={showQuoteBanner ? "eye-outline" : hasActiveOrder ? "briefcase-outline" : hasActiveQuote ? "eye-outline" : "document-text-outline"} size={16} color={colors.textPrimary} />
+          <Ionicons
+            name={showQuoteBanner ? "eye-outline" : hasActiveOrder ? "briefcase-outline" : hasActiveQuote ? "eye-outline" : "document-text-outline"}
+            size={16}
+            color={(hasActiveOrder || hasActiveQuote) && colorScheme === "light" ? "#5B21B6" : "#FFFFFF"}
+          />
           <Text style={styles.quoteHeaderBtnText}>
             {showQuoteBanner ? t("chat.viewQuote") : hasActiveOrder ? t("chat.viewOrder") : hasActiveQuote ? t("chat.viewQuote") : t("createQuote.createQuoteButton")}
           </Text>
@@ -1048,7 +1069,7 @@ export default function ChatScreen() {
               ${getQuoteDisplayTotal(activeQuote!).toFixed(2)} • {t(`chat.quoteStatus_${activeQuote!.status}`)}
             </Text>
           </View>
-          <Ionicons name="chevron-forward" size={18} color="rgba(255,255,255,0.4)" />
+          <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
         </TouchableOpacity>
       )}
 

--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -8,7 +8,6 @@ import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  Image,
   RefreshControl,
   StyleSheet,
   Text,
@@ -21,6 +20,176 @@ export default function ConversationsListScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: colors.screenBackground,
+        },
+        header: {
+          paddingHorizontal: 20,
+          paddingBottom: 20,
+          backgroundColor: colors.card,
+        },
+        headerTitle: {
+          fontSize: 28,
+          fontWeight: '700',
+          color: colors.textPrimary,
+        },
+        centerContainer: {
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: 20,
+          backgroundColor: colors.screenBackground,
+        },
+        listWrapper: {
+          flex: 1,
+          backgroundColor: colors.screenBackground,
+        },
+        listContent: {
+          paddingHorizontal: 20,
+          paddingVertical: 20,
+          backgroundColor: colors.screenBackground,
+        },
+        conversationItem: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingVertical: 14,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.cardBorder,
+          backgroundColor: colors.screenBackground,
+        },
+        conversationItemLast: {
+          borderBottomWidth: 0,
+        },
+        avatarContainer: {
+          position: 'relative',
+          marginRight: 14,
+        },
+        avatar: {
+          width: 56,
+          height: 56,
+          borderRadius: 28,
+        },
+        avatarPlaceholder: {
+          width: 56,
+          height: 56,
+          borderRadius: 28,
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: colors.surfaceSecondary,
+        },
+        avatarEmoji: {
+          fontSize: 24,
+        },
+        onlineIndicator: {
+          position: 'absolute',
+          bottom: 2,
+          right: 2,
+          width: 14,
+          height: 14,
+          borderRadius: 7,
+          borderWidth: 3,
+          backgroundColor: '#10b981',
+          borderColor: colors.screenBackground,
+        },
+        unreadBadge: {
+          minWidth: 20,
+          height: 20,
+          borderRadius: 10,
+          justifyContent: 'center',
+          alignItems: 'center',
+          paddingHorizontal: 6,
+          backgroundColor: colors.primary,
+        },
+        unreadBadgeCircular: {
+          width: 20,
+          minWidth: 20,
+          paddingHorizontal: 0,
+        },
+        unreadText: {
+          color: '#FFFFFF',
+          fontSize: 11,
+          fontWeight: '600',
+        },
+        conversationContent: {
+          flex: 1,
+          justifyContent: 'center',
+        },
+        conversationHeader: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 4,
+        },
+        userName: {
+          fontSize: 16,
+          fontWeight: '600',
+          color: colors.textPrimary,
+        },
+        userNameBold: {
+          fontWeight: '600',
+        },
+        timeText: {
+          fontSize: 12,
+          textAlign: 'right',
+          color: colors.textTertiary,
+        },
+        timeTextUnread: {
+          color: colors.primary,
+        },
+        lastMessageRow: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        },
+        lastMessage: {
+          fontSize: 14,
+          flex: 1,
+          marginRight: 8,
+          maxWidth: 200,
+          color: colors.textTertiary,
+        },
+        lastMessageUnread: {
+          color: colors.textPrimary,
+          fontWeight: '500',
+        },
+        emptyTitle: {
+          fontSize: 18,
+          fontWeight: '600',
+          marginTop: 16,
+          color: colors.textPrimary,
+        },
+        emptySubtitle: {
+          fontSize: 14,
+          textAlign: 'center',
+          marginTop: 8,
+          paddingHorizontal: 40,
+          color: colors.textTertiary,
+        },
+        errorText: {
+          fontSize: 16,
+          textAlign: 'center',
+          marginBottom: 16,
+          color: '#EF4444',
+        },
+        retryButton: {
+          backgroundColor: colors.primary,
+          paddingHorizontal: 24,
+          paddingVertical: 12,
+          borderRadius: 8,
+          marginTop: 8,
+        },
+        retryText: {
+          color: '#FFFFFF',
+          fontSize: 16,
+          fontWeight: '600',
+        },
+      }),
+    [colors]
+  );
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -138,11 +307,7 @@ export default function ConversationsListScreen() {
     
     return (
       <TouchableOpacity
-        style={[
-          styles.conversationItem, 
-          { backgroundColor: colors.background, borderBottomColor: colors.cardBorder },
-          isLastItem && styles.conversationItemLast
-        ]}
+        style={[styles.conversationItem, isLastItem && styles.conversationItemLast]}
         onPress={() => handleConversationPress(item.id)}
         activeOpacity={0.7}
       >
@@ -153,37 +318,27 @@ export default function ConversationsListScreen() {
             rounded
             style={styles.avatar}
           />
-          {isOnline && (
-            <View style={[styles.onlineIndicator, { borderColor: colors.background }]} />
-          )}
+          {isOnline && <View style={styles.onlineIndicator} />}
         </View>
 
         <View style={styles.conversationContent}>
           <View style={styles.conversationHeader}>
-            <Text style={[styles.userName, { color: colors.textPrimary }, item.unread_count > 0 && styles.userNameBold]}>
+            <Text style={[styles.userName, item.unread_count > 0 && styles.userNameBold]}>
               {item.other_user_name}
             </Text>
-            <Text style={[styles.timeText, { color: item.unread_count > 0 ? colors.primary : colors.textTertiary }]}>
+            <Text style={[styles.timeText, item.unread_count > 0 && styles.timeTextUnread]}>
               {formatTime(item.last_message_at)}
             </Text>
           </View>
           <View style={styles.lastMessageRow}>
             <Text
-              style={[
-                styles.lastMessage,
-                { color: item.unread_count > 0 ? colors.textPrimary : colors.textTertiary },
-                item.unread_count > 0 && styles.lastMessageUnread,
-              ]}
+              style={[styles.lastMessage, item.unread_count > 0 && styles.lastMessageUnread]}
               numberOfLines={1}
             >
               {item.last_message || t('chat.noMessages')}
             </Text>
             {item.unread_count > 0 && (
-              <View style={[
-                styles.unreadBadge, 
-                { backgroundColor: colors.primary },
-                item.unread_count < 10 && styles.unreadBadgeCircular
-              ]}>
+              <View style={[styles.unreadBadge, item.unread_count < 10 && styles.unreadBadgeCircular]}>
                 <Text style={styles.unreadText}>
                   {item.unread_count > 9 ? '9+' : item.unread_count}
                 </Text>
@@ -199,11 +354,11 @@ export default function ConversationsListScreen() {
 
   if (loading) {
     return (
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <View style={[styles.header, { paddingTop: insets.top + 20, backgroundColor: colors.card }]}>
-          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t('chat.messages')}</Text>
+      <View style={styles.container}>
+        <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
+          <Text style={styles.headerTitle}>{t('chat.messages')}</Text>
         </View>
-        <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <View style={styles.centerContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </View>
@@ -211,35 +366,33 @@ export default function ConversationsListScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <View style={[styles.header, { paddingTop: insets.top + 20, backgroundColor: colors.card }]}>
-        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t('chat.messages')}</Text>
+    <View style={styles.container}>
+      <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
+        <Text style={styles.headerTitle}>{t('chat.messages')}</Text>
       </View>
 
       {error ? (
-        <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <View style={styles.centerContainer}>
           <Text style={styles.errorText}>{error}</Text>
-          <TouchableOpacity style={[styles.retryButton, { backgroundColor: colors.primary }]} onPress={loadConversations}>
+          <TouchableOpacity style={styles.retryButton} onPress={loadConversations}>
             <Text style={styles.retryText}>{t('chat.retry')}</Text>
           </TouchableOpacity>
         </View>
       ) : conversations.length === 0 ? (
-        <View style={[styles.centerContainer, { backgroundColor: colors.background }]}>
+        <View style={styles.centerContainer}>
           <Ionicons name="chatbubbles-outline" size={64} color={colors.textTertiary} />
-          <Text style={[styles.emptyTitle, { color: colors.textPrimary }]}>{t('chat.noMessages')}</Text>
-          <Text style={[styles.emptySubtitle, { color: colors.textTertiary }]}>
-            {t('chat.noMessagesDesc')}
-          </Text>
+          <Text style={styles.emptyTitle}>{t('chat.noMessages')}</Text>
+          <Text style={styles.emptySubtitle}>{t('chat.noMessagesDesc')}</Text>
         </View>
       ) : (
-        <View style={{ flex: 1, backgroundColor: colors.background }}>
+        <View style={styles.listWrapper}>
           <FlashList
             data={conversations}
             keyExtractor={(item) => item.id}
             renderItem={renderConversation}
             estimatedItemSize={estimatedItemSize}
-            style={{ flex: 1, backgroundColor: colors.background }}
-            contentContainerStyle={{ paddingHorizontal: 20, paddingVertical: 20, paddingBottom: 20 + insets.bottom, backgroundColor: colors.background }}
+            style={styles.listWrapper}
+            contentContainerStyle={[styles.listContent, { paddingBottom: 20 + insets.bottom }]}
             refreshControl={
               <RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[colors.primary]} />
             }
@@ -249,174 +402,4 @@ export default function ConversationsListScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#1a1a2e', // Hardcode dark background like Home
-  },
-  header: {
-    paddingHorizontal: 20,
-    paddingTop: 20,
-    paddingBottom: 20,
-    backgroundColor: '#252542', // Hardcode dark header
-  },
-  headerTitle: {
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#FFFFFF', // Hardcode white text
-  },
-  centerContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-    backgroundColor: '#1a1a2e', // Hardcode dark background
-  },
-  listContainer: {
-    flex: 1,
-    backgroundColor: '#1a1a2e', // Hardcode dark background for list container
-  },
-  listContent: {
-    paddingHorizontal: 20,
-    paddingVertical: 0,
-    backgroundColor: '#1a1a2e', // Hardcode dark background for list
-  },
-  conversationItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-    borderBottomWidth: 1,
-    borderBottomColor: '#374151', // Hardcode dark border
-    backgroundColor: '#1a1a2e', // Hardcode dark background for each item
-  },
-  conversationItemLast: {
-    borderBottomWidth: 0,
-  },
-  avatarContainer: {
-    position: 'relative',
-    marginRight: 14,
-  },
-  avatar: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-  },
-  avatarPlaceholder: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#252542', // Hardcode dark header background
-  },
-  avatarEmoji: {
-    fontSize: 24,
-  },
-  onlineIndicator: {
-    position: 'absolute',
-    bottom: 2,
-    right: 2,
-    width: 14,
-    height: 14,
-    borderRadius: 7,
-    borderWidth: 3,
-    backgroundColor: '#10b981', // Hardcode secondary color
-    borderColor: '#1a1a2e', // Hardcode dark background
-  },
-  unreadBadge: {
-    minWidth: 20,
-    height: 20,
-    borderRadius: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 6,
-    backgroundColor: '#3b82f6', // Hardcode primary color
-  },
-  unreadBadgeCircular: {
-    width: 20,
-    minWidth: 20,
-    paddingHorizontal: 0,
-    borderRadius: 10, // Keep circular shape
-  },
-  unreadText: {
-    color: '#FFFFFF',
-    fontSize: 11,
-    fontWeight: '600',
-  },
-  conversationContent: {
-    flex: 1,
-    justifyContent: 'center',
-  },
-  conversationHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  userName: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#FFFFFF', // Hardcode white text
-  },
-  userNameBold: {
-    fontWeight: '600',
-  },
-  timeText: {
-    fontSize: 12,
-    textAlign: 'right',
-    color: '#9ca3af', // Hardcode secondary text
-  },
-  timeTextUnread: {
-    color: '#3b82f6', // Hardcode primary color for unread
-  },
-  lastMessageRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  lastMessage: {
-    fontSize: 14,
-    flex: 1,
-    marginRight: 8,
-    maxWidth: 200,
-    color: '#9ca3af', // Hardcode secondary text
-  },
-  lastMessageUnread: {
-    color: '#FFFFFF', // Hardcode white text for unread
-    fontWeight: '500',
-  },
-  emptyTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    marginTop: 16,
-    color: '#FFFFFF', // Hardcode white text
-  },
-  emptySubtitle: {
-    fontSize: 14,
-    textAlign: 'center',
-    marginTop: 8,
-    paddingHorizontal: 40,
-    color: '#9ca3af', // Hardcode secondary text
-  },
-  errorText: {
-    fontSize: 16,
-    textAlign: 'center',
-    marginBottom: 16,
-    color: '#EF4444', // Hardcode error color
-  },
-  retryButton: {
-    backgroundColor: '#3b82f6',
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
-    marginTop: 8,
-  },
-  retryText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});
-
 

--- a/app/orders/[orderId].tsx
+++ b/app/orders/[orderId].tsx
@@ -1,10 +1,12 @@
+import { useColorScheme } from '@/hooks/use-color-scheme';
 import { t } from '@/i18n';
 import { getOrCreateConversation } from '@/services/conversations';
 import { fetchOrderDetail, OrderDetailResponse, updateOrderStatus } from '@/services/orders';
 import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Ionicons } from '@expo/vector-icons';
+import { getThemeColors, type ThemeColors } from '@/utils/themeStyles';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -27,10 +29,322 @@ interface ProgressStep {
   timestamp?: string;
 }
 
+function createOrderDetailStyles(theme: ThemeColors) {
+  return StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.screenBackground,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorText: {
+    color: '#ef4444',
+    fontSize: 16,
+  },
+  greenHeader: {
+    backgroundColor: '#10b981',
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  backButtonGreen: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  greenHeaderTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#fff',
+    flex: 1,
+    marginLeft: 16,
+  },
+  greenSection: {
+    backgroundColor: '#10b981',
+    paddingHorizontal: 20,
+    paddingBottom: 30,
+    borderBottomLeftRadius: 24,
+    borderBottomRightRadius: 24,
+    alignItems: 'center',
+  },
+  serviceIconContainer: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  serviceIcon: {
+    fontSize: 36,
+  },
+  serviceStatusText: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#fff',
+    marginBottom: 8,
+  },
+  estimatedTimeLabel: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginBottom: 8,
+  },
+  estimatedTime: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  content: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  providerCard: {
+    backgroundColor: theme.card,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+  },
+  providerImageContainer: {
+    position: 'relative',
+  },
+  providerImage: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: theme.surfaceSecondary,
+    borderWidth: 3,
+    borderColor: '#10b981',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  providerInfo: {
+    flex: 1,
+  },
+  providerName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: theme.textPrimary,
+    marginBottom: 4,
+  },
+  locationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  locationDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#10b981',
+  },
+  locationText: {
+    fontSize: 14,
+    color: '#10b981',
+  },
+  providerActions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  actionButton: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    backgroundColor: theme.surfaceSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chatButton: {
+    backgroundColor: '#3b82f6',
+  },
+  progressSection: {
+    marginBottom: 20,
+  },
+  progressTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: theme.textPrimary,
+    marginBottom: 20,
+  },
+  timelineItem: {
+    flexDirection: 'row',
+    gap: 16,
+    marginBottom: 20,
+  },
+  timelineIndicator: {
+    alignItems: 'center',
+  },
+  timelineCircle: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: theme.surfaceSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  timelineCircleCompleted: {
+    backgroundColor: '#10b981',
+  },
+  timelineCircleCurrent: {
+    backgroundColor: '#3b82f6',
+    borderWidth: 2,
+    borderColor: '#3b82f6',
+  },
+  timelineLine: {
+    width: 2,
+    height: 30,
+    backgroundColor: theme.border,
+    marginTop: 4,
+  },
+  timelineLineCompleted: {
+    backgroundColor: '#10b981',
+  },
+  timelineContent: {
+    flex: 1,
+  },
+  timelineLabel: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: theme.textPrimary,
+    marginBottom: 4,
+  },
+  timelineTime: {
+    fontSize: 13,
+    color: theme.textSecondary,
+  },
+  detailsSection: {
+    backgroundColor: theme.card,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+  },
+  detailsTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: theme.textPrimary,
+    marginBottom: 12,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+  },
+  detailText: {
+    fontSize: 14,
+    color: theme.textSecondary,
+    flex: 1,
+  },
+  actionButtonsSection: {
+    gap: 12,
+    marginTop: 20,
+  },
+  completePaymentButton: {
+    backgroundColor: '#10B981',
+    padding: 16,
+    borderRadius: 14,
+    alignItems: 'center',
+    minHeight: 52,
+    justifyContent: 'center',
+  },
+  completePaymentButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#fff',
+  },
+  cancelButton: {
+    padding: 16,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: theme.border,
+    alignItems: 'center',
+    minHeight: 52,
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+  },
+  cancelButtonPressed: {
+    backgroundColor: 'rgba(239, 68, 68, 0.1)',
+    borderColor: '#ef4444',
+  },
+  cancelButtonDisabled: {
+    opacity: 0.6,
+  },
+  cancelButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#ef4444',
+  },
+  supportButton: {
+    padding: 16,
+    borderRadius: 14,
+    backgroundColor: theme.card,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+  },
+  supportButtonPressed: {
+    backgroundColor: theme.surfaceSecondary,
+    opacity: 0.8,
+  },
+  supportButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#3b82f6',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingBottom: 16,
+    backgroundColor: theme.card,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.cardBorder,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: theme.textPrimary,
+  },
+  statusText: {
+    fontSize: 16,
+    color: theme.textPrimary,
+    padding: 20,
+  },
+  });
+}
+
 export default function OrderDetailScreen() {
   const router = useRouter();
   const { orderId, navRef } = useLocalSearchParams<{ orderId: string; navRef?: string }>();
   const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme();
+  const themeColors = useMemo(() => getThemeColors(colorScheme === 'dark'), [colorScheme]);
+  const styles = useMemo(() => createOrderDetailStyles(themeColors), [themeColors]);
   const [loading, setLoading] = useState(true);
   const [orderDetail, setOrderDetail] = useState<OrderDetailResponse | null>(null);
   const [estimatedTimeRemaining, setEstimatedTimeRemaining] = useState('1:24:30'); // TODO: Calculate from actual data
@@ -336,7 +650,7 @@ export default function OrderDetailScreen() {
       <View style={styles.container}>
         <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={24} color="#fff" />
+            <Ionicons name="arrow-back" size={24} color={themeColors.textPrimary} />
           </TouchableOpacity>
           <Text style={styles.headerTitle}>{t('orders.viewDetails')}</Text>
           <View style={{ width: 40 }} />
@@ -358,7 +672,7 @@ export default function OrderDetailScreen() {
             <View style={styles.detailsSection}>
               <Text style={styles.detailsTitle}>Detalles del servicio</Text>
               <View style={styles.detailRow}>
-                <Ionicons name="calendar-outline" size={16} color="#9ca3af" />
+                <Ionicons name="calendar-outline" size={16} color={themeColors.iconSecondary} />
                 <Text style={styles.detailText}>
                   {new Date(order.scheduled_at).toLocaleDateString('es-ES', {
                     weekday: 'long',
@@ -370,7 +684,7 @@ export default function OrderDetailScreen() {
               </View>
               {order.address && (
                 <View style={styles.detailRow}>
-                  <Ionicons name="location-outline" size={16} color="#9ca3af" />
+                  <Ionicons name="location-outline" size={16} color={themeColors.iconSecondary} />
                   <Text style={styles.detailText}>{order.address}</Text>
                 </View>
               )}
@@ -563,7 +877,7 @@ export default function OrderDetailScreen() {
           <View style={styles.detailsSection}>
             <Text style={styles.detailsTitle}>Detalles del servicio</Text>
             <View style={styles.detailRow}>
-              <Ionicons name="calendar-outline" size={16} color="#9ca3af" />
+              <Ionicons name="calendar-outline" size={16} color={themeColors.iconSecondary} />
               <Text style={styles.detailText}>
                 {new Date(order.scheduled_at).toLocaleDateString('es-ES', {
                   weekday: 'long',
@@ -575,7 +889,7 @@ export default function OrderDetailScreen() {
             </View>
             {order.address && (
               <View style={styles.detailRow}>
-                <Ionicons name="location-outline" size={16} color="#9ca3af" />
+                <Ionicons name="location-outline" size={16} color={themeColors.iconSecondary} />
                 <Text style={styles.detailText}>{order.address}</Text>
               </View>
             )}
@@ -630,310 +944,3 @@ export default function OrderDetailScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#1a1a2e',
-  },
-  centerContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  errorText: {
-    color: '#ef4444',
-    fontSize: 16,
-  },
-  // Green Header
-  greenHeader: {
-    backgroundColor: '#10b981',
-    paddingHorizontal: 20,
-    paddingBottom: 20,
-    borderBottomLeftRadius: 0,
-    borderBottomRightRadius: 0,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  backButtonGreen: {
-    width: 40,
-    height: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  greenHeaderTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#fff',
-    flex: 1,
-    marginLeft: 16,
-  },
-  // Green Section with Service Status
-  greenSection: {
-    backgroundColor: '#10b981',
-    paddingHorizontal: 20,
-    paddingBottom: 30,
-    borderBottomLeftRadius: 24,
-    borderBottomRightRadius: 24,
-    alignItems: 'center',
-  },
-  serviceIconContainer: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 16,
-  },
-  serviceIcon: {
-    fontSize: 36,
-  },
-  serviceStatusText: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#fff',
-    marginBottom: 8,
-  },
-  estimatedTimeLabel: {
-    fontSize: 14,
-    color: 'rgba(255, 255, 255, 0.8)',
-    marginBottom: 8,
-  },
-  estimatedTime: {
-    fontSize: 32,
-    fontWeight: '700',
-    color: '#fff',
-  },
-  // Content
-  content: {
-    flex: 1,
-  },
-  scrollContent: {
-    padding: 20,
-    paddingBottom: 40,
-  },
-  // Provider Card
-  providerCard: {
-    backgroundColor: '#252542',
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 14,
-  },
-  providerImageContainer: {
-    position: 'relative',
-  },
-  providerImage: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: '#2d2d4a',
-    borderWidth: 3,
-    borderColor: '#10b981',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  providerInfo: {
-    flex: 1,
-  },
-  providerName: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#fff',
-    marginBottom: 4,
-  },
-  locationRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  locationDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: '#10b981',
-  },
-  locationText: {
-    fontSize: 14,
-    color: '#10b981',
-  },
-  providerActions: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  actionButton: {
-    width: 48,
-    height: 48,
-    borderRadius: 12,
-    backgroundColor: '#2d2d4a',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  chatButton: {
-    backgroundColor: '#3b82f6',
-  },
-  // Progress Timeline
-  progressSection: {
-    marginBottom: 20,
-  },
-  progressTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#fff',
-    marginBottom: 20,
-  },
-  timelineItem: {
-    flexDirection: 'row',
-    gap: 16,
-    marginBottom: 20,
-  },
-  timelineIndicator: {
-    alignItems: 'center',
-  },
-  timelineCircle: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: '#252542',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  timelineCircleCompleted: {
-    backgroundColor: '#10b981',
-  },
-  timelineCircleCurrent: {
-    backgroundColor: '#3b82f6',
-    borderWidth: 2,
-    borderColor: '#3b82f6',
-  },
-  timelineLine: {
-    width: 2,
-    height: 30,
-    backgroundColor: '#252542',
-    marginTop: 4,
-  },
-  timelineLineCompleted: {
-    backgroundColor: '#10b981',
-  },
-  timelineContent: {
-    flex: 1,
-  },
-  timelineLabel: {
-    fontSize: 15,
-    fontWeight: '500',
-    color: '#fff',
-    marginBottom: 4,
-  },
-  timelineTime: {
-    fontSize: 13,
-    color: '#9ca3af',
-  },
-  // Details Section
-  detailsSection: {
-    backgroundColor: '#252542',
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 20,
-  },
-  detailsTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#fff',
-    marginBottom: 12,
-  },
-  detailRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 8,
-  },
-  detailText: {
-    fontSize: 14,
-    color: '#9ca3af',
-    flex: 1,
-  },
-  // Action Buttons
-  actionButtonsSection: {
-    gap: 12,
-    marginTop: 20,
-  },
-  completePaymentButton: {
-    backgroundColor: '#10B981',
-    padding: 16,
-    borderRadius: 14,
-    alignItems: 'center',
-    minHeight: 52,
-    justifyContent: 'center',
-  },
-  completePaymentButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#fff',
-  },
-  cancelButton: {
-    padding: 16,
-    borderRadius: 14,
-    borderWidth: 1,
-    borderColor: '#374151',
-    alignItems: 'center',
-    minHeight: 52,
-    justifyContent: 'center',
-    backgroundColor: 'transparent',
-  },
-  cancelButtonPressed: {
-    backgroundColor: 'rgba(239, 68, 68, 0.1)',
-    borderColor: '#ef4444',
-  },
-  cancelButtonDisabled: {
-    opacity: 0.6,
-  },
-  cancelButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#ef4444',
-  },
-  supportButton: {
-    padding: 16,
-    borderRadius: 14,
-    backgroundColor: '#252542',
-    alignItems: 'center',
-  },
-  supportButtonPressed: {
-    backgroundColor: '#2d2d4a',
-    opacity: 0.8,
-  },
-  supportButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#3b82f6',
-  },
-  // Simple Header for non-in-progress orders
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingBottom: 16,
-    backgroundColor: '#252542',
-  },
-  backButton: {
-    width: 40,
-    height: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#fff',
-  },
-  statusText: {
-    fontSize: 16,
-    color: '#fff',
-    padding: 20,
-  },
-});

--- a/app/provider-onboarding/bank.tsx
+++ b/app/provider-onboarding/bank.tsx
@@ -1,4 +1,5 @@
 import { ProgressBar } from "@/components/onboarding/ProgressBar";
+import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { submitOnboardingStep } from "@/services/providers";
 import { formatClabeDisplay, normalizeClabe, validateClabe } from "@/utils/clabeValidation";
@@ -56,6 +57,7 @@ function getClabeErrorKey(error: string | undefined): BankErrorKey | null {
 export default function ProviderOnboardingBankScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const theme = useThemeColors();
   const [selectedBank, setSelectedBank] = useState<{ id: string; name: string } | null>(null);
   const [bankModalVisible, setBankModalVisible] = useState(false);
   const [clabeRaw, setClabeRaw] = useState("");
@@ -117,32 +119,55 @@ export default function ProviderOnboardingBankScreen() {
   };
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: theme.screenBackground }]}>
       <ProgressBar currentStep={5} totalSteps={TOTAL_STEPS} />
 
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
-        <Text style={styles.title}>{t("providerOnboarding.bank.title")}</Text>
-        <Text style={styles.subtitle}>{t("providerOnboarding.bank.subtitle")}</Text>
+      <ScrollView style={[styles.scrollView, { backgroundColor: theme.screenBackground }]} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+        <Text style={[styles.title, { color: theme.textPrimary }]}>{t("providerOnboarding.bank.title")}</Text>
+        <Text style={[styles.subtitle, { color: theme.textSecondary }]}>{t("providerOnboarding.bank.subtitle")}</Text>
 
         <View style={styles.form}>
           {/* Bank dropdown */}
           <View style={styles.field}>
-            <Text style={styles.label}>{t("providerOnboarding.bank.bank")}</Text>
-            <TouchableOpacity style={styles.selectContainer} onPress={() => setBankModalVisible(true)} activeOpacity={0.7}>
-              <Text style={[styles.selectText, !selectedBank && styles.selectPlaceholder]} numberOfLines={1}>
+            <Text style={[styles.label, { color: theme.textSecondary }]}>{t("providerOnboarding.bank.bank")}</Text>
+            <TouchableOpacity
+              style={[styles.selectContainer, { backgroundColor: theme.surfaceSecondary, borderColor: theme.border }]}
+              onPress={() => setBankModalVisible(true)}
+              activeOpacity={0.7}
+            >
+              <Text
+                style={[
+                  styles.selectText,
+                  { color: selectedBank ? theme.textPrimary : theme.textTertiary },
+                ]}
+                numberOfLines={1}
+              >
                 {selectedBank ? selectedBank.name : t("providerOnboarding.bank.selectBank")}
               </Text>
               <View style={styles.selectIconWrapper}>
-                <Ionicons name="chevron-down" size={16} color="rgba(255, 255, 255, 0.4)" />
+                <Ionicons name="chevron-down" size={16} color={theme.iconSecondary} />
               </View>
             </TouchableOpacity>
           </View>
 
           {/* Account number / CLABE with input mask */}
           <View style={styles.field}>
-            <Text style={styles.label}>{t("providerOnboarding.bank.clabe")}</Text>
-            <TextInput style={[styles.input, clabeError ? styles.inputError : null]} placeholder={t("providerOnboarding.bank.clabePlaceholder")} placeholderTextColor="rgba(255, 255, 255, 0.3)" value={clabeDisplay} onChangeText={handleClabeChange} onBlur={() => setTouched((p) => ({ ...p, clabe: true }))} keyboardType="numeric" maxLength={22} />
-            <Text style={styles.hint}>{t("providerOnboarding.bank.clabeHint")}</Text>
+            <Text style={[styles.label, { color: theme.textSecondary }]}>{t("providerOnboarding.bank.clabe")}</Text>
+            <TextInput
+              style={[
+                styles.input,
+                { backgroundColor: theme.surfaceSecondary, borderColor: theme.border, color: theme.textPrimary },
+                clabeError ? styles.inputError : null,
+              ]}
+              placeholder={t("providerOnboarding.bank.clabePlaceholder")}
+              placeholderTextColor={theme.textTertiary}
+              value={clabeDisplay}
+              onChangeText={handleClabeChange}
+              onBlur={() => setTouched((p) => ({ ...p, clabe: true }))}
+              keyboardType="numeric"
+              maxLength={22}
+            />
+            <Text style={[styles.hint, { color: theme.textTertiary }]}>{t("providerOnboarding.bank.clabeHint")}</Text>
             {clabeError ?
               <Text style={styles.errorText}>{clabeError}</Text>
             : null}
@@ -150,28 +175,40 @@ export default function ProviderOnboardingBankScreen() {
 
           {/* Account holder name (required) */}
           <View style={styles.field}>
-            <Text style={styles.label}>{t("providerOnboarding.bank.accountHolder")}</Text>
-            <TextInput style={[styles.input, accountHolderError ? styles.inputError : null]} placeholder={t("providerOnboarding.bank.accountHolderPlaceholder")} placeholderTextColor="rgba(255, 255, 255, 0.3)" value={accountHolder} onChangeText={setAccountHolder} onBlur={() => setTouched((p) => ({ ...p, accountHolder: true }))} autoCapitalize="words" />
-            <Text style={styles.hint}>{t("providerOnboarding.bank.accountHolderHint")}</Text>
+            <Text style={[styles.label, { color: theme.textSecondary }]}>{t("providerOnboarding.bank.accountHolder")}</Text>
+            <TextInput
+              style={[
+                styles.input,
+                { backgroundColor: theme.surfaceSecondary, borderColor: theme.border, color: theme.textPrimary },
+                accountHolderError ? styles.inputError : null,
+              ]}
+              placeholder={t("providerOnboarding.bank.accountHolderPlaceholder")}
+              placeholderTextColor={theme.textTertiary}
+              value={accountHolder}
+              onChangeText={setAccountHolder}
+              onBlur={() => setTouched((p) => ({ ...p, accountHolder: true }))}
+              autoCapitalize="words"
+            />
+            <Text style={[styles.hint, { color: theme.textTertiary }]}>{t("providerOnboarding.bank.accountHolderHint")}</Text>
             {accountHolderError ?
               <Text style={styles.errorText}>{accountHolderError}</Text>
             : null}
           </View>
 
           {/* Informative card: Weekly payments */}
-          <View style={styles.paymentInfoCard}>
+          <View style={[styles.paymentInfoCard, { backgroundColor: `${theme.primary}18`, borderColor: `${theme.primary}33` }]}>
             <Text style={styles.paymentIcon}>💳</Text>
             <View style={styles.paymentInfo}>
-              <Text style={styles.paymentTitle}>{t("providerOnboarding.bank.weeklyPayments")}</Text>
-              <Text style={styles.paymentDesc}>{t("providerOnboarding.bank.weeklyPaymentsDesc")}</Text>
+              <Text style={[styles.paymentTitle, { color: theme.textPrimary }]}>{t("providerOnboarding.bank.weeklyPayments")}</Text>
+              <Text style={[styles.paymentDesc, { color: theme.textSecondary }]}>{t("providerOnboarding.bank.weeklyPaymentsDesc")}</Text>
             </View>
           </View>
         </View>
       </ScrollView>
 
       <View style={[styles.buttonContainer, { paddingBottom: insets.bottom + 24 }]}>
-        <TouchableOpacity style={styles.backButton} onPress={handleBack} activeOpacity={0.7}>
-          <Text style={styles.backButtonText}>{t("providerOnboarding.bank.back")}</Text>
+        <TouchableOpacity style={[styles.backButton, { backgroundColor: theme.surfaceSecondary }]} onPress={handleBack} activeOpacity={0.7}>
+          <Text style={[styles.backButtonText, { color: theme.textSecondary }]}>{t("providerOnboarding.bank.back")}</Text>
         </TouchableOpacity>
         <TouchableOpacity style={[styles.continueButton, (!canContinue || saving) && styles.continueButtonDisabled]} onPress={handleContinue} activeOpacity={0.8} disabled={!canContinue || saving}>
           <LinearGradient colors={canContinue && !saving ? ["#6366F1", "#8B5CF6"] : ["#4B5563", "#4B5563"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }} style={styles.continueButtonGradient}>
@@ -184,15 +221,15 @@ export default function ProviderOnboardingBankScreen() {
       <Modal visible={bankModalVisible} transparent animationType="slide" onRequestClose={() => setBankModalVisible(false)}>
         <View style={styles.modalOverlay}>
           <TouchableOpacity style={StyleSheet.absoluteFill} activeOpacity={1} onPress={() => setBankModalVisible(false)} />
-          <View style={[styles.modalContent, { paddingBottom: insets.bottom + 16 }]}>
-            <View style={styles.modalHandle} />
-            <Text style={styles.modalTitle}>{t("providerOnboarding.bank.selectBank")}</Text>
+          <View style={[styles.modalContent, { paddingBottom: insets.bottom + 16, backgroundColor: theme.card }]}>
+            <View style={[styles.modalHandle, { backgroundColor: theme.border }]} />
+            <Text style={[styles.modalTitle, { color: theme.textPrimary }]}>{t("providerOnboarding.bank.selectBank")}</Text>
             <FlatList
               data={LOCAL_BANKS}
               keyExtractor={(item) => item.id}
               renderItem={({ item }) => (
-                <TouchableOpacity style={styles.bankOption} onPress={() => handleSelectBank(item)} activeOpacity={0.7}>
-                  <Text style={styles.bankOptionText}>{item.name}</Text>
+                <TouchableOpacity style={[styles.bankOption, { borderBottomColor: theme.border }]} onPress={() => handleSelectBank(item)} activeOpacity={0.7}>
+                  <Text style={[styles.bankOptionText, { color: theme.textPrimary }]}>{item.name}</Text>
                   {selectedBank?.id === item.id ?
                     <Ionicons name="checkmark" size={20} color="#8B5CF6" />
                   : null}
@@ -210,7 +247,6 @@ export default function ProviderOnboardingBankScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#12121A",
   },
   scrollView: {
     flex: 1,
@@ -222,13 +258,11 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 20,
     fontWeight: "700",
-    color: "#FFFFFF",
     marginBottom: 4,
     marginTop: 8,
   },
   subtitle: {
     fontSize: 12,
-    color: "rgba(255, 255, 255, 0.5)",
     marginBottom: 20,
   },
   form: {
@@ -240,7 +274,6 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 12,
     fontWeight: "500",
-    color: "rgba(255, 255, 255, 0.7)",
     textTransform: "uppercase",
     letterSpacing: 0.5,
     marginBottom: 6,
@@ -250,10 +283,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     borderRadius: 12,
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
     borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.08)",
-    color: "#FFFFFF",
     fontSize: 14,
   },
   inputError: {
@@ -261,7 +291,6 @@ const styles = StyleSheet.create({
   },
   hint: {
     fontSize: 11,
-    color: "rgba(255, 255, 255, 0.4)",
     marginTop: 4,
     marginLeft: 2,
   },
@@ -279,17 +308,11 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingRight: 40,
     borderRadius: 12,
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
     borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.08)",
   },
   selectText: {
     flex: 1,
     fontSize: 14,
-    color: "#FFFFFF",
-  },
-  selectPlaceholder: {
-    color: "rgba(255, 255, 255, 0.3)",
   },
   selectIconWrapper: {
     position: "absolute",
@@ -306,9 +329,7 @@ const styles = StyleSheet.create({
     gap: 8,
     padding: 14,
     borderRadius: 12,
-    backgroundColor: "rgba(99, 102, 241, 0.1)",
     borderWidth: 1,
-    borderColor: "rgba(99, 102, 241, 0.2)",
   },
   paymentIcon: {
     fontSize: 18,
@@ -319,12 +340,10 @@ const styles = StyleSheet.create({
   paymentTitle: {
     fontSize: 14,
     fontWeight: "500",
-    color: "#FFFFFF",
     marginBottom: 4,
   },
   paymentDesc: {
     fontSize: 12,
-    color: "rgba(255, 255, 255, 0.5)",
   },
   buttonContainer: {
     flexDirection: "row",
@@ -336,14 +355,12 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingVertical: 12,
     borderRadius: 12,
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
     alignItems: "center",
     justifyContent: "center",
   },
   backButtonText: {
     fontSize: 14,
     fontWeight: "500",
-    color: "rgba(255, 255, 255, 0.7)",
   },
   continueButton: {
     flex: 2,
@@ -372,7 +389,6 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
   },
   modalContent: {
-    backgroundColor: "#1F2937",
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     paddingTop: 12,
@@ -382,7 +398,6 @@ const styles = StyleSheet.create({
   modalHandle: {
     width: 40,
     height: 4,
-    backgroundColor: "rgba(255, 255, 255, 0.2)",
     borderRadius: 2,
     alignSelf: "center",
     marginBottom: 16,
@@ -390,7 +405,6 @@ const styles = StyleSheet.create({
   modalTitle: {
     fontSize: 16,
     fontWeight: "600",
-    color: "#FFFFFF",
     marginBottom: 12,
   },
   bankList: {
@@ -403,10 +417,8 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     paddingHorizontal: 4,
     borderBottomWidth: 1,
-    borderBottomColor: "rgba(255, 255, 255, 0.06)",
   },
   bankOptionText: {
     fontSize: 15,
-    color: "#FFFFFF",
   },
 });

--- a/app/services/[categoryId]/index.tsx
+++ b/app/services/[categoryId]/index.tsx
@@ -1,20 +1,21 @@
 import { ProviderCard } from "@/components/ProviderCard";
 import { useAuth } from "@/contexts/AuthContext";
-import { useTheme } from "@/contexts/ThemeContext";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 import { t } from "@/i18n";
 import { getAddresses } from "@/services/addresses";
 import { ApiError, CategoryWithSubcategories, fetchCategoryWithSubcategories } from "@/services/categories";
 import { fetchSuppliers, Supplier } from "@/services/suppliers";
 import { Ionicons } from "@expo/vector-icons";
+import { getThemeColors } from "@/utils/themeStyles";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, FlatList, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function CategoryDetailScreen() {
   const router = useRouter();
   const { user } = useAuth();
-  const { colorScheme } = useTheme();
+  const colorScheme = useColorScheme();
   const { categoryId } = useLocalSearchParams<{ categoryId: string }>();
   const insets = useSafeAreaInsets();
   const [categoryData, setCategoryData] = useState<CategoryWithSubcategories | null>(null);
@@ -25,19 +26,21 @@ export default function CategoryDetailScreen() {
   const [selectedSubcategory, setSelectedSubcategory] = useState<string | null>(null);
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
 
-  // Use exact colors from JSX design
-  const colors = {
-    bg: "#1a1a2e",
-    bgCard: "#252542",
-    bgInput: "#2d2d4a",
-    primary: "#3b82f6",
-    secondary: "#10b981",
-    accent: "#f59e0b",
-    danger: "#ef4444",
-    textSecondary: "#9ca3af",
-    border: "#374151",
-    textPrimary: "#FFFFFF",
-  };
+  const colors = useMemo(() => {
+    const c = getThemeColors(colorScheme === "dark");
+    return {
+      bg: c.screenBackground,
+      bgCard: c.card,
+      bgInput: c.surfaceSecondary,
+      primary: "#3b82f6",
+      secondary: "#10b981",
+      accent: "#f59e0b",
+      danger: "#ef4444",
+      textSecondary: c.textSecondary,
+      border: c.border,
+      textPrimary: c.textPrimary,
+    };
+  }, [colorScheme]);
 
   useEffect(() => {
     if (categoryId && typeof categoryId === "string" && categoryId.trim() !== "") {
@@ -191,10 +194,10 @@ export default function CategoryDetailScreen() {
       {/* Sort Options */}
       <View style={[styles.sortContainer, { backgroundColor: colors.bgCard, borderBottomColor: colors.border }]}>
         <Text style={[styles.sortLabel, { color: colors.textSecondary }]}>Sort by:</Text>
-        <TouchableOpacity style={[styles.sortButton, { backgroundColor: "#374151" }, sortBy === "price" && styles.sortButtonActive]} onPress={() => setSortBy("price")}>
+        <TouchableOpacity style={[styles.sortButton, { backgroundColor: colors.bgInput }, sortBy === "price" && styles.sortButtonActive]} onPress={() => setSortBy("price")}>
           <Text style={[styles.sortButtonText, { color: colors.textPrimary }, sortBy === "price" && styles.sortButtonTextActive]}>Price</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={[styles.sortButton, { backgroundColor: "#374151" }, sortBy === "distance" && styles.sortButtonActive]} onPress={() => setSortBy("distance")}>
+        <TouchableOpacity style={[styles.sortButton, { backgroundColor: colors.bgInput }, sortBy === "distance" && styles.sortButtonActive]} onPress={() => setSortBy("distance")}>
           <Text style={[styles.sortButtonText, { color: colors.textPrimary }, sortBy === "distance" && styles.sortButtonTextActive]}>Distance</Text>
         </TouchableOpacity>
       </View>

--- a/app/services/suppliers/[supplierId].tsx
+++ b/app/services/suppliers/[supplierId].tsx
@@ -1,6 +1,7 @@
 import { FavoriteButton } from '@/components/FavoriteButton';
 import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { useAuth } from '@/contexts/AuthContext';
+import { useColorScheme } from '@/hooks/use-color-scheme';
 import { getOrCreateConversation } from '@/services/conversations';
 import { getProfileImageUrl } from '@/utils/profileImage';
 import {
@@ -12,15 +13,15 @@ import {
 } from '@/services/suppliers';
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
+import { getThemeColors, type ThemeColors } from '@/utils/themeStyles';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
   Animated,
   Image,
   Platform,
-  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -29,31 +30,296 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { t } from '@/i18n';
 
-// Theme colors matching the JSX design
-const colors = {
-  bg: '#1a1a2e',
-  bgCard: '#252542',
-  bgInput: '#2d2d4a',
+/** Brand accents (same in light/dark); surfaces and text come from `getThemeColors`. */
+const BRAND = {
   primary: '#3b82f6',
   secondary: '#10b981',
   accent: '#f59e0b',
   danger: '#ef4444',
-  purple: '#8b5cf6',
-  pink: '#ec4899',
-  textSecondary: '#9ca3af',
-  border: '#374151',
-  white: '#ffffff',
-};
+} as const;
+
+const ICON_ON_HEADER = '#ffffff';
 
 const HEADER_HEIGHT = 200;
 const PROFILE_IMAGE_SIZE = 90;
 const PROFILE_IMAGE_OFFSET = -40; // Negative margin to overlap header
+
+function createProviderDetailStyles(theme: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.screenBackground,
+    },
+    centerContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    scrollContent: {
+      paddingBottom: 100,
+    },
+    headerImageContainer: {
+      height: HEADER_HEIGHT,
+      width: '100%',
+      position: 'relative',
+    },
+    headerImage: {
+      width: '100%',
+      height: '100%',
+    },
+    headerGradient: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      height: '100%',
+    },
+    headerButtons: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      paddingHorizontal: 20,
+      zIndex: 10,
+    },
+    headerButtonsRight: {
+      flexDirection: 'row',
+      gap: 10,
+    },
+    headerButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    providerInfoSection: {
+      padding: 20,
+      marginTop: PROFILE_IMAGE_OFFSET,
+      backgroundColor: theme.screenBackground,
+    },
+    providerInfoRow: {
+      flexDirection: 'row',
+      gap: 16,
+      alignItems: 'flex-end',
+      marginBottom: 20,
+    },
+    profileImage: {
+      width: PROFILE_IMAGE_SIZE,
+      height: PROFILE_IMAGE_SIZE,
+      borderRadius: 20,
+      backgroundColor: theme.surfaceSecondary,
+      borderWidth: 4,
+      borderColor: theme.screenBackground,
+    },
+    providerInfoText: {
+      flex: 1,
+      paddingBottom: 8,
+    },
+    nameRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      marginBottom: 4,
+    },
+    providerName: {
+      fontSize: 22,
+      fontWeight: '700',
+      color: theme.textPrimary,
+    },
+    profession: {
+      fontSize: 15,
+      color: BRAND.secondary,
+      marginBottom: 4,
+    },
+    locationRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+    location: {
+      fontSize: 14,
+      color: theme.textSecondary,
+    },
+    statsRow: {
+      flexDirection: 'row',
+      gap: 12,
+      marginBottom: 24,
+    },
+    statCard: {
+      flex: 1,
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      padding: 14,
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    statContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      marginBottom: 4,
+    },
+    statValue: {
+      fontSize: 20,
+      fontWeight: '700',
+      color: theme.textPrimary,
+    },
+    statLabel: {
+      fontSize: 12,
+      color: theme.textSecondary,
+    },
+    aboutSection: {
+      marginBottom: 24,
+    },
+    sectionTitle: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.textPrimary,
+      marginBottom: 12,
+    },
+    aboutText: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: theme.textSecondary,
+    },
+    readMoreText: {
+      fontSize: 14,
+      color: BRAND.primary,
+      marginTop: 8,
+      fontWeight: '500',
+    },
+    servicesSection: {
+      marginBottom: 24,
+    },
+    serviceCard: {
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      padding: 14,
+      marginBottom: 10,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      borderWidth: 2,
+      borderColor: 'transparent',
+    },
+    serviceCardSelected: {
+      borderColor: BRAND.primary,
+      backgroundColor: 'rgba(59, 130, 246, 0.12)',
+    },
+    serviceInfo: {
+      flex: 1,
+    },
+    serviceName: {
+      fontSize: 15,
+      fontWeight: '500',
+      color: theme.textPrimary,
+      marginBottom: 4,
+    },
+    serviceDurationRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+    serviceDuration: {
+      fontSize: 13,
+      color: theme.textSecondary,
+    },
+    serviceRightSection: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    servicePrice: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: BRAND.primary,
+    },
+    bottomBar: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      flexDirection: 'row',
+      gap: 12,
+      padding: 20,
+      backgroundColor: theme.screenBackground,
+      borderTopWidth: 1,
+      borderTopColor: theme.border,
+      ...Platform.select({
+        ios: {
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: -2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 4,
+        },
+        android: {
+          elevation: 8,
+        },
+      }),
+    },
+    messageButton: {
+      width: 56,
+      height: 56,
+      borderRadius: 14,
+      backgroundColor: theme.card,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    bookButton: {
+      flex: 1,
+      height: 56,
+      borderRadius: 14,
+      backgroundColor: BRAND.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    bookButtonDisabled: {
+      backgroundColor: theme.surfaceSecondary,
+      opacity: 0.6,
+    },
+    bookButtonText: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: '#ffffff',
+    },
+    errorText: {
+      fontSize: 16,
+      color: BRAND.danger,
+      textAlign: 'center',
+      marginBottom: 16,
+    },
+    retryButton: {
+      backgroundColor: BRAND.primary,
+      paddingHorizontal: 24,
+      paddingVertical: 12,
+      borderRadius: 8,
+    },
+    retryText: {
+      color: '#ffffff',
+      fontSize: 16,
+      fontWeight: '600',
+    },
+  });
+}
 
 export default function ProviderDetailScreen() {
   const router = useRouter();
   const { user } = useAuth();
   const { supplierId } = useLocalSearchParams<{ supplierId: string }>();
   const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme();
+  const theme = useMemo(() => getThemeColors(colorScheme === 'dark'), [colorScheme]);
+  const styles = useMemo(() => createProviderDetailStyles(theme), [theme]);
   const isSelfProvider = Boolean(supplierId && user?.id && supplierId === user.id);
   const scrollY = useRef(new Animated.Value(0)).current;
   const [supplier, setSupplier] = useState<Supplier | null>(null);
@@ -196,7 +462,7 @@ export default function ProviderDetailScreen() {
     return (
       <View style={styles.container}>
         <View style={styles.centerContainer}>
-          <ActivityIndicator size="large" color={colors.primary} />
+          <ActivityIndicator size="large" color={BRAND.primary} />
         </View>
       </View>
     );
@@ -264,19 +530,19 @@ export default function ProviderDetailScreen() {
             onPress={() => router.back()}
             style={styles.headerButton}
           >
-            <Ionicons name="arrow-back" size={20} color={colors.white} />
+            <Ionicons name="arrow-back" size={20} color={ICON_ON_HEADER} />
           </TouchableOpacity>
           <View style={styles.headerButtonsRight}>
             <TouchableOpacity style={styles.headerButton}>
               <FavoriteButton
                 supplierId={supplierId || ''}
                 size={18}
-                color={colors.white}
-                activeColor={colors.danger}
+                color={ICON_ON_HEADER}
+                activeColor={BRAND.danger}
               />
             </TouchableOpacity>
             <TouchableOpacity style={styles.headerButton}>
-              <Ionicons name="share-outline" size={18} color={colors.white} />
+              <Ionicons name="share-outline" size={18} color={ICON_ON_HEADER} />
             </TouchableOpacity>
           </View>
         </View>
@@ -296,7 +562,7 @@ export default function ProviderDetailScreen() {
                 {supplier.business_name?.trim() || supplier.full_name}
               </Text>
                 {supplier.verified && (
-                  <Ionicons name="checkmark-circle" size={20} color={colors.secondary} />
+                  <Ionicons name="checkmark-circle" size={20} color={BRAND.secondary} />
                 )}
               </View>
               {supplier.service_category && (
@@ -304,7 +570,7 @@ export default function ProviderDetailScreen() {
               )}
               {supplier.location && (
                 <View style={styles.locationRow}>
-                  <Ionicons name="location-outline" size={14} color={colors.textSecondary} />
+                  <Ionicons name="location-outline" size={14} color={theme.textSecondary} />
                   <Text style={styles.location}>{supplier.location}</Text>
                 </View>
               )}
@@ -315,21 +581,21 @@ export default function ProviderDetailScreen() {
           <View style={styles.statsRow}>
             <View style={styles.statCard}>
               <View style={styles.statContent}>
-                <Ionicons name="star" size={20} color={colors.accent} />
+                <Ionicons name="star" size={20} color={BRAND.accent} />
                 <Text style={styles.statValue}>{Number(supplier.rating).toFixed(1)}</Text>
               </View>
               <Text style={styles.statLabel}>{t('supplier.rating')}</Text>
             </View>
             <View style={styles.statCard}>
               <View style={styles.statContent}>
-                <Ionicons name="chatbubble-outline" size={20} color={colors.white} />
+                <Ionicons name="chatbubble-outline" size={20} color={theme.icon} />
                 <Text style={styles.statValue}>{supplier.total_reviews}</Text>
               </View>
               <Text style={styles.statLabel}>{t('supplier.reviewsCount')}</Text>
             </View>
             <View style={styles.statCard}>
               <View style={styles.statContent}>
-                <Ionicons name="calendar-outline" size={20} color={colors.white} />
+                <Ionicons name="calendar-outline" size={20} color={theme.icon} />
                 <Text style={styles.statValue}>{supplier.years_experience || 0}</Text>
               </View>
               <Text style={styles.statLabel}>{t('supplier.years')}</Text>
@@ -371,7 +637,7 @@ export default function ProviderDetailScreen() {
                         {service.name?.trim() || service.category_name || 'Service'}
                       </Text>
                       <View style={styles.serviceDurationRow}>
-                        <Ionicons name="time-outline" size={14} color={colors.textSecondary} />
+                        <Ionicons name="time-outline" size={14} color={theme.textSecondary} />
                         <Text style={styles.serviceDuration}>{getServiceDuration(service)}</Text>
                       </View>
                     </View>
@@ -382,7 +648,7 @@ export default function ProviderDetailScreen() {
                         </Text>
                       )}
                       {isSelected && (
-                        <Ionicons name="checkmark-circle" size={24} color={colors.primary} />
+                        <Ionicons name="checkmark-circle" size={24} color={BRAND.primary} />
                       )}
                     </View>
                   </TouchableOpacity>
@@ -402,9 +668,9 @@ export default function ProviderDetailScreen() {
             disabled={startingChat}
           >
             {startingChat ? (
-              <ActivityIndicator size="small" color={colors.white} />
+              <ActivityIndicator size="small" color={BRAND.primary} />
             ) : (
-              <Ionicons name="chatbubble-outline" size={24} color={colors.white} />
+              <Ionicons name="chatbubble-outline" size={24} color={BRAND.primary} />
             )}
           </TouchableOpacity>
         )}
@@ -422,265 +688,3 @@ export default function ProviderDetailScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.bg,
-  },
-  centerContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-  },
-  scrollView: {
-    flex: 1,
-  },
-  scrollContent: {
-    paddingBottom: 100, // Space for fixed bottom bar
-  },
-  headerImageContainer: {
-    height: HEADER_HEIGHT,
-    width: '100%',
-    position: 'relative',
-  },
-  headerImage: {
-    width: '100%',
-    height: '100%',
-  },
-  headerGradient: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    height: '100%',
-  },
-  headerButtons: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    zIndex: 10,
-  },
-  headerButtonsRight: {
-    flexDirection: 'row',
-    gap: 10,
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  providerInfoSection: {
-    padding: 20,
-    marginTop: PROFILE_IMAGE_OFFSET,
-    backgroundColor: colors.bg,
-  },
-  providerInfoRow: {
-    flexDirection: 'row',
-    gap: 16,
-    alignItems: 'flex-end',
-    marginBottom: 20,
-  },
-  profileImage: {
-    width: PROFILE_IMAGE_SIZE,
-    height: PROFILE_IMAGE_SIZE,
-    borderRadius: 20,
-    backgroundColor: colors.bgInput,
-    borderWidth: 4,
-    borderColor: colors.bg,
-  },
-  providerInfoText: {
-    flex: 1,
-    paddingBottom: 8,
-  },
-  nameRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 4,
-  },
-  providerName: {
-    fontSize: 22,
-    fontWeight: '700',
-    color: colors.white,
-  },
-  profession: {
-    fontSize: 15,
-    color: colors.secondary,
-    marginBottom: 4,
-  },
-  locationRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-  },
-  location: {
-    fontSize: 14,
-    color: colors.textSecondary,
-  },
-  statsRow: {
-    flexDirection: 'row',
-    gap: 12,
-    marginBottom: 24,
-  },
-  statCard: {
-    flex: 1,
-    backgroundColor: colors.bgCard,
-    borderRadius: 12,
-    padding: 14,
-    alignItems: 'center',
-  },
-  statContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    marginBottom: 4,
-  },
-  statValue: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: colors.white,
-  },
-  statLabel: {
-    fontSize: 12,
-    color: colors.textSecondary,
-  },
-  aboutSection: {
-    marginBottom: 24,
-  },
-  sectionTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: colors.white,
-    marginBottom: 12,
-  },
-  aboutText: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: colors.textSecondary,
-  },
-  readMoreText: {
-    fontSize: 14,
-    color: colors.primary,
-    marginTop: 8,
-    fontWeight: '500',
-  },
-  servicesSection: {
-    marginBottom: 24,
-  },
-  serviceCard: {
-    backgroundColor: colors.bgCard,
-    borderRadius: 12,
-    padding: 14,
-    marginBottom: 10,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: 'transparent',
-  },
-  serviceCardSelected: {
-    borderColor: colors.primary,
-    backgroundColor: `${colors.primary}20`,
-  },
-  serviceInfo: {
-    flex: 1,
-  },
-  serviceName: {
-    fontSize: 15,
-    fontWeight: '500',
-    color: colors.white,
-    marginBottom: 4,
-  },
-  serviceDurationRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-  },
-  serviceDuration: {
-    fontSize: 13,
-    color: colors.textSecondary,
-  },
-  serviceRightSection: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  servicePrice: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: colors.primary,
-  },
-  bottomBar: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    flexDirection: 'row',
-    gap: 12,
-    padding: 20,
-    backgroundColor: colors.bg,
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
-    ...Platform.select({
-      ios: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: -2 },
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-      },
-      android: {
-        elevation: 8,
-      },
-    }),
-  },
-  messageButton: {
-    width: 56,
-    height: 56,
-    borderRadius: 14,
-    backgroundColor: colors.bgCard,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  bookButton: {
-    flex: 1,
-    height: 56,
-    borderRadius: 14,
-    backgroundColor: colors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  bookButtonDisabled: {
-    backgroundColor: colors.bgCard,
-    opacity: 0.5,
-  },
-  bookButtonText: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: colors.white,
-  },
-  errorText: {
-    fontSize: 16,
-    color: colors.danger,
-    textAlign: 'center',
-    marginBottom: 16,
-  },
-  retryButton: {
-    backgroundColor: colors.primary,
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
-  },
-  retryText: {
-    color: colors.white,
-    fontSize: 16,
-    fontWeight: '600',
-  },
-});

--- a/app/switch-mode.tsx
+++ b/app/switch-mode.tsx
@@ -1,11 +1,13 @@
 import { useMode } from "@/contexts/ModeContext";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import type { ThemeColors } from "@/utils/themeStyles";
 import { t } from "@/i18n";
 import { checkProviderStatus } from "@/services/providers";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
     ActivityIndicator,
     Platform,
@@ -19,10 +21,154 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const GRADIENT_START = "#6366F1";
 const GRADIENT_END = "#8B5CF6";
-const AMBER_BG = "rgba(245, 158, 11, 0.15)";
-const AMBER_BORDER = "rgba(245, 158, 11, 0.4)";
 
 type TargetMode = "client" | "provider";
+
+function createSwitchModeStyles(colors: ThemeColors, amberBg: string, amberBorder: string) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      paddingHorizontal: 20,
+      paddingVertical: 16,
+      paddingBottom: 20,
+    },
+    backButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 12,
+      backgroundColor: colors.surfaceSecondary,
+      borderWidth: 1,
+      borderColor: colors.cardBorder,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    headerTitle: {
+      fontSize: 20,
+      fontWeight: "700",
+      color: colors.textPrimary,
+    },
+    scroll: {
+      flex: 1,
+      backgroundColor: colors.screenBackground,
+    },
+    scrollContent: {
+      paddingHorizontal: 20,
+    },
+    iconsRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      marginBottom: 12,
+      gap: 16,
+    },
+    modeIconBox: {
+      alignItems: "center",
+      gap: 8,
+    },
+    modeIconLabel: {
+      color: colors.primary,
+      fontSize: 13,
+      fontWeight: "600",
+    },
+    modeIconLabelInactive: {
+      color: colors.textTertiary,
+      fontSize: 13,
+      fontWeight: "500",
+    },
+    arrowBox: {
+      padding: 8,
+    },
+    currentModeText: {
+      color: colors.textSecondary,
+      fontSize: 13,
+      textAlign: "center",
+      marginBottom: 24,
+    },
+    title: {
+      color: colors.textPrimary,
+      fontSize: 22,
+      fontWeight: "700",
+      textAlign: "center",
+      marginBottom: 12,
+    },
+    description: {
+      color: colors.textSecondary,
+      fontSize: 15,
+      lineHeight: 22,
+      textAlign: "center",
+      marginBottom: 24,
+    },
+    grid: {
+      flexDirection: "row",
+      gap: 12,
+      marginBottom: 20,
+    },
+    gridColumn: {
+      flex: 1,
+      padding: 16,
+      borderRadius: 12,
+      borderWidth: 1,
+      backgroundColor: colors.card,
+      borderColor: colors.cardBorder,
+    },
+    gridColumnTitle: {
+      fontSize: 14,
+      fontWeight: "600",
+      marginBottom: 12,
+      textAlign: "center",
+      color: colors.textPrimary,
+    },
+    gridItem: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+      marginBottom: 8,
+    },
+    gridItemText: {
+      fontSize: 13,
+      flex: 1,
+      color: colors.textPrimary,
+    },
+    infoBanner: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: 12,
+      padding: 14,
+      borderRadius: 12,
+      backgroundColor: amberBg,
+      borderWidth: 1,
+      borderColor: amberBorder,
+      marginBottom: 24,
+    },
+    infoBannerText: {
+      flex: 1,
+      color: colors.textPrimary,
+      fontSize: 13,
+      lineHeight: 20,
+    },
+    primaryButtonWrap: {
+      marginBottom: 12,
+      borderRadius: 14,
+      overflow: "hidden",
+    },
+    primaryButton: {
+      paddingVertical: 16,
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: 52,
+    },
+    primaryButtonText: {
+      color: "#fff",
+      fontSize: 16,
+      fontWeight: "600",
+    },
+  });
+}
 
 export default function SwitchModeScreen() {
   const { target = "client" } = useLocalSearchParams<{ target?: string }>();
@@ -30,6 +176,18 @@ export default function SwitchModeScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const colorScheme = useColorScheme();
+  const amberBanner = useMemo(() => {
+    const isDark = colorScheme === "dark";
+    return {
+      bg: isDark ? "rgba(245, 158, 11, 0.15)" : "rgba(245, 158, 11, 0.2)",
+      border: isDark ? "rgba(245, 158, 11, 0.4)" : "rgba(217, 119, 6, 0.4)",
+    };
+  }, [colorScheme]);
+  const styles = useMemo(
+    () => createSwitchModeStyles(colors, amberBanner.bg, amberBanner.border),
+    [colors, amberBanner.bg, amberBanner.border]
+  );
   const { setMode } = useMode();
   const [switching, setSwitching] = useState(false);
 
@@ -81,7 +239,7 @@ export default function SwitchModeScreen() {
   const bottomInset = insets.bottom || (Platform.OS === "android" ? 40 : 0);
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset, backgroundColor: colors.background }]}>
+    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset, backgroundColor: colors.screenBackground }]}>
       <View style={styles.header}>
         <TouchableOpacity
           style={styles.backButton}
@@ -90,9 +248,9 @@ export default function SwitchModeScreen() {
           accessibilityLabel={t("common.back")}
           accessibilityRole="button"
         >
-          <Ionicons name="chevron-back" size={24} color={colors.textSecondary} />
+          <Ionicons name="chevron-back" size={24} color={colors.icon} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t("mode.switchMode")}</Text>
+        <Text style={styles.headerTitle}>{t("mode.switchMode")}</Text>
       </View>
 
       <ScrollView
@@ -106,7 +264,7 @@ export default function SwitchModeScreen() {
             <Ionicons
               name="person"
               size={32}
-              color={isToProvider ? "rgba(255,255,255,0.5)" : "#8B5CF6"}
+              color={isToProvider ? colors.textTertiary : colors.primary}
             />
             <Text
               style={
@@ -117,13 +275,13 @@ export default function SwitchModeScreen() {
             </Text>
           </View>
           <View style={styles.arrowBox}>
-            <Ionicons name="swap-horizontal" size={28} color="rgba(255,255,255,0.5)" />
+            <Ionicons name="swap-horizontal" size={28} color={colors.icon} />
           </View>
           <View style={styles.modeIconBox}>
             <Ionicons
               name="briefcase"
               size={32}
-              color={isToProvider ? "#8B5CF6" : "rgba(255,255,255,0.5)"}
+              color={isToProvider ? colors.primary : colors.textTertiary}
             />
             <Text
               style={
@@ -135,52 +293,52 @@ export default function SwitchModeScreen() {
           </View>
         </View>
 
-        <Text style={[styles.currentModeText, { color: colors.textTertiary }]}>
+        <Text style={styles.currentModeText}>
           {isToProvider
             ? t("mode.currentModeIndicatorClient")
             : t("mode.currentModeIndicator")}
         </Text>
 
-        <Text style={[styles.title, { color: colors.textPrimary }]}>
+        <Text style={styles.title}>
           {isToProvider
             ? t("mode.switchToProviderQuestion")
             : t("mode.switchToClientQuestion")}
         </Text>
-        <Text style={[styles.description, { color: colors.textSecondary }]}>
+        <Text style={styles.description}>
           {isToProvider
             ? t("mode.switchDescriptionProvider")
             : t("mode.switchDescription")}
         </Text>
 
         <View style={styles.grid}>
-          <View style={[styles.gridColumn, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-            <Text style={[styles.gridColumnTitle, { color: colors.textPrimary }]}>{t("mode.asProvider")}</Text>
+          <View style={styles.gridColumn}>
+            <Text style={styles.gridColumnTitle}>{t("mode.asProvider")}</Text>
             <View style={styles.gridItem}>
               <Ionicons name="checkmark-circle" size={18} color={colors.primary} />
-              <Text style={[styles.gridItemText, { color: colors.textOnDark }]}>{t("mode.providerOfferServices")}</Text>
+              <Text style={styles.gridItemText}>{t("mode.providerOfferServices")}</Text>
             </View>
             <View style={styles.gridItem}>
               <Ionicons name="checkmark-circle" size={18} color={colors.primary} />
-              <Text style={[styles.gridItemText, { color: colors.textOnDark }]}>{t("mode.providerReceivePayments")}</Text>
+              <Text style={styles.gridItemText}>{t("mode.providerReceivePayments")}</Text>
             </View>
             <View style={styles.gridItem}>
               <Ionicons name="checkmark-circle" size={18} color={colors.primary} />
-              <Text style={[styles.gridItemText, { color: colors.textOnDark }]}>{t("mode.providerManageSchedule")}</Text>
+              <Text style={styles.gridItemText}>{t("mode.providerManageSchedule")}</Text>
             </View>
           </View>
-          <View style={[styles.gridColumn, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-            <Text style={[styles.gridColumnTitle, { color: colors.textPrimary }]}>{t("mode.asClient")}</Text>
+          <View style={styles.gridColumn}>
+            <Text style={styles.gridColumnTitle}>{t("mode.asClient")}</Text>
             <View style={styles.gridItem}>
               <Ionicons name="checkmark-circle" size={18} color={colors.primary} />
-              <Text style={[styles.gridItemText, { color: colors.textOnDark }]}>{t("mode.clientHireServices")}</Text>
+              <Text style={styles.gridItemText}>{t("mode.clientHireServices")}</Text>
             </View>
             <View style={styles.gridItem}>
               <Ionicons name="checkmark-circle" size={18} color={colors.primary} />
-              <Text style={[styles.gridItemText, { color: colors.textOnDark }]}>{t("mode.clientMakePayments")}</Text>
+              <Text style={styles.gridItemText}>{t("mode.clientMakePayments")}</Text>
             </View>
             <View style={styles.gridItem}>
               <Ionicons name="checkmark-circle" size={18} color={colors.primary} />
-              <Text style={[styles.gridItemText, { color: colors.textOnDark }]}>{t("mode.clientLeaveReviews")}</Text>
+              <Text style={styles.gridItemText}>{t("mode.clientLeaveReviews")}</Text>
             </View>
           </View>
         </View>
@@ -217,139 +375,3 @@ export default function SwitchModeScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    paddingBottom: 20,
-  },
-  backButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 12,
-    backgroundColor: "rgba(255,255,255,0.08)",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  headerTitle: {
-    fontSize: 20,
-    fontWeight: "700",
-  },
-  scroll: {
-    flex: 1,
-  },
-  scrollContent: {
-    paddingHorizontal: 20,
-  },
-  iconsRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: 12,
-    gap: 16,
-  },
-  modeIconBox: {
-    alignItems: "center",
-    gap: 8,
-  },
-  modeIconLabel: {
-    color: "#A78BFA",
-    fontSize: 13,
-    fontWeight: "600",
-  },
-  modeIconLabelInactive: {
-    color: "rgba(255,255,255,0.4)",
-    fontSize: 13,
-    fontWeight: "500",
-  },
-  arrowBox: {
-    padding: 8,
-  },
-  currentModeText: {
-    color: "rgba(255,255,255,0.5)",
-    fontSize: 13,
-    textAlign: "center",
-    marginBottom: 24,
-  },
-  title: {
-    color: "#fff",
-    fontSize: 22,
-    fontWeight: "700",
-    textAlign: "center",
-    marginBottom: 12,
-  },
-  description: {
-    color: "rgba(255,255,255,0.7)",
-    fontSize: 15,
-    lineHeight: 22,
-    textAlign: "center",
-    marginBottom: 24,
-  },
-  grid: {
-    flexDirection: "row",
-    gap: 12,
-    marginBottom: 20,
-  },
-  gridColumn: {
-    flex: 1,
-    padding: 16,
-    borderRadius: 12,
-    borderWidth: 1,
-  },
-  gridColumnTitle: {
-    fontSize: 14,
-    fontWeight: "600",
-    marginBottom: 12,
-    textAlign: "center",
-  },
-  gridItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    marginBottom: 8,
-  },
-  gridItemText: {
-    fontSize: 13,
-    flex: 1,
-  },
-  infoBanner: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 12,
-    padding: 14,
-    borderRadius: 12,
-    backgroundColor: AMBER_BG,
-    borderWidth: 1,
-    borderColor: AMBER_BORDER,
-    marginBottom: 24,
-  },
-  infoBannerText: {
-    flex: 1,
-    color: "rgba(255,255,255,0.9)",
-    fontSize: 13,
-    lineHeight: 20,
-  },
-  primaryButtonWrap: {
-    marginBottom: 12,
-    borderRadius: 14,
-    overflow: "hidden",
-  },
-  primaryButton: {
-    paddingVertical: 16,
-    alignItems: "center",
-    justifyContent: "center",
-    minHeight: 52,
-  },
-  primaryButtonText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "600",
-  },
-});

--- a/components/BookingDateTimePicker.tsx
+++ b/components/BookingDateTimePicker.tsx
@@ -1,8 +1,10 @@
 import { ProviderAvatar } from '@/components/ProviderAvatar';
+import { useThemeColors } from '@/hooks/useThemeColors';
 import { fetchSupplierAvailability } from '@/services/suppliers';
+import type { ThemeColors } from '@/utils/themeStyles';
 import { Ionicons } from '@expo/vector-icons';
 import { t } from '@/i18n';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   ScrollView,
@@ -14,14 +16,138 @@ import {
 
 const TIME_SLOTS = ['09:00', '10:00', '11:00', '12:00', '14:00', '15:00', '16:00', '17:00'];
 
-const colors = {
-  bg: '#1a1a2e',
-  bgCard: '#252542',
-  primary: '#3b82f6',
-  textSecondary: '#9ca3af',
-  border: '#374151',
-  white: '#ffffff',
-};
+const TEXT_ON_PRIMARY = '#ffffff';
+
+function createBookingDateTimePickerStyles(theme: ThemeColors) {
+  return StyleSheet.create({
+    wrap: {
+      marginBottom: 16,
+    },
+    loadingWrap: {
+      minHeight: 200,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    providerCard: {
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      padding: 12,
+      marginBottom: 20,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    providerImageContainer: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+      backgroundColor: theme.surfaceSecondary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    providerImage: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+    },
+    providerInfo: { flex: 1 },
+    providerName: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: theme.textPrimary,
+      marginBottom: 2,
+    },
+    serviceInfo: {
+      fontSize: 13,
+      color: theme.textSecondary,
+    },
+    monthNavigation: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 16,
+    },
+    monthNavButtonDisabled: { opacity: 0.3 },
+    monthText: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: theme.textPrimary,
+    },
+    dateSelector: {
+      gap: 6,
+      marginBottom: 24,
+    },
+    dateItem: {
+      width: 56,
+      paddingVertical: 12,
+      paddingHorizontal: 4,
+      backgroundColor: theme.card,
+      borderRadius: 12,
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    dateItemSelected: {
+      backgroundColor: theme.primary,
+      borderColor: theme.primary,
+    },
+    dateItemUnavailable: { opacity: 0.3 },
+    dateDayName: {
+      fontSize: 11,
+      color: theme.textSecondary,
+      marginBottom: 4,
+    },
+    dateDayNameSelected: { color: TEXT_ON_PRIMARY },
+    dateDayNameUnavailable: { color: theme.textSecondary },
+    dateDayNumber: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: theme.textPrimary,
+    },
+    dateDayNumberSelected: { color: TEXT_ON_PRIMARY },
+    dateDayNumberUnavailable: { color: theme.textSecondary },
+    section: {
+      marginBottom: 0,
+    },
+    sectionTitleCentered: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.textPrimary,
+      marginBottom: 16,
+      textAlign: 'center',
+    },
+    timeGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 10,
+    },
+    timeSlot: {
+      width: '22%',
+      paddingVertical: 14,
+      paddingHorizontal: 8,
+      backgroundColor: theme.card,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: theme.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    timeSlotSelected: {
+      backgroundColor: theme.primary,
+      borderColor: theme.primary,
+    },
+    timeSlotUnavailable: { opacity: 0.3 },
+    timeSlotText: {
+      fontSize: 14,
+      fontWeight: '500',
+      color: theme.textPrimary,
+    },
+    timeSlotTextSelected: { color: TEXT_ON_PRIMARY },
+    timeSlotTextUnavailable: { color: theme.textSecondary },
+  });
+}
 
 export interface BookingDateTimePickerProviderCard {
   name: string;
@@ -46,6 +172,9 @@ export function BookingDateTimePicker({
   providerCard,
   minDate = new Date(),
 }: BookingDateTimePickerProps) {
+  const theme = useThemeColors();
+  const styles = useMemo(() => createBookingDateTimePickerStyles(theme), [theme]);
+
   const [currentMonth, setCurrentMonth] = useState(() => value || new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(() =>
     value ? new Date(value.getFullYear(), value.getMonth(), value.getDate()) : null
@@ -234,7 +363,7 @@ export function BookingDateTimePicker({
   if (loadingAvailability) {
     return (
       <View style={styles.loadingWrap}>
-        <ActivityIndicator size="small" color={colors.primary} />
+        <ActivityIndicator size="small" color={theme.primary} />
       </View>
     );
   }
@@ -269,7 +398,7 @@ export function BookingDateTimePicker({
           <Ionicons
             name="chevron-back"
             size={20}
-            color={canNavigatePrev() ? colors.textSecondary : colors.border}
+            color={canNavigatePrev() ? theme.icon : theme.border}
           />
         </TouchableOpacity>
         <Text style={styles.monthText}>
@@ -277,7 +406,7 @@ export function BookingDateTimePicker({
             formatMonthYear(currentMonth).slice(1)}
         </Text>
         <TouchableOpacity onPress={() => navigateMonth('next')}>
-          <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+          <Ionicons name="chevron-forward" size={20} color={theme.icon} />
         </TouchableOpacity>
       </View>
 
@@ -357,127 +486,3 @@ export function BookingDateTimePicker({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  wrap: {
-    marginBottom: 16,
-  },
-  loadingWrap: {
-    minHeight: 200,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  providerCard: {
-    backgroundColor: colors.bgCard,
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  providerImageContainer: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    backgroundColor: '#2d2d4a',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  providerImage: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-  },
-  providerInfo: { flex: 1 },
-  providerName: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: colors.white,
-    marginBottom: 2,
-  },
-  serviceInfo: {
-    fontSize: 13,
-    color: colors.textSecondary,
-  },
-  monthNavigation: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 16,
-  },
-  monthNavButtonDisabled: { opacity: 0.3 },
-  monthText: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: colors.white,
-  },
-  dateSelector: {
-    gap: 6,
-    marginBottom: 24,
-  },
-  dateItem: {
-    width: 56,
-    paddingVertical: 12,
-    paddingHorizontal: 4,
-    backgroundColor: colors.bgCard,
-    borderRadius: 12,
-    alignItems: 'center',
-  },
-  dateItemSelected: {
-    backgroundColor: colors.primary,
-  },
-  dateItemUnavailable: { opacity: 0.3 },
-  dateDayName: {
-    fontSize: 11,
-    color: colors.textSecondary,
-    marginBottom: 4,
-  },
-  dateDayNameSelected: { color: colors.white },
-  dateDayNameUnavailable: { color: colors.textSecondary },
-  dateDayNumber: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: colors.white,
-  },
-  dateDayNumberSelected: { color: colors.white },
-  dateDayNumberUnavailable: { color: colors.textSecondary },
-  section: {
-    marginBottom: 0,
-  },
-  sectionTitleCentered: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: colors.white,
-    marginBottom: 16,
-    textAlign: 'center',
-  },
-  timeGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 10,
-  },
-  timeSlot: {
-    width: '22%',
-    paddingVertical: 14,
-    paddingHorizontal: 8,
-    backgroundColor: colors.bgCard,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: colors.border,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  timeSlotSelected: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
-  },
-  timeSlotUnavailable: { opacity: 0.3 },
-  timeSlotText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: colors.white,
-  },
-  timeSlotTextSelected: { color: colors.white },
-  timeSlotTextUnavailable: { color: colors.textSecondary },
-});

--- a/components/onboarding/ProgressBar.tsx
+++ b/components/onboarding/ProgressBar.tsx
@@ -1,3 +1,4 @@
+import { useThemeColors } from '@/hooks/useThemeColors';
 import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
@@ -9,6 +10,7 @@ interface ProgressBarProps {
 }
 
 export function ProgressBar({ currentStep, totalSteps }: ProgressBarProps) {
+  const colors = useThemeColors();
   return (
     <View style={styles.container}>
       <View style={styles.barContainer}>
@@ -28,12 +30,12 @@ export function ProgressBar({ currentStep, totalSteps }: ProgressBarProps) {
           return (
             <View
               key={index}
-              style={styles.barSegment}
+              style={[styles.barSegment, { backgroundColor: colors.borderLight }]}
             />
           );
         })}
       </View>
-      <Text style={styles.stepText}>
+      <Text style={[styles.stepText, { color: colors.textTertiary }]}>
         Paso {currentStep + 1} de {totalSteps}
       </Text>
     </View>
@@ -55,11 +57,9 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 4,
     borderRadius: 2,
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
   },
   stepText: {
     fontSize: 12,
-    color: 'rgba(255, 255, 255, 0.4)',
     marginTop: 8,
   },
 });

--- a/components/payment/AddCardModal.tsx
+++ b/components/payment/AddCardModal.tsx
@@ -1,14 +1,14 @@
+import { useThemeColors } from '@/hooks/useThemeColors';
 import { createPaymentMethod, ApiError as PaymentApiError } from '@/services/payments';
-import { Ionicons } from '@expo/vector-icons';
+import type { ThemeColors } from '@/utils/themeStyles';
 import { LinearGradient } from 'expo-linear-gradient';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   Modal,
   Platform,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -18,63 +18,184 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { t } from '@/i18n';
 
-// Theme colors matching the JSX design
-const colors = {
-  bg: '#1a1a2e',
-  bgCard: '#252542',
-  bgInput: '#2d2d4a',
-  primary: '#3b82f6',
-  secondary: '#10b981',
-  purple: '#8b5cf6',
-  textSecondary: '#9ca3af',
-  border: '#374151',
-  white: '#ffffff',
-  danger: '#ef4444',
-};
+const TEXT_ON_PRIMARY = '#ffffff';
+
+function createAddCardModalStyles(theme: ThemeColors) {
+  return StyleSheet.create({
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.7)',
+      justifyContent: 'flex-end',
+    },
+    modalContent: {
+      width: '100%',
+      backgroundColor: theme.screenBackground,
+      borderTopLeftRadius: 24,
+      borderTopRightRadius: 24,
+      padding: 24,
+      paddingHorizontal: 20,
+      paddingBottom: 40,
+    },
+    modalHandle: {
+      width: 40,
+      height: 4,
+      backgroundColor: theme.border,
+      borderRadius: 2,
+      alignSelf: 'center',
+      marginBottom: 20,
+    },
+    modalTitle: {
+      color: theme.textPrimary,
+      fontSize: 20,
+      fontWeight: '700',
+      marginBottom: 24,
+      textAlign: 'center',
+    },
+    inputContainer: {
+      marginBottom: 16,
+    },
+    inputRow: {
+      flexDirection: 'row',
+      gap: 12,
+      marginBottom: 16,
+    },
+    inputHalf: {
+      flex: 1,
+    },
+    inputLabel: {
+      color: theme.textSecondary,
+      fontSize: 12,
+      fontWeight: '600',
+      marginBottom: 8,
+    },
+    input: {
+      width: '100%',
+      padding: 16,
+      backgroundColor: theme.surfaceSecondary,
+      borderWidth: 1,
+      borderColor: theme.border,
+      borderRadius: 12,
+      color: theme.textPrimary,
+      fontSize: 16,
+      fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+      letterSpacing: 2,
+    },
+    inputCVV: {
+      letterSpacing: 4,
+    },
+    inputCardHolder: {
+      fontFamily: 'system',
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
+    modalButtons: {
+      flexDirection: 'row',
+      gap: 12,
+      marginTop: 24,
+    },
+    modalButtonCancel: {
+      flex: 1,
+      padding: 18,
+      backgroundColor: theme.card,
+      borderRadius: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    modalButtonConfirm: {
+      flex: 1,
+      borderRadius: 14,
+      overflow: 'hidden',
+      shadowColor: theme.primary,
+      shadowOffset: { width: 0, height: 4 },
+      shadowOpacity: 0.35,
+      shadowRadius: 15,
+      elevation: 8,
+    },
+    modalButtonConfirmLoading: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 18,
+      backgroundColor: theme.primary,
+    },
+    modalButtonGradient: {
+      padding: 18,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    modalButtonTextCancel: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.textPrimary,
+    },
+    modalButtonTextConfirm: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: TEXT_ON_PRIMARY,
+    },
+    securityNote: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      marginTop: 20,
+    },
+    lockIcon: {
+      fontSize: 14,
+    },
+    securityNoteText: {
+      color: theme.textSecondary,
+      fontSize: 11,
+    },
+  });
+}
 
 interface AddCardModalProps {
   visible: boolean;
   onClose: () => void;
   onCardAdded: () => void;
-  isDefault?: boolean; // Whether to set as default when adding
+  isDefault?: boolean;
 }
 
-// Luhn algorithm for card validation
 const validateCardNumber = (cardNumber: string): boolean => {
   const cleaned = cardNumber.replace(/\s+/g, '');
   if (cleaned.length < 13 || cleaned.length > 19) return false;
-  
+
   let sum = 0;
   let isEven = false;
-  
+
   for (let i = cleaned.length - 1; i >= 0; i--) {
     let digit = parseInt(cleaned[i], 10);
-    
+
     if (isEven) {
       digit *= 2;
       if (digit > 9) {
         digit -= 9;
       }
     }
-    
+
     sum += digit;
     isEven = !isEven;
   }
-  
+
   return sum % 10 === 0;
 };
 
-// Detect card brand from number
 const detectCardBrand = (cardNumber: string): 'visa' | 'mastercard' | 'amex' => {
   const cleaned = cardNumber.replace(/\s+/g, '');
   if (cleaned.startsWith('4')) return 'visa';
   if (cleaned.startsWith('5') || cleaned.startsWith('2')) return 'mastercard';
   if (cleaned.startsWith('3')) return 'amex';
-  return 'visa'; // Default to visa
+  return 'visa';
 };
 
 export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false }: AddCardModalProps) {
   const insets = useSafeAreaInsets();
+  const theme = useThemeColors();
+  const styles = useMemo(() => createAddCardModalStyles(theme), [theme]);
+  const confirmGradient = useMemo(() => [theme.primary, '#6d28d9'] as const, [theme.primary]);
+
   const [cardNumber, setCardNumber] = useState('');
   const [expDate, setExpDate] = useState('');
   const [cvv, setCvv] = useState('');
@@ -101,7 +222,6 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
   };
 
   const handleAddCard = async () => {
-    // Validate card number
     const cleanedCardNumber = cardNumber.replace(/\s+/g, '');
     if (cleanedCardNumber.length < 13 || cleanedCardNumber.length > 19) {
       Alert.alert(t('common.error'), t('paymentMethods.invalidCardNumber'));
@@ -113,7 +233,6 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
       return;
     }
 
-    // Validate expiry date
     const [month, year] = expDate.split('/');
     if (!month || !year || month.length !== 2 || year.length !== 2) {
       Alert.alert(t('common.error'), t('paymentMethods.invalidExpiry'));
@@ -123,19 +242,21 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
     const expMonth = parseInt(month, 10);
     const expYear = parseInt('20' + year, 10);
     const now = new Date();
-    if (expMonth < 1 || expMonth > 12 || expYear < now.getFullYear() || 
-        (expYear === now.getFullYear() && expMonth < now.getMonth() + 1)) {
+    if (
+      expMonth < 1 ||
+      expMonth > 12 ||
+      expYear < now.getFullYear() ||
+      (expYear === now.getFullYear() && expMonth < now.getMonth() + 1)
+    ) {
       Alert.alert(t('common.error'), t('paymentMethods.invalidExpiry'));
       return;
     }
 
-    // Validate CVV
     if (cvv.length < 3 || cvv.length > 4) {
       Alert.alert(t('common.error'), t('paymentMethods.invalidCVV'));
       return;
     }
 
-    // Validate card holder
     if (!cardHolder.trim()) {
       Alert.alert(t('common.error'), t('paymentMethods.invalidCardHolder'));
       return;
@@ -149,7 +270,6 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
       const expiryMonth = parseInt(month, 10);
       const expiryYear = parseInt('20' + year, 10);
 
-      // Create payment method via API
       await createPaymentMethod({
         type: brand === 'visa' ? 'visa' : brand === 'mastercard' ? 'mastercard' : 'visa',
         last4,
@@ -157,10 +277,9 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
         expiry_year: expiryYear,
         brand: brand === 'visa' ? 'Visa' : brand === 'mastercard' ? 'Mastercard' : 'Visa',
         card_holder_name: cardHolder.trim(),
-        is_default: isDefault, // Use the prop to determine if this should be default
+        is_default: isDefault,
       });
 
-      // Reset form
       setCardNumber('');
       setExpDate('');
       setCvv('');
@@ -180,7 +299,6 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
   };
 
   const handleClose = () => {
-    // Reset form when closing
     setCardNumber('');
     setExpDate('');
     setCvv('');
@@ -189,35 +307,21 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
   };
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={handleClose}
-    >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={styles.modalOverlay}
-      >
-        <TouchableOpacity
-          style={styles.modalOverlay}
-          activeOpacity={1}
-          onPress={handleClose}
-        >
-          <View style={styles.modalContent}>
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modalOverlay}>
+        <TouchableOpacity style={styles.modalOverlay} activeOpacity={1} onPress={handleClose}>
+          <View style={[styles.modalContent, { paddingBottom: insets.bottom + 24 }]}>
             <TouchableOpacity activeOpacity={1} onPress={(e) => e.stopPropagation()}>
-              {/* Handle */}
               <View style={styles.modalHandle} />
 
               <Text style={styles.modalTitle}>{t('paymentMethods.addCard')}</Text>
 
-              {/* Card Number */}
               <View style={styles.inputContainer}>
                 <Text style={styles.inputLabel}>{t('paymentMethods.cardNumber')}</Text>
                 <TextInput
                   style={styles.input}
                   placeholder="1234 5678 9012 3456"
-                  placeholderTextColor={colors.textSecondary}
+                  placeholderTextColor={theme.textSecondary}
                   maxLength={19}
                   value={cardNumber}
                   onChangeText={(text) => setCardNumber(formatCardNumber(text))}
@@ -226,14 +330,13 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
                 />
               </View>
 
-              {/* Row: Expiry & CVV */}
               <View style={styles.inputRow}>
                 <View style={[styles.inputContainer, styles.inputHalf]}>
                   <Text style={styles.inputLabel}>{t('paymentMethods.expiryDate')}</Text>
                   <TextInput
                     style={styles.input}
                     placeholder="MM/YY"
-                    placeholderTextColor={colors.textSecondary}
+                    placeholderTextColor={theme.textSecondary}
                     maxLength={5}
                     value={expDate}
                     onChangeText={(text) => setExpDate(formatExpDate(text))}
@@ -246,7 +349,7 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
                   <TextInput
                     style={[styles.input, styles.inputCVV]}
                     placeholder="•••"
-                    placeholderTextColor={colors.textSecondary}
+                    placeholderTextColor={theme.textSecondary}
                     maxLength={4}
                     value={cvv}
                     onChangeText={(text) => setCvv(text.replace(/\D/g, ''))}
@@ -257,13 +360,12 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
                 </View>
               </View>
 
-              {/* Card Holder */}
               <View style={styles.inputContainer}>
                 <Text style={styles.inputLabel}>{t('paymentMethods.cardHolder')}</Text>
                 <TextInput
                   style={[styles.input, styles.inputCardHolder]}
                   placeholder={t('paymentMethods.cardHolderPlaceholder')}
-                  placeholderTextColor={colors.textSecondary}
+                  placeholderTextColor={theme.textSecondary}
                   value={cardHolder}
                   onChangeText={(text) => setCardHolder(text.toUpperCase())}
                   autoCapitalize="characters"
@@ -271,27 +373,18 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
                 />
               </View>
 
-              {/* Buttons */}
               <View style={styles.modalButtons}>
-                <TouchableOpacity
-                  onPress={handleClose}
-                  style={styles.modalButtonCancel}
-                  activeOpacity={0.7}
-                >
+                <TouchableOpacity onPress={handleClose} style={styles.modalButtonCancel} activeOpacity={0.7}>
                   <Text style={styles.modalButtonTextCancel}>{t('common.cancel')}</Text>
                 </TouchableOpacity>
                 {loading ? (
                   <View style={[styles.modalButtonConfirm, styles.modalButtonConfirmLoading]}>
-                    <ActivityIndicator color="#FFFFFF" />
+                    <ActivityIndicator color={TEXT_ON_PRIMARY} />
                   </View>
                 ) : (
-                  <TouchableOpacity
-                    onPress={handleAddCard}
-                    style={styles.modalButtonConfirm}
-                    activeOpacity={0.7}
-                  >
+                  <TouchableOpacity onPress={handleAddCard} style={styles.modalButtonConfirm} activeOpacity={0.7}>
                     <LinearGradient
-                      colors={[colors.primary, colors.purple]}
+                      colors={confirmGradient}
                       start={{ x: 0, y: 0 }}
                       end={{ x: 1, y: 1 }}
                       style={styles.modalButtonGradient}
@@ -302,7 +395,6 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
                 )}
               </View>
 
-              {/* Security Note */}
               <View style={styles.securityNote}>
                 <Text style={styles.lockIcon}>🔒</Text>
                 <Text style={styles.securityNoteText}>{t('paymentMethods.sslEncryption')}</Text>
@@ -314,130 +406,3 @@ export function AddCardModal({ visible, onClose, onCardAdded, isDefault = false 
     </Modal>
   );
 }
-
-const styles = StyleSheet.create({
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.7)',
-    justifyContent: 'flex-end',
-  },
-  modalContent: {
-    width: '100%',
-    backgroundColor: colors.bg,
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    padding: 24,
-    paddingHorizontal: 20,
-    paddingBottom: 40,
-  },
-  modalHandle: {
-    width: 40,
-    height: 4,
-    backgroundColor: colors.border,
-    borderRadius: 2,
-    alignSelf: 'center',
-    marginBottom: 20,
-  },
-  modalTitle: {
-    color: colors.white,
-    fontSize: 20,
-    fontWeight: '700',
-    marginBottom: 24,
-    textAlign: 'center',
-  },
-  inputContainer: {
-    marginBottom: 16,
-  },
-  inputRow: {
-    flexDirection: 'row',
-    gap: 12,
-    marginBottom: 16,
-  },
-  inputHalf: {
-    flex: 1,
-  },
-  inputLabel: {
-    color: colors.textSecondary,
-    fontSize: 12,
-    fontWeight: '600',
-    marginBottom: 8,
-  },
-  input: {
-    width: '100%',
-    padding: 16,
-    backgroundColor: colors.bgInput,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: 12,
-    color: colors.white,
-    fontSize: 16,
-    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-    letterSpacing: 2,
-  },
-  inputCVV: {
-    letterSpacing: 4,
-  },
-  inputCardHolder: {
-    fontFamily: 'system',
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-  },
-  modalButtons: {
-    flexDirection: 'row',
-    gap: 12,
-    marginTop: 24,
-  },
-  modalButtonCancel: {
-    flex: 1,
-    padding: 18,
-    backgroundColor: colors.bgCard,
-    borderRadius: 14,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  modalButtonConfirm: {
-    flex: 1,
-    borderRadius: 14,
-    overflow: 'hidden',
-    shadowColor: colors.primary,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.4,
-    shadowRadius: 15,
-    elevation: 8,
-  },
-  modalButtonConfirmLoading: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 18,
-    backgroundColor: colors.primary,
-  },
-  modalButtonGradient: {
-    padding: 18,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  modalButtonTextCancel: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: colors.white,
-  },
-  modalButtonTextConfirm: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: colors.white,
-  },
-  securityNote: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    marginTop: 20,
-  },
-  lockIcon: {
-    fontSize: 14,
-  },
-  securityNoteText: {
-    color: colors.textSecondary,
-    fontSize: 11,
-  },
-});

--- a/components/profile/ProfileFooter.tsx
+++ b/components/profile/ProfileFooter.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 /** Version label shown in profile footer for both Client and Provider. */
-const PROFILE_VERSION_LABEL = "3.0.7";
+const PROFILE_VERSION_LABEL = "3.0.8";
 
 /**
  * Shared footer for Client and Provider profile screens: app version label and logout button.


### PR DESCRIPTION
- Replace hardcoded dark colors with useThemeColors / theme tokens across booking, chat, orders, provider jobs/messages/profile, account, services, supplier detail, and provider onboarding bank screen.
- Switch mode: theme-driven styles via createSwitchModeStyles; readable info banner text in light mode; remove duplicate StyleSheet; scroll background.
- Shared components: BookingDateTimePicker, ProgressBar, AddCardModal, ProfileFooter aligned with theme surfaces and text colors.
