### PR TITLE
fix(provider-jobs): restore access to rate-client after leaving or cl…

### DIFF
--- a/app/(provider-tabs)/jobs/[id].tsx
+++ b/app/(provider-tabs)/jobs/[id].tsx
@@ -206,22 +206,24 @@ export default function ProviderJobDetailScreen() {
           : null}
         </View>
 
-        {/* Work in progress: for scheduled (accepted) jobs, call start API then navigate; for in_progress, open timer/tasks */}
-        <TouchableOpacity
-          style={[styles.inProgressBtn, { backgroundColor: colors.primary }, startingJob && styles.inProgressBtnDisabled]}
-          onPress={handleStartJob}
-          activeOpacity={0.8}
-          disabled={startingJob}
-        >
-          {startingJob ? (
-            <ActivityIndicator size="small" color="#FFFFFF" />
-          ) : (
-            <Ionicons name="play-circle" size={20} color="#FFFFFF" />
-          )}
-          <Text style={styles.completeBtnText}>
-            {startingJob ? t("providerDashboard.inProgress.starting") : t("providerDashboard.inProgress.title")}
-          </Text>
-        </TouchableOpacity>
+        {/* Work in progress: scheduled/accepted → start API; in_progress/on_way → timer/tasks. Hidden after job is submitted for review or fully closed. */}
+        {(job.status === "scheduled" || job.status === "in_progress" || job.status === "on_way" || job.status === "pending") && (
+          <TouchableOpacity
+            style={[styles.inProgressBtn, { backgroundColor: colors.primary }, startingJob && styles.inProgressBtnDisabled]}
+            onPress={handleStartJob}
+            activeOpacity={0.8}
+            disabled={startingJob}
+          >
+            {startingJob ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : (
+              <Ionicons name="play-circle" size={20} color="#FFFFFF" />
+            )}
+            <Text style={styles.completeBtnText}>
+              {startingJob ? t("providerDashboard.inProgress.starting") : t("providerDashboard.inProgress.title")}
+            </Text>
+          </TouchableOpacity>
+        )}
         {/* Mark as completed: only when job is already in_progress (started) */}
         {job.status === "in_progress" && (
           <TouchableOpacity style={[styles.completeBtn, { backgroundColor: GREEN_BUTTON }]} onPress={handleMarkAsCompleted} activeOpacity={0.8}>
@@ -229,7 +231,7 @@ export default function ProviderJobDetailScreen() {
             <Text style={styles.completeBtnText}>{t("providerDashboard.markAsCompleted")}</Text>
           </TouchableOpacity>
         )}
-        {job.status === "pending_review" && (
+        {(job.status === "pending_review" || job.status === "awaiting_provider_rating") && (
           <TouchableOpacity style={[styles.completeBtn, { backgroundColor: colors.primary }]} onPress={handleRateClient} activeOpacity={0.8}>
             <Ionicons name="star-outline" size={20} color="#FFFFFF" />
             <Text style={styles.completeBtnText}>{t("providerDashboard.rateClient.title")}</Text>

--- a/app/(provider-tabs)/jobs/index.tsx
+++ b/app/(provider-tabs)/jobs/index.tsx
@@ -32,8 +32,10 @@ function sortByPriority(jobs: ProviderActiveJob[]): ProviderActiveJob[] {
   const order: Record<ProviderActiveJobStatus, number> = {
     in_progress: 0,
     on_way: 1,
-    scheduled: 2,
-    pending: 3,
+    pending_review: 2,
+    awaiting_provider_rating: 2,
+    scheduled: 3,
+    pending: 4,
   };
   return [...jobs].sort((a, b) => order[a.status] - order[b.status]);
 }
@@ -44,7 +46,13 @@ function getFilteredJobs(jobs: ProviderActiveJob[], filter: FilterType): Provide
     return sorted.filter((j) => j.status === "pending");
   }
   if (filter === "in_progress") {
-    return sorted.filter((j) => j.status === "in_progress" || j.status === "on_way");
+    return sorted.filter(
+      (j) =>
+        j.status === "in_progress" ||
+        j.status === "on_way" ||
+        j.status === "pending_review" ||
+        j.status === "awaiting_provider_rating",
+    );
   }
   return sorted.filter((j) => j.status === "scheduled");
 }
@@ -56,6 +64,11 @@ function JobStatusBadge({ status }: { status: ProviderActiveJobStatus }) {
     on_way: { label: t("providerDashboard.statusOnTheWay"), bg: STATUS_ON_WAY_BG, text: STATUS_ON_WAY_TEXT },
     scheduled: { label: t("providerDashboard.filterScheduled"), bg: STATUS_ON_WAY_BG, text: STATUS_ON_WAY_TEXT },
     pending_review: { label: t("orders.status.pending_review"), bg: STATUS_IN_PROGRESS_BG, text: STATUS_IN_PROGRESS_TEXT },
+    awaiting_provider_rating: {
+      label: t("providerDashboard.statusAwaitingProviderRating"),
+      bg: STATUS_PENDING_BG,
+      text: STATUS_PENDING_TEXT,
+    },
   };
   const c = config[status] ?? config.pending;
   return (
@@ -68,8 +81,11 @@ function JobStatusBadge({ status }: { status: ProviderActiveJobStatus }) {
 function JobCard({ job, onChat, onCall, onDetails, colors }: { job: ProviderActiveJob; onChat: (job: ProviderActiveJob) => void; onCall: (job: ProviderActiveJob) => void; onDetails: (job: ProviderActiveJob) => void; colors: ThemeColors }) {
   const isScheduled = job.status === "scheduled";
   const isPendingReview = job.status === "pending_review";
+  const isAwaitingProviderRating = job.status === "awaiting_provider_rating";
   const timeLabel =
-    isPendingReview
+    isAwaitingProviderRating
+      ? t("providerDashboard.invoice.continueToRate")
+      : isPendingReview
       ? t("providerDashboard.completeJob.waitingForClientReview")
       : isScheduled ?
       job.scheduledAt ?
@@ -153,7 +169,17 @@ export default function ProviderJobsScreen() {
 
   const filteredJobs = useMemo(() => getFilteredJobs(jobs, filter), [jobs, filter]);
   const pendingCount = useMemo(() => jobs.filter((j) => j.status === "pending").length, [jobs]);
-  const inProgressCount = useMemo(() => jobs.filter((j) => j.status === "in_progress" || j.status === "on_way").length, [jobs]);
+  const inProgressCount = useMemo(
+    () =>
+      jobs.filter(
+        (j) =>
+          j.status === "in_progress" ||
+          j.status === "on_way" ||
+          j.status === "pending_review" ||
+          j.status === "awaiting_provider_rating",
+      ).length,
+    [jobs],
+  );
   const scheduledCount = useMemo(() => jobs.filter((j) => j.status === "scheduled").length, [jobs]);
 
   const onRefresh = React.useCallback(async () => {

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1637,6 +1637,7 @@ export default {
     statusPending: "Pending",
     statusInProgress: "In progress",
     statusOnTheWay: "On the way",
+    statusAwaitingProviderRating: "Your rating",
     chat: "Chat",
     call: "Call",
     viewDetails: "View details",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -1638,6 +1638,7 @@ export default {
     statusPending: "Pendiente",
     statusInProgress: "En progreso",
     statusOnTheWay: "En camino",
+    statusAwaitingProviderRating: "Tu calificación",
     chat: "Chat",
     call: "Llamar",
     viewDetails: "Ver detalles",

--- a/services/providerDashboard.ts
+++ b/services/providerDashboard.ts
@@ -43,7 +43,14 @@ export interface ProviderDashboardScheduleItem {
   status: string;
 }
 
-export type ProviderActiveJobStatus = "pending" | "in_progress" | "on_way" | "scheduled" | "pending_review";
+export type ProviderActiveJobStatus =
+  | "pending"
+  | "in_progress"
+  | "on_way"
+  | "scheduled"
+  | "pending_review"
+  /** Order is completed (e.g. client rated) but provider has not submitted provider_client_ratings yet */
+  | "awaiting_provider_rating";
 
 export interface ProviderActiveJob {
   id: string;


### PR DESCRIPTION
…ient review

- Add awaiting_provider_rating job status from API for completed orders pending provider client rating.
- Show pending_review and awaiting_provider_rating in In Progress filter and counts; sort them with other action-needed jobs.
- Job detail: show rate-client CTA for both statuses; hide work-in-progress CTA when job is past active work.
- i18n: badge label statusAwaitingProviderRating (en/es).
