### PR TITLE
fix(chat): route provider View Order to job detail, not client order

### DIFF
--- a/app/(provider-tabs)/jobs/[id].tsx
+++ b/app/(provider-tabs)/jobs/[id].tsx
@@ -93,6 +93,11 @@ export default function ProviderJobDetailScreen() {
     router.push({ pathname: "/(provider-tabs)/jobs/complete", params: { id: job.orderId } });
   }, [job, router]);
 
+  const handleRateClient = useCallback(() => {
+    if (!job) return;
+    router.push({ pathname: "/(provider-tabs)/jobs/rate-client", params: { id: job.orderId } });
+  }, [job, router]);
+
   if (isLoading && jobs.length === 0) {
     return (
       <View style={[styles.container, styles.centered, { paddingTop: insets.top, backgroundColor: colors.background }]}>
@@ -222,6 +227,12 @@ export default function ProviderJobDetailScreen() {
           <TouchableOpacity style={[styles.completeBtn, { backgroundColor: GREEN_BUTTON }]} onPress={handleMarkAsCompleted} activeOpacity={0.8}>
             <Ionicons name="checkmark-circle" size={20} color="#FFFFFF" />
             <Text style={styles.completeBtnText}>{t("providerDashboard.markAsCompleted")}</Text>
+          </TouchableOpacity>
+        )}
+        {job.status === "pending_review" && (
+          <TouchableOpacity style={[styles.completeBtn, { backgroundColor: colors.primary }]} onPress={handleRateClient} activeOpacity={0.8}>
+            <Ionicons name="star-outline" size={20} color="#FFFFFF" />
+            <Text style={styles.completeBtnText}>{t("providerDashboard.rateClient.title")}</Text>
           </TouchableOpacity>
         )}
       </ScrollView>

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -775,7 +775,11 @@ export default function ChatScreen() {
         t("booking.activeOrderExists"),
         [
           { text: t("common.cancel") },
-          { text: t("booking.viewExistingOrder"), onPress: () => router.push(`/orders/${activeOrder!.id}`) },
+          {
+            text: t("booking.viewExistingOrder"),
+            onPress: () =>
+              router.push(isProvider ? `/(provider-tabs)/jobs/${activeOrder!.id}` : `/orders/${activeOrder!.id}`),
+          },
         ]
       );
       return;
@@ -798,7 +802,11 @@ export default function ChatScreen() {
 
   const handleViewOrder = () => {
     if (!activeOrder) return;
-    router.push(`/orders/${activeOrder.id}`);
+    if (isProvider) {
+      router.push(`/(provider-tabs)/jobs/${activeOrder.id}`);
+    } else {
+      router.push(`/orders/${activeOrder.id}`);
+    }
   };
 
   const handleViewQuote = () => {


### PR DESCRIPTION
- Chat: when mode is provider, Ver orden and view-existing-order alert use /(provider-tabs)/jobs/:orderId instead of /orders/:id (client Ver detalles and rate-service flow).
- Provider job detail: add Calificar Cliente CTA when status is pending_review linking to rate-client screen.
