### PR TITLE
fix(provider): isolate profile cache, avatar fallbacks, web upload (M…

### DIFF
--- a/app/(provider-tabs)/index.tsx
+++ b/app/(provider-tabs)/index.tsx
@@ -4,7 +4,8 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { ApiError } from "@/services/auth";
 import { acceptOrder, getDashboardRequests, getDashboardSchedule, getDashboardStats, rejectOrder, type ProviderDashboardRequest, type ProviderDashboardScheduleItem, type ProviderDashboardStats } from "@/services/providerDashboard";
-import { getProviderProfile } from "@/services/providers";
+import { getProviderProfile, providerProfileQueryKey } from "@/services/providers";
+import { getDisplayNameInitials } from "@/utils/displayNameInitials";
 import { getProfileImageUrl } from "@/utils/profileImage";
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery } from "@tanstack/react-query";
@@ -70,15 +71,21 @@ export default function ProviderDashboardScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [actionLoadingId, setActionLoadingId] = useState<string | null>(null);
+  const [headerAvatarFailed, setHeaderAvatarFailed] = useState(false);
 
   const { data: providerProfile } = useQuery({
-    queryKey: ["providerProfile"],
+    queryKey: providerProfileQueryKey(user?.id),
     queryFn: getProviderProfile,
     staleTime: 60_000,
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !!user?.id,
   });
   const displayName = (providerProfile?.displayName ?? "").trim() || "—";
   const providerAvatarUrl = getProfileImageUrl(providerProfile?.avatarUrl ?? null) ?? null;
+  const headerInitials = getDisplayNameInitials(displayName === "—" ? "" : displayName);
+
+  useEffect(() => {
+    setHeaderAvatarFailed(false);
+  }, [providerAvatarUrl, user?.id]);
 
   const loadAll = useCallback(async () => {
     if (!isAuthenticated) {
@@ -166,8 +173,15 @@ export default function ProviderDashboardScreen() {
                 <Ionicons name="notifications-outline" size={24} color="rgba(255,255,255,0.9)" />
               </TouchableOpacity>
               <TouchableOpacity style={styles.profileIcon} onPress={() => router.push("/(provider-tabs)/profile")} activeOpacity={0.8} accessibilityLabel={t("providerDashboard.providerProfile.screenTitle")}>
-                {providerAvatarUrl ?
-                  <Image source={{ uri: providerAvatarUrl }} style={styles.profileAvatar} contentFit="contain" />
+                {providerAvatarUrl && !headerAvatarFailed ?
+                  <Image
+                    source={{ uri: providerAvatarUrl }}
+                    style={styles.profileAvatar}
+                    contentFit="cover"
+                    onError={() => setHeaderAvatarFailed(true)}
+                  />
+                : headerInitials !== "?" ?
+                  <Text style={styles.profileAvatarInitials}>{headerInitials}</Text>
                 : <Ionicons name="person" size={24} color="rgba(255,255,255,0.5)" />}
               </TouchableOpacity>
             </View>
@@ -349,6 +363,11 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
+  },
+  profileAvatarInitials: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "rgba(255,255,255,0.95)",
   },
   availabilityCard: {
     flexDirection: "row",

--- a/app/(provider-tabs)/profile/edit.tsx
+++ b/app/(provider-tabs)/profile/edit.tsx
@@ -1,9 +1,12 @@
 import { Toast } from "@/components/Toast";
+import { useAuth } from "@/contexts/AuthContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { fetchCategoriesTree, type CategoryTreeItem } from "@/services/categories";
-import { getProviderProfile, updateProviderProfile, uploadProviderAvatar, type UpdateProviderProfilePayload } from "@/services/providers";
+import { ApiError } from "@/services/auth";
+import { getProviderProfile, providerProfileQueryKey, updateProviderProfile, uploadProviderAvatar, type UpdateProviderProfilePayload } from "@/services/providers";
 import { normalizePhoneInput, validatePhone } from "@/utils/phoneValidation";
+import { getDisplayNameInitials } from "@/utils/displayNameInitials";
 import { getProfileImageUrl } from "@/utils/profileImage";
 import { Ionicons } from "@expo/vector-icons";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -37,14 +40,6 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>;
 
-function getInitials(displayName: string): string {
-  const parts = displayName.trim().split(/\s+/);
-  if (parts.length >= 2) {
-    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
-  }
-  return displayName.trim().slice(0, 2).toUpperCase() || "?";
-}
-
 /** Parent categories only (for first dropdown) */
 function getParentCategoryOptions(tree: CategoryTreeItem[]): { id: string; name: string }[] {
   return (tree || []).map((c) => ({ id: c.id, name: c.name }));
@@ -72,6 +67,7 @@ export default function ProviderEditProfileScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const { user } = useAuth();
   const queryClient = useQueryClient();
   const [avatarUri, setAvatarUri] = useState<string | null>(null);
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
@@ -104,9 +100,10 @@ export default function ProviderEditProfileScreen() {
   }, []);
 
   const { data: profile, isLoading: profileLoading } = useQuery({
-    queryKey: ["providerProfile"],
+    queryKey: providerProfileQueryKey(user?.id),
     queryFn: getProviderProfile,
     staleTime: 0,
+    enabled: !!user?.id,
   });
 
   const { data: categoriesTree } = useQuery({
@@ -200,7 +197,7 @@ export default function ProviderEditProfileScreen() {
     try {
       const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (status !== "granted") {
-        Alert.alert(t("common.error"), "Permission to access photos is required.");
+        Alert.alert(t("common.error"), t("chat.imagePermissionDenied"));
         return;
       }
       const result = await ImagePicker.launchImageLibraryAsync({
@@ -213,14 +210,18 @@ export default function ProviderEditProfileScreen() {
       const compressed = await ImageManipulator.manipulateAsync(uri, [{ resize: { width: 400 } }], { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG });
       setUploadingAvatar(true);
       const base64 = await (async (): Promise<string> => {
-        if (Platform.OS === "web" && compressed.uri.startsWith("blob:")) {
+        if (compressed.uri.startsWith("data:")) {
+          const comma = compressed.uri.indexOf(",");
+          return comma >= 0 ? compressed.uri.slice(comma + 1) : "";
+        }
+        if (Platform.OS === "web") {
           const res = await fetch(compressed.uri);
           const blob = await res.blob();
           return new Promise((resolve, reject) => {
             const reader = new FileReader();
             reader.onloadend = () => {
               const dataUrl = reader.result as string;
-              const base64Data = dataUrl.split(",")[1] || dataUrl;
+              const base64Data = dataUrl.includes(",") ? dataUrl.split(",")[1] || "" : dataUrl;
               resolve(base64Data);
             };
             reader.onerror = reject;
@@ -240,7 +241,8 @@ export default function ProviderEditProfileScreen() {
       await queryClient.invalidateQueries({ queryKey: ["providerProfile"] });
     } catch (e) {
       console.error("[ProviderEditProfile] Avatar upload failed:", e);
-      Alert.alert(t("common.error"), t("errors.uploadProviderAvatarFailed"));
+      const message = e instanceof ApiError ? e.message : t("errors.uploadProviderAvatarFailed");
+      Alert.alert(t("common.error"), message);
     } finally {
       setUploadingAvatar(false);
     }
@@ -309,7 +311,7 @@ export default function ProviderEditProfileScreen() {
               {avatarUri ?
                 <Image source={{ uri: avatarUri }} style={styles.avatarImage} contentFit="contain" />
               : <View style={[styles.avatarPlaceholder, { backgroundColor: colors.card }]}>
-                  <Text style={[styles.avatarInitials, { color: colors.textSecondary }]}>{getInitials(watch("displayName") || "")}</Text>
+                  <Text style={[styles.avatarInitials, { color: colors.textSecondary }]}>{getDisplayNameInitials(watch("displayName") || "")}</Text>
                 </View>
               }
               {uploadingAvatar ?

--- a/app/(provider-tabs)/profile/index.tsx
+++ b/app/(provider-tabs)/profile/index.tsx
@@ -1,11 +1,13 @@
 import { ModeSwitch } from "@/components/common/ModeSwitch";
 import { ProfileFooter } from "@/components/profile/ProfileFooter";
+import { useAuth } from "@/contexts/AuthContext";
 import { useMode } from "@/contexts/ModeContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { getPortfolio } from "@/services/portfolio";
-import { getProviderProfile, getProviderProfileStats } from "@/services/providers";
+import { getProviderProfile, getProviderProfileStats, providerProfileQueryKey } from "@/services/providers";
 import { getProviderServices } from "@/services/providerServices";
+import { getDisplayNameInitials } from "@/utils/displayNameInitials";
 import { getProfileImageUrl } from "@/utils/profileImage";
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery } from "@tanstack/react-query";
@@ -18,27 +20,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const GRADIENT_COLORS = ["#6366F1", "#8B5CF6", "#EC4899"] as const;
 
-/** Get initials from a display name string (e.g. "Business Name" → "BN", "Angelo Rivas" → "AR"). */
-function getInitialsFromDisplayName(displayName: string): string {
-  const parts = displayName.trim().split(/\s+/).filter(Boolean);
-  if (parts.length >= 2) {
-    const first = parts[0].charAt(0).toUpperCase();
-    const last = parts[parts.length - 1].charAt(0).toUpperCase();
-    return first && last ? `${first}${last}` : first || last || "?";
-  }
-  if (parts.length === 1 && parts[0].length >= 2) {
-    return parts[0].slice(0, 2).toUpperCase();
-  }
-  if (parts.length === 1 && parts[0].length === 1) {
-    return parts[0].toUpperCase();
-  }
-  return "?";
-}
-
 export default function ProviderProfileScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const { user } = useAuth();
   const { mode } = useMode();
   const scrollViewRef = useRef<ScrollView>(null);
 
@@ -68,14 +54,15 @@ export default function ProviderProfileScreen() {
   const portfolioPhotoCount = portfolioData?.stats?.totalPhotos ?? 0;
 
   const { data: providerProfile, refetch: refetchProviderProfile } = useQuery({
-    queryKey: ["providerProfile"],
+    queryKey: providerProfileQueryKey(user?.id),
     queryFn: getProviderProfile,
     staleTime: 60_000,
+    enabled: !!user?.id,
   });
   const providerAvatarUrl = getProfileImageUrl(providerProfile?.avatarUrl ?? null) ?? null;
   const [avatarError, setAvatarError] = useState(false);
   const displayName = (providerProfile?.displayName ?? "").trim() || "—";
-  const initials = getInitialsFromDisplayName(displayName);
+  const initials = getDisplayNameInitials(displayName);
   const categoryName = (providerProfile?.categoryName ?? "").trim() || null;
   const bio = (providerProfile?.bio ?? "").trim() || null;
 

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { t } from '@/i18n';
 import { ApiError, refreshTokens, setTokenUpdateCallback, clearTokenState } from '@/services/auth';
 import { getProfile } from '@/services/profile';
+import { queryClient } from '@/services/queryClient';
 import { authEvents } from '@/utils/authEvents';
 import { getTimeUntilExpiryMs, isTokenExpiringSoon } from '@/utils/tokenUtils';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -203,6 +204,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       
       // Clear token state FIRST to prevent any new API calls
       clearTokenState();
+
+      try {
+        queryClient.clear();
+      } catch {
+        /* ignore */
+      }
       
       // Clear token update callback to prevent any pending token updates
       setTokenUpdateCallback(async () => {

--- a/services/providers.ts
+++ b/services/providers.ts
@@ -1,6 +1,10 @@
 import { t } from "@/i18n";
 import { request } from "./auth";
 
+/** React Query key for provider profile — include `userId` so cached data never leaks across account switches. */
+export const providerProfileQueryKey = (userId: string | undefined): readonly ["providerProfile", string] =>
+  ["providerProfile", userId ?? "__none__"] as const;
+
 // ========== Provider profile (edit screen) ==========
 
 export interface ProviderProfile {

--- a/utils/displayNameInitials.ts
+++ b/utils/displayNameInitials.ts
@@ -1,0 +1,16 @@
+/** Initials for avatar placeholders (e.g. "Walker animal" → "WA"). */
+export function getDisplayNameInitials(displayName: string): string {
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    const first = parts[0].charAt(0).toUpperCase();
+    const last = parts[parts.length - 1].charAt(0).toUpperCase();
+    return first && last ? `${first}${last}` : first || last || "?";
+  }
+  if (parts.length === 1 && parts[0].length >= 2) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  if (parts.length === 1 && parts[0].length === 1) {
+    return parts[0].toUpperCase();
+  }
+  return "?";
+}

--- a/utils/profileImage.ts
+++ b/utils/profileImage.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { API_BASE } from '@/utils/apiConfig';
 
 /**
@@ -17,7 +19,22 @@ export function getProfileImageUrl(url: string | null | undefined): string | nul
   if (!url || typeof url !== 'string') return null;
   const trimmed = url.trim();
   if (!trimmed) return null;
-  if (trimmed.startsWith('data:') || trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed;
+  if (trimmed.startsWith('data:')) return trimmed;
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    // Android emulator: API may store avatar as http://localhost/... which does not reach the host machine.
+    if (Platform.OS === 'android') {
+      try {
+        const parsed = new URL(trimmed);
+        if (/^(localhost|127\.0\.0\.1)$/i.test(parsed.hostname)) {
+          const origin = API_BASE.replace(/\/$/, '');
+          return `${origin}${parsed.pathname}${parsed.search}`;
+        }
+      } catch {
+        /* ignore malformed URL */
+      }
+    }
+    return trimmed;
+  }
   const base = API_BASE.replace(/\/$/, '');
   const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
   return `${base}${path}`;


### PR DESCRIPTION
…DB-310)

- Scope React Query provider profile by user id (providerProfileQueryKey) so cached avatar/displayName cannot leak across account switches.
- Clear TanStack Query cache on logout (queryClient.clear).
- Provider Home: show display-name initials when no avatar or image load fails; use cover fit and onError fallback instead of a generic person icon only.
- getProfileImageUrl: on Android, rewrite localhost/127.0.0.1 absolute URLs to API_BASE so emulator can load avatars stored with localhost origin.
- Edit profile: read base64 from data: URIs; use fetch+FileReader for all web compressed URIs; surface ApiError message on upload failure; i18n gallery permission string.
- Extract getDisplayNameInitials to utils/displayNameInitials.ts.
