### PR TITLE
fix(lists): avoid FlashList AutoLayoutView crash with FlatList wrappe…

### DIFF
--- a/app/(provider-tabs)/profile/reviews.tsx
+++ b/app/(provider-tabs)/profile/reviews.tsx
@@ -10,7 +10,7 @@ import {
     type ProviderReviewsSort,
 } from "@/services/reviews";
 import { Ionicons } from "@expo/vector-icons";
-import { FlashList } from "@shopify/flash-list";
+import { PlatformFlashList } from "@/components/PlatformFlashList";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
@@ -202,7 +202,7 @@ export default function ProviderReviewsScreen() {
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
-        <FlashList
+        <PlatformFlashList
           data={allReviews}
           keyExtractor={(item) => item.id}
           estimatedItemSize={180}

--- a/app/(provider-tabs)/profile/services/index.tsx
+++ b/app/(provider-tabs)/profile/services/index.tsx
@@ -7,7 +7,7 @@ import {
     updateProviderServiceStatus,
 } from "@/services/providerServices";
 import { Ionicons } from "@expo/vector-icons";
-import { FlashList } from "@shopify/flash-list";
+import { PlatformFlashList } from "@/components/PlatformFlashList";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { useCallback, useState } from "react";
@@ -276,7 +276,7 @@ export default function ProviderServicesScreen() {
           </TouchableOpacity>
         </View>
       ) : (
-        <FlashList
+        <PlatformFlashList
           data={services}
           renderItem={renderItem}
           estimatedItemSize={140}

--- a/app/(provider-tabs)/requests.tsx
+++ b/app/(provider-tabs)/requests.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/services/providerDashboard";
 import type { ThemeColors } from "@/utils/themeStyles";
 import { Ionicons } from "@expo/vector-icons";
-import { FlashList } from "@shopify/flash-list";
+import { PlatformFlashList } from "@/components/PlatformFlashList";
 import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -304,7 +304,7 @@ export default function ProviderRequestsScreen() {
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
-        <FlashList
+        <PlatformFlashList
           data={requests}
           renderItem={renderItem}
           estimatedItemSize={140}

--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -3,7 +3,7 @@ import { useThemeColors } from '@/hooks/useThemeColors';
 import { t } from '@/i18n';
 import { Conversation, fetchConversations } from '@/services/conversations';
 import { Ionicons } from '@expo/vector-icons';
-import { FlashList } from '@shopify/flash-list';
+import { PlatformFlashList } from '@/components/PlatformFlashList';
 import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -386,7 +386,7 @@ export default function ConversationsListScreen() {
         </View>
       ) : (
         <View style={styles.listWrapper}>
-          <FlashList
+          <PlatformFlashList
             data={conversations}
             keyExtractor={(item) => item.id}
             renderItem={renderConversation}

--- a/app/services/search-results.tsx
+++ b/app/services/search-results.tsx
@@ -17,7 +17,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { FlashList } from '@shopify/flash-list';
+import { PlatformFlashList } from '@/components/PlatformFlashList';
 
 type FilterType = 'all' | 'near_me' | 'top_rated' | 'low_price' | 'available_today';
 
@@ -321,7 +321,7 @@ export default function SearchResultsScreen() {
           </TouchableOpacity>
         </View>
       ) : (
-        <FlashList
+        <PlatformFlashList
           data={suppliers}
           renderItem={({ item }) => {
             // Validate item before rendering

--- a/components/PlatformFlashList.tsx
+++ b/components/PlatformFlashList.tsx
@@ -1,0 +1,17 @@
+import type { FlashListProps } from "@shopify/flash-list";
+import React from "react";
+import { FlatList, type FlatListProps } from "react-native";
+
+/**
+ * FlashList v1 depends on native `AutoLayoutView`. That fails on web and can
+ * fail on native (e.g. dev client built without FlashList, or bridge mismatch)
+ * with "View config not found for component 'AutoLayoutView'".
+ *
+ * This component keeps the FlashList props type but always renders FlatList
+ * (ignoring `estimatedItemSize`). Lists stay stable; revisit FlashList v2 or a
+ * rebuilt native binary if you need recycling perf on very large lists.
+ */
+export function PlatformFlashList<T>(props: FlashListProps<T>): React.ReactElement {
+  const { estimatedItemSize: _estimatedItemSize, ...rest } = props;
+  return <FlatList<T> {...(rest as FlatListProps<T>)} />;
+}


### PR DESCRIPTION
…r (MDB-392)

- Add PlatformFlashList: FlashListProps typing but always render FlatList so native AutoLayoutView is never required (fixes web and mis-linked dev clients).
- Replace direct FlashList usage in provider requests, chat, search results, provider services list, and provider reviews.

FlashList v1 native views were missing in some builds, causing invariant "View config not found for component AutoLayoutView" and contentContainerStyle warnings.
