### PR TITLE
feat(provider-support): FAQ help stack, legal viewer, and determinist…

### DIFF
--- a/app/(provider-tabs)/profile/_layout.tsx
+++ b/app/(provider-tabs)/profile/_layout.tsx
@@ -22,6 +22,10 @@ export default function ProviderProfileLayout() {
       <Stack.Screen name="service-area" />
       <Stack.Screen name="payment-methods" />
       <Stack.Screen name="services" />
+      <Stack.Screen name="help-center" />
+      <Stack.Screen name="contact-support" />
+      <Stack.Screen name="terms-privacy" />
+      <Stack.Screen name="legal-document/[docType]" />
     </Stack>
   );
 }

--- a/app/(provider-tabs)/profile/contact-support.tsx
+++ b/app/(provider-tabs)/profile/contact-support.tsx
@@ -1,0 +1,227 @@
+import { ProviderSubScreenHeader } from '@/components/provider/ProviderSubScreenHeader';
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { t } from '@/i18n';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import React, { useCallback } from 'react';
+import {
+  Alert,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export default function ProviderContactSupportScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+
+  const goBackToConfiguration = useCallback(() => {
+    router.replace('/(provider-tabs)/profile/settings' as never);
+  }, [router]);
+
+  const handleLiveChat = useCallback(() => {
+    Alert.alert(t('helpCenter.liveChat'), t('helpCenter.liveChatComingBody'));
+  }, []);
+
+  const handleEmailSupport = useCallback(() => {
+    const email = t('helpCenter.emailAddress');
+    const subject = encodeURIComponent(t('helpCenter.emailDefaultSubject'));
+    const body = encodeURIComponent(t('helpCenter.emailDefaultBody'));
+    const mailtoUrl = `mailto:${email}?subject=${subject}&body=${body}`;
+    Linking.openURL(mailtoUrl).catch(() => {
+      Alert.alert(t('common.error'), t('helpCenter.openEmailFailed'));
+    });
+  }, []);
+
+  const handlePhoneSupport = useCallback(() => {
+    const phoneNumber = t('helpCenter.phoneNumber').replace(/\s/g, '');
+    Linking.openURL(`tel:${phoneNumber}`).catch(() => {
+      Alert.alert(t('common.error'), t('helpCenter.openPhoneFailed'));
+    });
+  }, []);
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <ProviderSubScreenHeader
+        title={t('providerDashboard.providerSettings.contactSupport')}
+        onBack={goBackToConfiguration}
+        accessibilityLabelBack={t('providerDashboard.providerSettings.back')}
+      />
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: 32 + insets.bottom }]}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={[styles.sectionLabel, { color: colors.textTertiary }]}>
+          {t('providerDashboard.providerSupportScreens.chatSection')}
+        </Text>
+        <View style={[styles.statusCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
+          <View style={styles.statusRow}>
+            <View style={[styles.dot, { backgroundColor: colors.primary }]} />
+            <Text style={[styles.statusTitle, { color: colors.textPrimary }]}>
+              {t('providerDashboard.providerSupportScreens.statusOnline')}
+            </Text>
+          </View>
+          <Text style={[styles.statusHint, { color: colors.textSecondary }]}>
+            {t('providerDashboard.providerSupportScreens.chatHoursHint')}
+          </Text>
+          <TouchableOpacity
+            style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+            onPress={handleLiveChat}
+            activeOpacity={0.85}
+          >
+            <Text style={styles.primaryButtonText}>{t('providerDashboard.providerSupportScreens.startChat')}</Text>
+          </TouchableOpacity>
+        </View>
+
+        <Text style={[styles.sectionLabel, styles.sectionSpaced, { color: colors.textTertiary }]}>
+          {t('helpCenter.contact')}
+        </Text>
+
+        <TouchableOpacity
+          style={[styles.row, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+          onPress={handleEmailSupport}
+          activeOpacity={0.75}
+        >
+          <View style={[styles.iconBox, { backgroundColor: `${colors.primary}20` }]}>
+            <Text style={styles.emoji}>📧</Text>
+          </View>
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: colors.textPrimary }]}>{t('helpCenter.email')}</Text>
+            <Text style={[styles.rowDesc, { color: colors.textSecondary }]}>{t('helpCenter.emailAddress')}</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.row, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+          onPress={handlePhoneSupport}
+          activeOpacity={0.75}
+        >
+          <View style={[styles.iconBox, { backgroundColor: `${colors.primary}20` }]}>
+            <Text style={styles.emoji}>📞</Text>
+          </View>
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: colors.textPrimary }]}>{t('helpCenter.phone')}</Text>
+            <Text style={[styles.rowDesc, { color: colors.textSecondary }]}>{t('helpCenter.phoneNumber')}</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+        </TouchableOpacity>
+
+        <Text style={[styles.sectionLabel, styles.sectionSpaced, { color: colors.textTertiary }]}>
+          {t('providerDashboard.providerSupportScreens.formalRequests')}
+        </Text>
+        <TouchableOpacity
+          style={[styles.row, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+          onPress={() => router.push('/account/complaints')}
+          activeOpacity={0.75}
+        >
+          <View style={[styles.iconBox, { backgroundColor: `${colors.primary}20` }]}>
+            <Text style={styles.emoji}>📋</Text>
+          </View>
+          <View style={styles.rowText}>
+            <Text style={[styles.rowTitle, { color: colors.textPrimary }]}>
+              {t('helpCenter.complaintsRowTitle')}
+            </Text>
+            <Text style={[styles.rowDesc, { color: colors.textSecondary }]}>
+              {t('helpCenter.complaintsRowSubtitle')}
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    marginBottom: 12,
+  },
+  sectionSpaced: {
+    marginTop: 24,
+  },
+  statusCard: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+    gap: 10,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  statusTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  statusHint: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  primaryButton: {
+    marginTop: 4,
+    paddingVertical: 12,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 10,
+    gap: 12,
+  },
+  iconBox: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emoji: {
+    fontSize: 20,
+  },
+  rowText: {
+    flex: 1,
+  },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  rowDesc: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+});

--- a/app/(provider-tabs)/profile/help-center.tsx
+++ b/app/(provider-tabs)/profile/help-center.tsx
@@ -1,0 +1,48 @@
+import { HelpCenterScrollContent } from '@/components/help/HelpCenterScrollContent';
+import { ProviderSubScreenHeader } from '@/components/provider/ProviderSubScreenHeader';
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { t } from '@/i18n';
+import { useRouter } from 'expo-router';
+import React, { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export default function ProviderHelpCenterScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+
+  const goContact = useCallback(() => {
+    router.push('/(provider-tabs)/profile/contact-support');
+  }, [router]);
+
+  const goBackToConfiguration = useCallback(() => {
+    router.replace('/(provider-tabs)/profile/settings' as never);
+  }, [router]);
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <ProviderSubScreenHeader
+        title={t('helpCenter.title')}
+        onBack={goBackToConfiguration}
+        accessibilityLabelBack={t('providerDashboard.providerSettings.back')}
+      />
+      <HelpCenterScrollContent
+        faqAudience="provider"
+        showComplaintsRow={false}
+        showInlineContactSection={false}
+        onPressComplaints={() => router.push('/account/complaints')}
+        onPressMoreHelp={goContact}
+        moreHelpLabel={t('providerDashboard.providerSupportScreens.helpCenterMoreHelpTitle')}
+        moreHelpSubtitle={t('providerDashboard.providerSupportScreens.helpCenterMoreHelpSubtitle')}
+        bottomInset={insets.bottom}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/app/(provider-tabs)/profile/legal-document/[docType].tsx
+++ b/app/(provider-tabs)/profile/legal-document/[docType].tsx
@@ -1,0 +1,161 @@
+import { ProviderSubScreenHeader } from '@/components/provider/ProviderSubScreenHeader';
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { getLocale, t } from '@/i18n';
+import { fetchLegalDocument, isLegalDocType, type LegalDocType } from '@/services/legal';
+import { useQuery } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+import { enUS, es as esLocale } from 'date-fns/locale';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useCallback, useMemo } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { WebView } from 'react-native-webview';
+
+function wrapLegalHtml(body: string, background: string, foreground: string, link: string): string {
+  const safeBody = body || '<p></p>';
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+<style>
+  body { margin:0; padding:16px; font-family:-apple-system,BlinkMacSystemFont,sans-serif;
+    background:${background}; color:${foreground}; font-size:16px; line-height:1.5; }
+  a { color:${link}; }
+  img { max-width:100%; height:auto; }
+</style>
+</head>
+<body>${safeBody}</body>
+</html>`;
+}
+
+function titleForDoc(docType: LegalDocType): string {
+  switch (docType) {
+    case 'terms_of_service':
+      return t('providerDashboard.providerLegal.termsOfServiceTitle');
+    case 'privacy_policy':
+      return t('providerDashboard.providerLegal.privacyTitle');
+    case 'cookie_policy':
+      return t('providerDashboard.providerLegal.cookiesTitle');
+    case 'provider_agreement':
+      return t('providerDashboard.providerLegal.providerAgreementTitle');
+    default:
+      return t('providerDashboard.providerSettings.termsPrivacy');
+  }
+}
+
+export default function ProviderLegalDocumentScreen() {
+  const { docType: rawDoc } = useLocalSearchParams<{ docType: string }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+  const appLocale = getLocale();
+
+  const goBackToTermsList = useCallback(() => {
+    router.replace('/(provider-tabs)/profile/terms-privacy' as never);
+  }, [router]);
+
+  const docType = typeof rawDoc === 'string' ? rawDoc : '';
+  const valid = isLegalDocType(docType);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['legalDocument', docType, appLocale],
+    queryFn: () => fetchLegalDocument(docType as LegalDocType, appLocale),
+    enabled: valid,
+  });
+
+  const updatedLabel = useMemo(() => {
+    if (!data?.updatedAt) return null;
+    try {
+      const d = parseISO(String(data.updatedAt));
+      const loc = appLocale === 'es' ? esLocale : enUS;
+      return format(d, 'PPP', { locale: loc });
+    } catch {
+      return null;
+    }
+  }, [data?.updatedAt, appLocale]);
+
+  const html = useMemo(() => {
+    if (!data?.bodyHtml) return wrapLegalHtml('<p></p>', colors.background, colors.textPrimary, colors.primary);
+    return wrapLegalHtml(data.bodyHtml, colors.background, colors.textPrimary, colors.primary);
+  }, [data?.bodyHtml, colors.background, colors.textPrimary, colors.primary]);
+
+  if (!valid) {
+    return (
+      <View style={[styles.centered, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+        <ProviderSubScreenHeader
+          title={t('providerDashboard.providerSettings.termsPrivacy')}
+          onBack={goBackToTermsList}
+          accessibilityLabelBack={t('providerDashboard.providerSettings.back')}
+        />
+        <Text style={{ color: colors.textSecondary, paddingHorizontal: 20 }}>
+          {t('providerDashboard.providerLegal.loadError')}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <ProviderSubScreenHeader
+        title={titleForDoc(docType)}
+        onBack={goBackToTermsList}
+        accessibilityLabelBack={t('providerDashboard.providerSettings.back')}
+      />
+      {updatedLabel ? (
+        <Text style={[styles.meta, { color: colors.textTertiary }]}>
+          {t('providerDashboard.providerLegal.lastUpdated', { date: updatedLabel })}
+        </Text>
+      ) : null}
+      {isLoading ? (
+        <View style={styles.loader}>
+          <ActivityIndicator size="large" color={colors.primary} />
+          <Text style={[styles.loaderText, { color: colors.textSecondary }]}>{t('common.loading')}</Text>
+        </View>
+      ) : isError ? (
+        <View style={styles.loader}>
+          <Text style={[styles.loaderText, { color: colors.textSecondary }]}>
+            {error instanceof Error ? error.message : t('providerDashboard.providerLegal.loadError')}
+          </Text>
+        </View>
+      ) : (
+        <WebView
+          style={styles.webview}
+          originWhitelist={['*']}
+          source={{ html }}
+          setSupportMultipleWindows={false}
+          nestedScrollEnabled
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+  },
+  meta: {
+    paddingHorizontal: 20,
+    paddingBottom: 8,
+    fontSize: 12,
+  },
+  webview: {
+    flex: 1,
+    backgroundColor: 'transparent',
+  },
+  loader: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 24,
+  },
+  loaderText: {
+    fontSize: 14,
+    textAlign: 'center',
+  },
+});

--- a/app/(provider-tabs)/profile/settings.tsx
+++ b/app/(provider-tabs)/profile/settings.tsx
@@ -77,8 +77,9 @@ export default function ProviderSettingsScreen() {
     { icon: "stats-chart-outline", labelKey: "providerDashboard.providerSettings.statistics", descKey: "providerDashboard.providerSettings.statisticsDesc", route: "/(provider-tabs)/profile/statistics" },
   ];
   const supportRows: SettingsRow[] = [
-    { icon: "help-circle-outline", labelKey: "providerDashboard.providerSettings.helpCenter", descKey: "providerDashboard.providerSettings.helpCenterDesc", route: "/account/support" },
-    { icon: "document-outline", labelKey: "providerDashboard.providerSettings.termsPrivacy", descKey: "providerDashboard.providerSettings.termsPrivacyDesc", route: "/account/support" },
+    { icon: "help-circle-outline", labelKey: "providerDashboard.providerSettings.helpCenter", descKey: "providerDashboard.providerSettings.helpCenterDesc", route: "/(provider-tabs)/profile/help-center" },
+    { icon: "chatbubble-ellipses-outline", labelKey: "providerDashboard.providerSettings.contactSupport", descKey: "providerDashboard.providerSettings.contactSupportDesc", route: "/(provider-tabs)/profile/contact-support" },
+    { icon: "document-outline", labelKey: "providerDashboard.providerSettings.termsPrivacy", descKey: "providerDashboard.providerSettings.termsPrivacyDesc", route: "/(provider-tabs)/profile/terms-privacy" },
   ];
 
   return (
@@ -86,7 +87,7 @@ export default function ProviderSettingsScreen() {
       <View style={styles.header}>
         <TouchableOpacity
           style={styles.backButton}
-          onPress={() => router.back()}
+          onPress={() => router.replace("/(provider-tabs)/profile" as never)}
           activeOpacity={0.8}
           accessibilityLabel={t("providerDashboard.providerSettings.back")}
           accessibilityRole="button"
@@ -103,25 +104,25 @@ export default function ProviderSettingsScreen() {
         <SettingsSection
           sectionTitleKey="providerDashboard.providerSettings.sectionAccount"
           rows={accountRows}
-          onRowPress={(route) => router.push(route)}
+          onRowPress={(route) => router.push(route as never)}
           colors={colors}
         />
         <SettingsSection
           sectionTitleKey="providerDashboard.providerSettings.sectionPreferences"
           rows={preferencesRows}
-          onRowPress={(route) => router.push(route)}
+          onRowPress={(route) => router.push(route as never)}
           colors={colors}
         />
         <SettingsSection
           sectionTitleKey="providerDashboard.providerSettings.sectionBusiness"
           rows={businessRows}
-          onRowPress={(route) => router.push(route)}
+          onRowPress={(route) => router.push(route as never)}
           colors={colors}
         />
         <SettingsSection
           sectionTitleKey="providerDashboard.providerSettings.sectionSupport"
           rows={supportRows}
-          onRowPress={(route) => router.push(route)}
+          onRowPress={(route) => router.push(route as never)}
           colors={colors}
         />
       </ScrollView>

--- a/app/(provider-tabs)/profile/terms-privacy.tsx
+++ b/app/(provider-tabs)/profile/terms-privacy.tsx
@@ -1,0 +1,134 @@
+import { ProviderSubScreenHeader } from '@/components/provider/ProviderSubScreenHeader';
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { t } from '@/i18n';
+import type { LegalDocType } from '@/services/legal';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import React, { useCallback, useMemo } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type DocRow = {
+  docType: LegalDocType;
+  icon: keyof typeof Ionicons.glyphMap;
+  titleKey: string;
+  subtitleKey: string;
+};
+
+export default function ProviderTermsPrivacyScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+
+  const goBackToConfiguration = useCallback(() => {
+    router.replace('/(provider-tabs)/profile/settings' as never);
+  }, [router]);
+
+  const rows: DocRow[] = useMemo(
+    () => [
+      {
+        docType: 'terms_of_service',
+        icon: 'document-text-outline',
+        titleKey: 'providerDashboard.providerLegal.termsOfServiceTitle',
+        subtitleKey: 'providerDashboard.providerLegal.termsOfServiceSubtitle',
+      },
+      {
+        docType: 'privacy_policy',
+        icon: 'shield-checkmark-outline',
+        titleKey: 'providerDashboard.providerLegal.privacyTitle',
+        subtitleKey: 'providerDashboard.providerLegal.privacySubtitle',
+      },
+      {
+        docType: 'cookie_policy',
+        icon: 'cafe-outline',
+        titleKey: 'providerDashboard.providerLegal.cookiesTitle',
+        subtitleKey: 'providerDashboard.providerLegal.cookiesSubtitle',
+      },
+      {
+        docType: 'provider_agreement',
+        icon: 'briefcase-outline',
+        titleKey: 'providerDashboard.providerLegal.providerAgreementTitle',
+        subtitleKey: 'providerDashboard.providerLegal.providerAgreementSubtitle',
+      },
+    ],
+    []
+  );
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <ProviderSubScreenHeader
+        title={t('providerDashboard.providerSettings.termsPrivacy')}
+        onBack={goBackToConfiguration}
+        accessibilityLabelBack={t('providerDashboard.providerSettings.back')}
+      />
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: 32 + insets.bottom }]}
+        showsVerticalScrollIndicator={false}
+      >
+        {rows.map((row) => (
+          <TouchableOpacity
+            key={row.docType}
+            style={[styles.row, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}
+            onPress={() =>
+              router.push(`/(provider-tabs)/profile/legal-document/${row.docType}` as never)
+            }
+            activeOpacity={0.75}
+          >
+            <View style={[styles.iconBox, { backgroundColor: `${colors.primary}20` }]}>
+              <Ionicons name={row.icon} size={22} color={colors.primary} />
+            </View>
+            <View style={styles.rowText}>
+              <Text style={[styles.rowTitle, { color: colors.textPrimary }]}>{t(row.titleKey)}</Text>
+              <Text style={[styles.rowDesc, { color: colors.textSecondary }]}>{t(row.subtitleKey)}</Text>
+            </View>
+            <Text style={[styles.arrow, { color: colors.textTertiary }]}>→</Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    gap: 10,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 4,
+  },
+  iconBox: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 14,
+  },
+  rowText: {
+    flex: 1,
+  },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  rowDesc: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  arrow: {
+    fontSize: 14,
+  },
+});

--- a/app/account/support.tsx
+++ b/app/account/support.tsx
@@ -1,97 +1,19 @@
+import { HelpCenterScrollContent } from '@/components/help/HelpCenterScrollContent';
 import { useThemeColors } from '@/hooks/useThemeColors';
-import { fetchFaqs, flattenFaqsToItems, type FaqListItem } from '@/services/faqs';
 import { t } from '@/i18n';
-import { getLocale } from '@/i18n';
 import { Ionicons } from '@expo/vector-icons';
-import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
-import React, { useMemo, useState } from 'react';
-import {
-  ActivityIndicator,
-  Alert,
-  Linking,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function HelpCenterScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
-  const [searchQuery, setSearchQuery] = useState('');
-  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(new Set());
-
-  const locale = getLocale();
-  const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ['faqs', locale],
-    queryFn: () => fetchFaqs(locale),
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const faqItems: FaqListItem[] = useMemo(() => {
-    if (!data?.categories?.length) return [];
-    return flattenFaqsToItems(data.categories);
-  }, [data?.categories]);
-
-  const filteredFaqs = useMemo(() => {
-    if (!searchQuery.trim()) return faqItems;
-    const query = searchQuery.toLowerCase();
-    return faqItems.filter(
-      (item) =>
-        item.question.toLowerCase().includes(query) ||
-        item.answer.toLowerCase().includes(query)
-    );
-  }, [searchQuery, faqItems]);
-
-  const toggleFaq = (id: string) => {
-    setExpandedFaqs((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
-
-  const handleComplaints = () => {
-    router.push('/account/complaints');
-  };
-
-  const handleLiveChat = () => {
-    // TODO: Implement live chat integration
-    Alert.alert(
-      t('helpCenter.liveChat'),
-      'Live chat will be available soon. Please use email or phone support for now.'
-    );
-  };
-
-  const handleEmailSupport = () => {
-    const email = t('helpCenter.emailAddress');
-    const subject = encodeURIComponent('Support Request');
-    const body = encodeURIComponent('Hello,\n\nI need help with:\n\n');
-    const mailtoUrl = `mailto:${email}?subject=${subject}&body=${body}`;
-
-    Linking.openURL(mailtoUrl).catch(() => {
-      Alert.alert(t('common.error'), 'Could not open email client');
-    });
-  };
-
-  const handlePhoneSupport = () => {
-    const phoneNumber = t('helpCenter.phoneNumber').replace(/\s/g, '');
-    const phoneUrl = `tel:${phoneNumber}`;
-
-    Linking.openURL(phoneUrl).catch(() => {
-      Alert.alert(t('common.error'), 'Could not open phone dialer');
-    });
-  };
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['bottom']}>
-      {/* Header */}
       <View
         style={[
           styles.header,
@@ -103,201 +25,20 @@ export default function HelpCenterScreen() {
           },
         ]}
       >
-        <TouchableOpacity
-          style={styles.backButton}
-          onPress={() => router.back()}
-          activeOpacity={0.7}
-        >
-          <Ionicons
-            name="arrow-back"
-            size={24}
-            color={colors.textPrimary}
-          />
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()} activeOpacity={0.7}>
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>
-          {t('helpCenter.title')}
-        </Text>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t('helpCenter.title')}</Text>
         <View style={styles.headerPlaceholder} />
       </View>
 
-      <ScrollView
-        style={[styles.scrollView, { backgroundColor: colors.background }]}
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: 20 + insets.bottom, backgroundColor: colors.background },
-        ]}
-        showsVerticalScrollIndicator={false}
-      >
-        {/* Search Bar - Exact match to JSX */}
-        <View style={styles.searchContainer}>
-          <View style={[styles.searchInputContainer, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-            <Text style={styles.searchIcon}>🔍</Text>
-            <TextInput
-              style={[styles.searchInput, { color: colors.textPrimary }]}
-              placeholder={t('helpCenter.searchPlaceholder')}
-              placeholderTextColor={colors.textTertiary}
-              value={searchQuery}
-              onChangeText={setSearchQuery}
-            />
-          </View>
-        </View>
-
-        {/* FAQs Section - from API (CRM/Backoffice) */}
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
-          {t('helpCenter.frequentlyAskedQuestions')}
-        </Text>
-
-        {isLoading ? (
-          <View style={styles.loadingContainer}>
-            <ActivityIndicator size="large" color={colors.primary} />
-            <Text style={[styles.loadingText, { color: colors.textSecondary }]}>{t('common.loading')}</Text>
-          </View>
-        ) : isError ? (
-          <View style={styles.noResultsContainer}>
-            <Text style={[styles.noResultsText, { color: colors.textSecondary }]}>
-              {error instanceof Error ? error.message : t('helpCenter.noResults')}
-            </Text>
-            <TouchableOpacity style={[styles.retryButton, { backgroundColor: colors.primary }]} onPress={() => refetch()} activeOpacity={0.7}>
-              <Text style={styles.retryButtonText}>{t('chat.retry')}</Text>
-            </TouchableOpacity>
-          </View>
-        ) : filteredFaqs.length > 0 ? (
-          filteredFaqs.map((faq) => {
-            const isExpanded = expandedFaqs.has(faq.id);
-            return (
-              <View key={faq.id} style={[styles.faqItem, { backgroundColor: colors.card }]}>
-                <TouchableOpacity
-                  style={styles.faqHeader}
-                  onPress={() => toggleFaq(faq.id)}
-                  activeOpacity={0.7}
-                >
-                  <Text style={styles.faqIcon}>{faq.icon}</Text>
-                  <Text style={[styles.faqQuestion, { color: colors.textPrimary }]}>{faq.question}</Text>
-                  <Ionicons
-                    name={isExpanded ? 'chevron-up' : 'chevron-forward'}
-                    size={20}
-                    color={colors.textTertiary}
-                  />
-                </TouchableOpacity>
-                {isExpanded && (
-                  <View style={[styles.faqAnswerContainer, { borderTopColor: colors.cardBorder }]}>
-                    <Text style={[styles.faqAnswer, { color: colors.textSecondary }]}>{faq.answer}</Text>
-                  </View>
-                )}
-              </View>
-            );
-          })
-        ) : (
-          <View style={styles.noResultsContainer}>
-            <Text style={[styles.noResultsText, { color: colors.textSecondary }]}>
-              {t('helpCenter.noResults')}
-            </Text>
-          </View>
-        )}
-
-        {/* Contact Section - Exact match to JSX */}
-        <Text style={[styles.sectionTitle, styles.contactSectionTitle, { color: colors.textSecondary }]}>
-          {t('helpCenter.contact')}
-        </Text>
-
-        {/* Complaints & suggestions (formal requests — same as /account/complaints) */}
-        <TouchableOpacity
-          style={[styles.contactItem, { backgroundColor: colors.card }]}
-          onPress={handleComplaints}
-          activeOpacity={0.7}
-          accessibilityRole="button"
-          accessibilityLabel={t('helpCenter.complaintsRowTitle')}
-        >
-          <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
-            <Text style={styles.contactIcon}>📋</Text>
-          </View>
-          <View style={styles.contactTextContainer}>
-            <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
-              {t('helpCenter.complaintsRowTitle')}
-            </Text>
-            <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
-              {t('helpCenter.complaintsRowSubtitle')}
-            </Text>
-          </View>
-          <Ionicons
-            name="chevron-forward"
-            size={20}
-            color={colors.textTertiary}
-          />
-        </TouchableOpacity>
-
-        {/* Live Chat */}
-        <TouchableOpacity
-          style={[styles.contactItem, { backgroundColor: colors.card }]}
-          onPress={handleLiveChat}
-          activeOpacity={0.7}
-        >
-          <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
-            <Text style={styles.contactIcon}>💬</Text>
-          </View>
-          <View style={styles.contactTextContainer}>
-            <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
-              {t('helpCenter.liveChat')}
-            </Text>
-            <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
-              {t('helpCenter.liveChatSubtitle')}
-            </Text>
-          </View>
-          <Ionicons
-            name="chevron-forward"
-            size={20}
-            color={colors.textTertiary}
-          />
-        </TouchableOpacity>
-
-        {/* Email */}
-        <TouchableOpacity
-          style={[styles.contactItem, { backgroundColor: colors.card }]}
-          onPress={handleEmailSupport}
-          activeOpacity={0.7}
-        >
-          <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
-            <Text style={styles.contactIcon}>📧</Text>
-          </View>
-          <View style={styles.contactTextContainer}>
-            <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
-              {t('helpCenter.email')}
-            </Text>
-            <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
-              {t('helpCenter.emailAddress')}
-            </Text>
-          </View>
-          <Ionicons
-            name="chevron-forward"
-            size={20}
-            color={colors.textTertiary}
-          />
-        </TouchableOpacity>
-
-        {/* Phone */}
-        <TouchableOpacity
-          style={[styles.contactItem, { backgroundColor: colors.card }]}
-          onPress={handlePhoneSupport}
-          activeOpacity={0.7}
-        >
-          <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
-            <Text style={styles.contactIcon}>📞</Text>
-          </View>
-          <View style={styles.contactTextContainer}>
-            <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
-              {t('helpCenter.phone')}
-            </Text>
-            <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
-              {t('helpCenter.phoneNumber')}
-            </Text>
-          </View>
-          <Ionicons
-            name="chevron-forward"
-            size={20}
-            color={colors.textTertiary}
-          />
-        </TouchableOpacity>
-      </ScrollView>
+      <HelpCenterScrollContent
+        faqAudience="client"
+        showComplaintsRow
+        showInlineContactSection
+        onPressComplaints={() => router.push('/account/complaints')}
+        bottomInset={insets.bottom}
+      />
     </SafeAreaView>
   );
 }
@@ -305,13 +46,11 @@ export default function HelpCenterScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a1a2e', // Hardcode dark background like Home
   },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 16,
-    backgroundColor: '#252542', // Hardcode dark header
   },
   backButton: {
     padding: 4,
@@ -321,150 +60,8 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     flex: 1,
     textAlign: 'center',
-    color: '#FFFFFF', // Hardcode white text
   },
   headerPlaceholder: {
     width: 32,
-  },
-  scrollView: {
-    flex: 1,
-    backgroundColor: '#1a1a2e', // Hardcode dark background
-  },
-  scrollContent: {
-    paddingHorizontal: 20,
-    paddingTop: 20,
-    backgroundColor: '#1a1a2e', // Hardcode dark background
-  },
-  searchContainer: {
-    marginBottom: 24,
-  },
-  searchInputContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    borderRadius: 12,
-    borderWidth: 1,
-    backgroundColor: '#252542', // Hardcode dark card
-    borderColor: '#374151', // Hardcode dark border
-  },
-  searchIcon: {
-    fontSize: 20,
-    marginRight: 12,
-  },
-  searchInput: {
-    flex: 1,
-    fontSize: 15,
-    padding: 0,
-    color: '#FFFFFF', // Hardcode white text
-  },
-  sectionTitle: {
-    fontSize: 12,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    marginBottom: 16,
-    letterSpacing: 0.5,
-    color: '#9ca3af', // Hardcode secondary text
-  },
-  contactSectionTitle: {
-    marginTop: 24,
-  },
-  faqItem: {
-    borderRadius: 12,
-    marginBottom: 10,
-    overflow: 'hidden',
-    backgroundColor: '#252542', // Hardcode dark card
-  },
-  faqHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 14,
-    padding: 16,
-  },
-  faqIcon: {
-    fontSize: 20,
-  },
-  faqQuestion: {
-    flex: 1,
-    fontSize: 15,
-    fontWeight: '400',
-    color: '#FFFFFF', // Hardcode white text
-  },
-  faqAnswerContainer: {
-    paddingTop: 8,
-    paddingHorizontal: 16,
-    paddingBottom: 16,
-    paddingLeft: 50, // Align with icon
-    borderTopWidth: 1,
-    borderTopColor: 'rgba(255, 255, 255, 0.1)', // Hardcode dark border
-    marginTop: 8,
-  },
-  faqAnswer: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: '#9ca3af', // Hardcode secondary text
-  },
-  loadingContainer: {
-    paddingVertical: 32,
-    alignItems: 'center',
-    gap: 12,
-  },
-  loadingText: {
-    fontSize: 14,
-    color: '#9ca3af',
-  },
-  noResultsContainer: {
-    paddingVertical: 24,
-    alignItems: 'center',
-  },
-  noResultsText: {
-    fontSize: 14,
-    color: '#9ca3af', // Hardcode secondary text
-  },
-  retryButton: {
-    marginTop: 12,
-    paddingVertical: 10,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    backgroundColor: '#3b82f6',
-  },
-  retryButtonText: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#FFFFFF',
-  },
-  contactItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 14,
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 10,
-    backgroundColor: '#252542', // Hardcode dark card
-  },
-  contactIconContainer: {
-    width: 44,
-    height: 44,
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#3b82f620', // Hardcode primary20
-  },
-  contactIcon: {
-    fontSize: 20,
-  },
-  contactTextContainer: {
-    flex: 1,
-  },
-  contactTitle: {
-    fontSize: 15,
-    fontWeight: '600',
-    marginBottom: 2,
-    color: '#FFFFFF', // Hardcode white text
-  },
-  contactSubtitle: {
-    fontSize: 12,
-    marginTop: 2,
-    color: '#9ca3af', // Hardcode secondary text
   },
 });

--- a/components/help/HelpCenterScrollContent.tsx
+++ b/components/help/HelpCenterScrollContent.tsx
@@ -1,0 +1,424 @@
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { getLocale, t } from '@/i18n';
+import { fetchFaqs, flattenFaqsToItems, type FaqAudience, type FaqListItem } from '@/services/faqs';
+import { Ionicons } from '@expo/vector-icons';
+import { useQuery } from '@tanstack/react-query';
+import React, { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+export interface HelpCenterScrollContentProps {
+  faqAudience: FaqAudience;
+  showComplaintsRow: boolean;
+  showInlineContactSection: boolean;
+  onPressComplaints: () => void;
+  /** When inline contact is hidden, show a single CTA row (e.g. navigate to provider contact support). */
+  onPressMoreHelp?: () => void;
+  moreHelpLabel?: string;
+  moreHelpSubtitle?: string;
+  bottomInset: number;
+}
+
+export function HelpCenterScrollContent({
+  faqAudience,
+  showComplaintsRow,
+  showInlineContactSection,
+  onPressComplaints,
+  onPressMoreHelp,
+  moreHelpLabel,
+  moreHelpSubtitle,
+  bottomInset,
+}: HelpCenterScrollContentProps) {
+  const colors = useThemeColors();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(new Set());
+
+  const locale = getLocale();
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ['faqs', locale, faqAudience],
+    queryFn: () => fetchFaqs(locale, faqAudience),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const faqItems: FaqListItem[] = useMemo(() => {
+    if (!data?.categories?.length) return [];
+    return flattenFaqsToItems(data.categories);
+  }, [data?.categories]);
+
+  const filteredFaqs = useMemo(() => {
+    if (!searchQuery.trim()) return faqItems;
+    const query = searchQuery.toLowerCase();
+    return faqItems.filter(
+      (item) =>
+        item.question.toLowerCase().includes(query) ||
+        item.answer.toLowerCase().includes(query)
+    );
+  }, [searchQuery, faqItems]);
+
+  const toggleFaq = (id: string) => {
+    setExpandedFaqs((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleLiveChat = () => {
+    Alert.alert(t('helpCenter.liveChat'), t('helpCenter.liveChatComingBody'));
+  };
+
+  const handleEmailSupport = () => {
+    const email = t('helpCenter.emailAddress');
+    const subject = encodeURIComponent(t('helpCenter.emailDefaultSubject'));
+    const body = encodeURIComponent(t('helpCenter.emailDefaultBody'));
+    const mailtoUrl = `mailto:${email}?subject=${subject}&body=${body}`;
+
+    Linking.openURL(mailtoUrl).catch(() => {
+      Alert.alert(t('common.error'), t('helpCenter.openEmailFailed'));
+    });
+  };
+
+  const handlePhoneSupport = () => {
+    const phoneNumber = t('helpCenter.phoneNumber').replace(/\s/g, '');
+    const phoneUrl = `tel:${phoneNumber}`;
+
+    Linking.openURL(phoneUrl).catch(() => {
+      Alert.alert(t('common.error'), t('helpCenter.openPhoneFailed'));
+    });
+  };
+
+  return (
+    <ScrollView
+      style={[styles.scrollView, { backgroundColor: colors.background }]}
+      contentContainerStyle={[
+        styles.scrollContent,
+        { paddingBottom: 20 + bottomInset, backgroundColor: colors.background },
+      ]}
+      showsVerticalScrollIndicator={false}
+    >
+      <View style={styles.searchContainer}>
+        <View
+          style={[
+            styles.searchInputContainer,
+            { backgroundColor: colors.card, borderColor: colors.cardBorder },
+          ]}
+        >
+          <Text style={styles.searchIcon}>🔍</Text>
+          <TextInput
+            style={[styles.searchInput, { color: colors.textPrimary }]}
+            placeholder={t('helpCenter.searchPlaceholder')}
+            placeholderTextColor={colors.textTertiary}
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+          />
+        </View>
+      </View>
+
+      <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+        {t('helpCenter.frequentlyAskedQuestions')}
+      </Text>
+
+      {isLoading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.primary} />
+          <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+            {t('common.loading')}
+          </Text>
+        </View>
+      ) : isError ? (
+        <View style={styles.noResultsContainer}>
+          <Text style={[styles.noResultsText, { color: colors.textSecondary }]}>
+            {error instanceof Error ? error.message : t('helpCenter.noResults')}
+          </Text>
+          <TouchableOpacity
+            style={[styles.retryButton, { backgroundColor: colors.primary }]}
+            onPress={() => refetch()}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.retryButtonText}>{t('chat.retry')}</Text>
+          </TouchableOpacity>
+        </View>
+      ) : filteredFaqs.length > 0 ? (
+        filteredFaqs.map((faq) => {
+          const isExpanded = expandedFaqs.has(faq.id);
+          return (
+            <View key={faq.id} style={[styles.faqItem, { backgroundColor: colors.card }]}>
+              <TouchableOpacity
+                style={styles.faqHeader}
+                onPress={() => toggleFaq(faq.id)}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.faqIcon}>{faq.icon}</Text>
+                <Text style={[styles.faqQuestion, { color: colors.textPrimary }]}>{faq.question}</Text>
+                <Ionicons
+                  name={isExpanded ? 'chevron-up' : 'chevron-forward'}
+                  size={20}
+                  color={colors.textTertiary}
+                />
+              </TouchableOpacity>
+              {isExpanded && (
+                <View style={[styles.faqAnswerContainer, { borderTopColor: colors.cardBorder }]}>
+                  <Text style={[styles.faqAnswer, { color: colors.textSecondary }]}>{faq.answer}</Text>
+                </View>
+              )}
+            </View>
+          );
+        })
+      ) : (
+        <View style={styles.noResultsContainer}>
+          <Text style={[styles.noResultsText, { color: colors.textSecondary }]}>
+            {t('helpCenter.noResults')}
+          </Text>
+        </View>
+      )}
+
+      <Text style={[styles.sectionTitle, styles.contactSectionTitle, { color: colors.textSecondary }]}>
+        {t('helpCenter.contact')}
+      </Text>
+
+      {showComplaintsRow && (
+        <TouchableOpacity
+          style={[styles.contactItem, { backgroundColor: colors.card }]}
+          onPress={onPressComplaints}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={t('helpCenter.complaintsRowTitle')}
+        >
+          <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
+            <Text style={styles.contactIcon}>📋</Text>
+          </View>
+          <View style={styles.contactTextContainer}>
+            <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
+              {t('helpCenter.complaintsRowTitle')}
+            </Text>
+            <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
+              {t('helpCenter.complaintsRowSubtitle')}
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+        </TouchableOpacity>
+      )}
+
+      {!showInlineContactSection && onPressMoreHelp && moreHelpLabel ? (
+        <TouchableOpacity
+          style={[styles.contactItem, { backgroundColor: colors.card }]}
+          onPress={onPressMoreHelp}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={moreHelpLabel}
+        >
+          <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
+            <Text style={styles.contactIcon}>💬</Text>
+          </View>
+          <View style={styles.contactTextContainer}>
+            <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>{moreHelpLabel}</Text>
+            {moreHelpSubtitle ? (
+              <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
+                {moreHelpSubtitle}
+              </Text>
+            ) : null}
+          </View>
+          <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+        </TouchableOpacity>
+      ) : null}
+
+      {showInlineContactSection ? (
+        <>
+          <TouchableOpacity
+            style={[styles.contactItem, { backgroundColor: colors.card }]}
+            onPress={handleLiveChat}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
+              <Text style={styles.contactIcon}>💬</Text>
+            </View>
+            <View style={styles.contactTextContainer}>
+              <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
+                {t('helpCenter.liveChat')}
+              </Text>
+              <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
+                {t('helpCenter.liveChatSubtitle')}
+              </Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.contactItem, { backgroundColor: colors.card }]}
+            onPress={handleEmailSupport}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
+              <Text style={styles.contactIcon}>📧</Text>
+            </View>
+            <View style={styles.contactTextContainer}>
+              <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
+                {t('helpCenter.email')}
+              </Text>
+              <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
+                {t('helpCenter.emailAddress')}
+              </Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.contactItem, { backgroundColor: colors.card }]}
+            onPress={handlePhoneSupport}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.contactIconContainer, { backgroundColor: `${colors.primary}20` }]}>
+              <Text style={styles.contactIcon}>📞</Text>
+            </View>
+            <View style={styles.contactTextContainer}>
+              <Text style={[styles.contactTitle, { color: colors.textPrimary }]}>
+                {t('helpCenter.phone')}
+              </Text>
+              <Text style={[styles.contactSubtitle, { color: colors.textSecondary }]}>
+                {t('helpCenter.phoneNumber')}
+              </Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+          </TouchableOpacity>
+        </>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+  },
+  searchContainer: {
+    marginBottom: 24,
+  },
+  searchInputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  searchIcon: {
+    fontSize: 20,
+    marginRight: 12,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    padding: 0,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    marginBottom: 16,
+    letterSpacing: 0.5,
+  },
+  contactSectionTitle: {
+    marginTop: 24,
+  },
+  faqItem: {
+    borderRadius: 12,
+    marginBottom: 10,
+    overflow: 'hidden',
+  },
+  faqHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    padding: 16,
+  },
+  faqIcon: {
+    fontSize: 20,
+  },
+  faqQuestion: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '400',
+  },
+  faqAnswerContainer: {
+    paddingTop: 8,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    paddingLeft: 50,
+    borderTopWidth: 1,
+    marginTop: 8,
+  },
+  faqAnswer: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  loadingContainer: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    gap: 12,
+  },
+  loadingText: {
+    fontSize: 14,
+  },
+  noResultsContainer: {
+    paddingVertical: 24,
+    alignItems: 'center',
+  },
+  noResultsText: {
+    fontSize: 14,
+  },
+  retryButton: {
+    marginTop: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+  contactItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 10,
+  },
+  contactIconContainer: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  contactIcon: {
+    fontSize: 20,
+  },
+  contactTextContainer: {
+    flex: 1,
+  },
+  contactTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  contactSubtitle: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+});

--- a/components/provider/ProviderSubScreenHeader.tsx
+++ b/components/provider/ProviderSubScreenHeader.tsx
@@ -1,0 +1,56 @@
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface ProviderSubScreenHeaderProps {
+  title: string;
+  onBack: () => void;
+  accessibilityLabelBack: string;
+}
+
+export function ProviderSubScreenHeader({
+  title,
+  onBack,
+  accessibilityLabelBack,
+}: ProviderSubScreenHeaderProps) {
+  const colors = useThemeColors();
+  return (
+    <View style={styles.header}>
+      <TouchableOpacity
+        style={[styles.backButton, { backgroundColor: 'rgba(255,255,255,0.05)' }]}
+        onPress={onBack}
+        activeOpacity={0.8}
+        accessibilityLabel={accessibilityLabelBack}
+        accessibilityRole="button"
+      >
+        <Ionicons name="chevron-back" size={24} color={colors.textSecondary} />
+      </TouchableOpacity>
+      <Text style={[styles.title, { color: colors.textPrimary }]} numberOfLines={1}>
+        {title}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    paddingBottom: 20,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: '700',
+  },
+});

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -853,6 +853,12 @@ export default {
     emailAddress: "support@mordobo.com",
     phone: "Phone",
     phoneNumber: "+1 809 555 0000",
+    liveChatComingBody:
+      "Live chat will be available soon. Please use email or phone support for now.",
+    emailDefaultSubject: "Support Request",
+    emailDefaultBody: "Hello,\n\nI need help with:\n\n",
+    openEmailFailed: "Could not open the email app.",
+    openPhoneFailed: "Could not open the phone dialer.",
     faqs: {
       howToBook: {
         question: "How do I book a service?",
@@ -1404,6 +1410,27 @@ export default {
         loadFailed: "Could not load statistics. Please try again.",
         retry: "Retry",
       },
+    },
+    providerSupportScreens: {
+      helpCenterMoreHelpTitle: "Contact support",
+      helpCenterMoreHelpSubtitle: "Chat, email, phone, and formal requests",
+      chatSection: "Live chat",
+      statusOnline: "Online",
+      chatHoursHint: "We typically reply within a few minutes during business hours.",
+      startChat: "Start chat",
+      formalRequests: "Formal requests",
+    },
+    providerLegal: {
+      termsOfServiceTitle: "Terms of Service",
+      termsOfServiceSubtitle: "Service terms",
+      privacyTitle: "Privacy Policy",
+      privacySubtitle: "How we handle your data",
+      cookiesTitle: "Cookie Policy",
+      cookiesSubtitle: "Cookies and similar technologies",
+      providerAgreementTitle: "Provider Agreement",
+      providerAgreementSubtitle: "Terms for professionals on Mordobo",
+      lastUpdated: "Last updated: {{date}}",
+      loadError: "We could not load this document. Please try again later.",
     },
     providerNotificationPreferences: {
       title: "Notification Preferences",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -853,6 +853,12 @@ export default {
     emailAddress: "soporte@mordobo.com",
     phone: "Teléfono",
     phoneNumber: "+1 809 555 0000",
+    liveChatComingBody:
+      "El chat en vivo estará disponible pronto. Por ahora usa el correo o el teléfono de soporte.",
+    emailDefaultSubject: "Solicitud de soporte",
+    emailDefaultBody: "Hola,\n\nNecesito ayuda con:\n\n",
+    openEmailFailed: "No se pudo abrir la app de correo.",
+    openPhoneFailed: "No se pudo abrir el marcador telefónico.",
     faqs: {
       howToBook: {
         question: "¿Cómo reservo un servicio?",
@@ -1404,6 +1410,27 @@ export default {
         loadFailed: "No se pudieron cargar las estadísticas. Intenta de nuevo.",
         retry: "Reintentar",
       },
+    },
+    providerSupportScreens: {
+      helpCenterMoreHelpTitle: "Contactar soporte",
+      helpCenterMoreHelpSubtitle: "Chat, correo, teléfono y solicitudes formales",
+      chatSection: "Chat en vivo",
+      statusOnline: "En línea",
+      chatHoursHint: "Solemos responder en pocos minutos en horario laboral.",
+      startChat: "Iniciar chat",
+      formalRequests: "Solicitudes formales",
+    },
+    providerLegal: {
+      termsOfServiceTitle: "Términos del servicio",
+      termsOfServiceSubtitle: "Condiciones del servicio",
+      privacyTitle: "Política de privacidad",
+      privacySubtitle: "Cómo tratamos tus datos",
+      cookiesTitle: "Política de cookies",
+      cookiesSubtitle: "Cookies y tecnologías similares",
+      providerAgreementTitle: "Acuerdo de proveedor",
+      providerAgreementSubtitle: "Condiciones para profesionales en Mordobo",
+      lastUpdated: "Última actualización: {{date}}",
+      loadError: "No pudimos cargar este documento. Inténtalo más tarde.",
     },
     providerNotificationPreferences: {
       title: "Preferencias de Notificaciones",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
         "react-native-web": "~0.21.0",
+        "react-native-webview": "13.15.0",
         "zod": "^4.1.8",
         "zustand": "^5.0.8"
       },
@@ -10300,6 +10301,19 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
+      "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-worklets": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
     "react-native-web": "~0.21.0",
+    "react-native-webview": "13.15.0",
     "zod": "^4.1.8",
     "zustand": "^5.0.8"
   },

--- a/services/faqs.ts
+++ b/services/faqs.ts
@@ -37,12 +37,16 @@ export interface FaqListItem {
 
 const DEFAULT_ICONS = ['📅', '💳', '❌', '⭐', '🔒', '💰', '📋', '❓'];
 
+export type FaqAudience = 'client' | 'provider';
+
 /**
- * Fetches published FAQs from the API (parametrized via CRM/Backoffice).
- * @param locale - 'en' | 'es'. Should match app language.
+ * Fetches published FAQs from the API (CRM/Backoffice).
+ * Categories are scoped by `audience` on each category: `client`, `provider`, or `all` (both apps).
+ * @param audience - App role: client help center vs provider help center.
  */
-export async function fetchFaqs(locale: 'en' | 'es'): Promise<FaqsResponse> {
-  const url = `${API_BASE}/api/content/faqs?locale=${locale}`;
+export async function fetchFaqs(locale: 'en' | 'es', audience: FaqAudience): Promise<FaqsResponse> {
+  const params = new URLSearchParams({ locale, audience });
+  const url = `${API_BASE}/api/content/faqs?${params.toString()}`;
   const response = await fetch(url, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },

--- a/services/legal.ts
+++ b/services/legal.ts
@@ -1,0 +1,46 @@
+import { API_BASE } from '@/utils/apiConfig';
+
+export const LEGAL_DOC_TYPES = [
+  'terms_of_service',
+  'privacy_policy',
+  'cookie_policy',
+  'provider_agreement',
+] as const;
+
+export type LegalDocType = (typeof LEGAL_DOC_TYPES)[number];
+
+export function isLegalDocType(value: string): value is LegalDocType {
+  return (LEGAL_DOC_TYPES as readonly string[]).includes(value);
+}
+
+export interface LegalDocumentPayload {
+  docType: string;
+  bodyHtml: string;
+  updatedAt: string;
+}
+
+export async function fetchLegalDocument(
+  docType: LegalDocType,
+  locale: 'en' | 'es'
+): Promise<LegalDocumentPayload> {
+  const url = `${API_BASE}/api/content/legal/${encodeURIComponent(docType)}?locale=${locale}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    const body: unknown = await response.json().catch(() => ({}));
+    const message =
+      body &&
+      typeof body === 'object' &&
+      body !== null &&
+      'message' in body &&
+      typeof (body as { message: unknown }).message === 'string'
+        ? (body as { message: string }).message
+        : `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  return (await response.json()) as LegalDocumentPayload;
+}


### PR DESCRIPTION
…ic back nav

- Add provider-only routes under profile stack: help-center (provider FAQs), contact-support, terms-privacy, and legal-document WebView viewer.
- Extract HelpCenterScrollContent for client vs provider audiences; client support screen wraps shared content with full contact section.
- Add services/legal and require fetchFaqs audience; i18n for support/legal strings and helpCenter mail/chat error copy.
- Provider settings: support rows target new screens; back goes to profile root; help/contact/terms backs go to configuration; legal doc back to terms list.
- Add react-native-webview dependency.
