### PR TITLE
fix(theme): light mode for category lists, cards, and QA client surfaces

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,9 +1,10 @@
 import { ModeSwitch } from "@/components/common/ModeSwitch";
 import { ProfileFooter } from "@/components/profile/ProfileFooter";
 import { Toast } from "@/components/Toast";
-import { CLIENT_TIERS } from "@/constants/tiers";
+import { CLIENT_TIERS, getTierBadgeForeground } from "@/constants/tiers";
 import { useAuth } from "@/contexts/AuthContext";
 import { useMode } from "@/contexts/ModeContext";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { fetchOrders } from "@/services/orders";
@@ -26,6 +27,7 @@ export default function ProfileScreen() {
   const { user } = useAuth();
   const { mode, setMode } = useMode();
   const colors = useThemeColors();
+  const colorScheme = useColorScheme();
   const isFocused = useIsFocused();
   const insets = useSafeAreaInsets();
   const [stats, setStats] = useState<UserStats>({ services: 0, reviews: 0 });
@@ -106,9 +108,10 @@ export default function ProfileScreen() {
               {(() => {
                 const tier = user?.tier ?? "bronze";
                 const cfg = CLIENT_TIERS[tier];
+                const badgeFg = getTierBadgeForeground(tier, colorScheme === "dark");
                 return (
-                  <View style={[styles.badge, { backgroundColor: `${cfg.color}20` }]}>
-                    <Text style={[styles.badgeText, { color: cfg.color }]}>
+                  <View style={[styles.badge, { backgroundColor: `${cfg.color}28` }]}>
+                    <Text style={[styles.badgeText, { color: badgeFg }]}>
                       {cfg.emoji ? `${cfg.emoji} ` : ""}
                       {t(cfg.i18nKey)}
                     </Text>

--- a/app/account/my-addresses.tsx
+++ b/app/account/my-addresses.tsx
@@ -15,10 +15,12 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Dimensions,
   Keyboard,
   KeyboardAvoidingView,
   Modal,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -72,10 +74,13 @@ const mapApiToUi = (apiAddress: ApiAddress): Address => {
   };
 };
 
+const ADDRESS_MODAL_OVERLAY = 'rgba(0,0,0,0.65)' as const;
+
 export default function MyAddressesScreen() {
   const router = useRouter();
   const colors = useThemeColors();
   const insets = useSafeAreaInsets();
+  const { width: screenW, height: screenH } = Dimensions.get('screen');
 
   const [addresses, setAddresses] = useState<Address[]>([]);
   const [apiAddresses, setApiAddresses] = useState<ApiAddress[]>([]); // Store full API data
@@ -341,17 +346,31 @@ export default function MyAddressesScreen() {
         visible={showAddEditModal}
         transparent
         animationType="slide"
+        statusBarTranslucent={Platform.OS === 'android'}
+        presentationStyle="overFullScreen"
         onRequestClose={() => setShowAddEditModal(false)}
       >
-        <View style={[styles.modalOverlay, Platform.OS === 'android' && keyboardHeight > 0 && { paddingBottom: keyboardHeight }]}>
-          <TouchableOpacity
-            style={styles.modalBackdrop}
-            activeOpacity={1}
+        <View
+          style={[
+            styles.modalOverlay,
+            {
+              width: screenW,
+              minHeight: screenH,
+              backgroundColor: ADDRESS_MODAL_OVERLAY,
+            },
+            Platform.OS === 'android' && keyboardHeight > 0 && { paddingBottom: keyboardHeight },
+          ]}
+        >
+          <Pressable
+            style={StyleSheet.absoluteFillObject}
             onPress={() => setShowAddEditModal(false)}
+            accessibilityRole="button"
+            accessibilityLabel={t('common.cancel')}
           />
           <KeyboardAvoidingView
             behavior={Platform.OS === 'ios' ? 'padding' : undefined}
             style={styles.modalKeyboardView}
+            pointerEvents="box-none"
           >
             <View style={[styles.modalContent, { backgroundColor: colors.card, paddingBottom: insets.bottom + 20 }]}>
                 {/* Handle */}
@@ -370,9 +389,9 @@ export default function MyAddressesScreen() {
                 >
                   {/* Address Name */}
                   <View style={styles.inputContainer}>
-                    <Text style={styles.inputLabel}>{t('addresses.name')}</Text>
+                    <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>{t('addresses.name')}</Text>
                     <TextInput
-                      style={styles.input}
+                      style={[styles.input, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border, color: colors.textPrimary }]}
                       placeholder={t('addresses.namePlaceholder')}
                       placeholderTextColor={colors.textTertiary}
                       value={formData.name}
@@ -382,37 +401,43 @@ export default function MyAddressesScreen() {
 
                   {/* Address Type */}
                   <View style={styles.inputContainer}>
-                    <Text style={styles.inputLabel}>{t('addresses.type')}</Text>
+                    <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>{t('addresses.type')}</Text>
                     <View style={styles.typeButtons}>
-                      {(['home', 'office', 'other'] as const).map((type) => (
-                        <TouchableOpacity
-                          key={type}
-                          onPress={() => setFormData((prev) => ({ ...prev, type }))}
-                          style={[
-                            styles.typeButton,
-                            formData.type === type && styles.typeButtonActive,
-                          ]}
-                          activeOpacity={0.7}
-                        >
-                          <Text style={styles.typeButtonIcon}>{getAddressIcon(type)}</Text>
-                          <Text
+                      {(['home', 'office', 'other'] as const).map((type) => {
+                        const selected = formData.type === type;
+                        return (
+                          <TouchableOpacity
+                            key={type}
+                            onPress={() => setFormData((prev) => ({ ...prev, type }))}
                             style={[
-                              styles.typeButtonText,
-                              formData.type === type && styles.typeButtonTextActive,
+                              styles.typeButton,
+                              {
+                                backgroundColor: selected ? `${colors.primary}18` : colors.surfaceSecondary,
+                                borderColor: selected ? colors.primary : colors.border,
+                              },
                             ]}
+                            activeOpacity={0.7}
                           >
-                            {t(`addresses.type${type.charAt(0).toUpperCase() + type.slice(1)}`)}
-                          </Text>
-                        </TouchableOpacity>
-                      ))}
+                            <Text style={styles.typeButtonIcon}>{getAddressIcon(type)}</Text>
+                            <Text
+                              style={[
+                                styles.typeButtonText,
+                                { color: selected ? colors.primary : colors.textPrimary, fontWeight: selected ? '600' : '500' },
+                              ]}
+                            >
+                              {t(`addresses.type${type.charAt(0).toUpperCase() + type.slice(1)}`)}
+                            </Text>
+                          </TouchableOpacity>
+                        );
+                      })}
                     </View>
                   </View>
 
                   {/* Address Line 1 */}
                   <View style={styles.inputContainer}>
-                    <Text style={styles.inputLabel}>{t('addresses.addressLine1')}</Text>
+                    <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>{t('addresses.addressLine1')}</Text>
                     <TextInput
-                      style={styles.input}
+                      style={[styles.input, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border, color: colors.textPrimary }]}
                       placeholder={t('addresses.addressLine1Placeholder')}
                       placeholderTextColor={colors.textTertiary}
                       value={formData.address_line1}
@@ -426,9 +451,9 @@ export default function MyAddressesScreen() {
 
                   {/* Address Line 2 (Optional) */}
                   <View style={styles.inputContainer}>
-                    <Text style={styles.inputLabel}>{t('addresses.addressLine2')} (Optional)</Text>
+                    <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>{t('addresses.addressLine2')} (Optional)</Text>
                     <TextInput
-                      style={styles.input}
+                      style={[styles.input, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border, color: colors.textPrimary }]}
                       placeholder={t('addresses.addressLine2Placeholder')}
                       placeholderTextColor={colors.textTertiary}
                       value={formData.address_line2}
@@ -440,9 +465,9 @@ export default function MyAddressesScreen() {
 
                   {/* City */}
                   <View style={styles.inputContainer}>
-                    <Text style={styles.inputLabel}>{t('addresses.city')}</Text>
+                    <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>{t('addresses.city')}</Text>
                     <TextInput
-                      style={styles.input}
+                      style={[styles.input, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border, color: colors.textPrimary }]}
                       placeholder={t('addresses.cityPlaceholder')}
                       placeholderTextColor={colors.textTertiary}
                       value={formData.city}
@@ -453,9 +478,9 @@ export default function MyAddressesScreen() {
                   {/* State and Postal Code Row */}
                   <View style={styles.inputRow}>
                     <View style={[styles.inputContainer, styles.inputHalf]}>
-                      <Text style={styles.inputLabel}>{t('addresses.state')}</Text>
+                      <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>{t('addresses.state')}</Text>
                       <TextInput
-                        style={styles.input}
+                        style={[styles.input, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border, color: colors.textPrimary }]}
                         placeholder={t('addresses.statePlaceholder')}
                         placeholderTextColor={colors.textTertiary}
                         value={formData.state}
@@ -464,9 +489,9 @@ export default function MyAddressesScreen() {
                       />
                     </View>
                     <View style={[styles.inputContainer, styles.inputHalf]}>
-                      <Text style={styles.inputLabel}>{t('addresses.postalCode')}</Text>
+                      <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>{t('addresses.postalCode')}</Text>
                       <TextInput
-                        style={styles.input}
+                        style={[styles.input, { backgroundColor: colors.surfaceSecondary, borderColor: colors.border, color: colors.textPrimary }]}
                         placeholder={t('addresses.postalCodePlaceholder')}
                         placeholderTextColor={colors.textTertiary}
                         value={formData.postal_code}
@@ -490,29 +515,33 @@ export default function MyAddressesScreen() {
                       <View
                         style={[
                           styles.checkbox,
-                          formData.is_default && styles.checkboxChecked,
+                          {
+                            borderColor: colors.border,
+                            backgroundColor: formData.is_default ? colors.primary : colors.surfaceSecondary,
+                          },
+                          formData.is_default && { borderColor: colors.primary },
                         ]}
                       >
                         {formData.is_default && (
-                          <Ionicons name="checkmark" size={16} color={colors.textPrimary} />
+                          <Ionicons name="checkmark" size={16} color="#FFFFFF" />
                         )}
                       </View>
-                      <Text style={styles.defaultToggleText}>{t('addresses.setAsDefault')}</Text>
+                      <Text style={[styles.defaultToggleText, { color: colors.textPrimary }]}>{t('addresses.setAsDefault')}</Text>
                     </TouchableOpacity>
                   )}
                 </ScrollView>
 
                 {/* Buttons - Fixed at bottom */}
-                <View style={styles.modalButtons}>
+                <View style={[styles.modalButtons, { borderTopColor: colors.border }]}>
                   <TouchableOpacity
                     onPress={() => {
                       setShowAddEditModal(false);
                       setEditingAddress(null);
                     }}
-                    style={styles.modalButtonCancel}
+                    style={[styles.modalButtonCancel, { backgroundColor: colors.surfaceSecondary }]}
                     activeOpacity={0.7}
                   >
-                    <Text style={styles.modalButtonTextCancel}>{t('common.cancel')}</Text>
+                    <Text style={[styles.modalButtonTextCancel, { color: colors.textPrimary }]}>{t('common.cancel')}</Text>
                   </TouchableOpacity>
                   {loading ? (
                     <View style={styles.modalButtonConfirm}>
@@ -716,19 +745,15 @@ const styles = StyleSheet.create({
   },
   modalOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.7)',
     justifyContent: 'flex-end',
-  },
-  modalBackdrop: {
-    ...StyleSheet.absoluteFillObject,
   },
   modalKeyboardView: {
     width: '100%',
+    flex: 1,
     justifyContent: 'flex-end',
   },
   modalContent: {
     width: '100%',
-    backgroundColor: '#1a1a2e',
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
     paddingTop: 24,
@@ -752,7 +777,6 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   modalTitle: {
-    color: '#ffffff',
     fontSize: 20,
     fontWeight: '700',
     marginBottom: 24,
@@ -770,7 +794,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   inputLabel: {
-    color: '#9ca3af',
     fontSize: 12,
     fontWeight: '600',
     marginBottom: 8,
@@ -778,11 +801,8 @@ const styles = StyleSheet.create({
   input: {
     width: '100%',
     padding: 16,
-    backgroundColor: '#2d2d4a',
     borderWidth: 1,
-    borderColor: '#374151',
     borderRadius: 12,
-    color: '#ffffff',
     fontSize: 15,
   },
   typeButtons: {
@@ -792,28 +812,17 @@ const styles = StyleSheet.create({
   typeButton: {
     flex: 1,
     padding: 14,
-    backgroundColor: '#252542',
     borderWidth: 1,
-    borderColor: '#374151',
     borderRadius: 12,
     alignItems: 'center',
     justifyContent: 'center',
     gap: 6,
   },
-  typeButtonActive: {
-    backgroundColor: '#3b82f620',
-    borderColor: '#3b82f6',
-  },
   typeButtonIcon: {
     fontSize: 20,
   },
   typeButtonText: {
-    color: '#ffffff',
     fontSize: 14,
-  },
-  typeButtonTextActive: {
-    color: '#3b82f6',
-    fontWeight: '600',
   },
   defaultToggle: {
     flexDirection: 'row',
@@ -826,17 +835,10 @@ const styles = StyleSheet.create({
     height: 24,
     borderRadius: 6,
     borderWidth: 2,
-    borderColor: '#374151',
-    backgroundColor: '#2d2d4a',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  checkboxChecked: {
-    backgroundColor: '#3b82f6',
-    borderColor: '#3b82f6',
-  },
   defaultToggleText: {
-    color: '#ffffff',
     fontSize: 15,
   },
   modalButtons: {
@@ -845,12 +847,10 @@ const styles = StyleSheet.create({
     marginTop: 16,
     paddingTop: 16,
     borderTopWidth: 1,
-    borderTopColor: '#374151',
   },
   modalButtonCancel: {
     flex: 1,
     padding: 18,
-    backgroundColor: '#252542',
     borderRadius: 14,
     alignItems: 'center',
     justifyContent: 'center',
@@ -866,7 +866,6 @@ const styles = StyleSheet.create({
   modalButtonTextCancel: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#ffffff',
   },
   modalButtonTextConfirm: {
     fontSize: 16,

--- a/app/orders/rate/[orderId].tsx
+++ b/app/orders/rate/[orderId].tsx
@@ -1,11 +1,12 @@
 import { StarRating } from '@/components/StarRating';
+import { useThemeColors } from '@/hooks/useThemeColors';
 import { t } from '@/i18n';
 import { fetchOrderDetail } from '@/services/orders';
 import { createReview, ApiError } from '@/services/reviews';
 import { useQueryClient } from '@tanstack/react-query';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -19,14 +20,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const BACKGROUND = '#1a1a2e';
-const HEADER_BG = '#252542';
-const CARD_BG = '#252542';
-const CARD_BORDER = '#374151';
 const ACCENT = '#3b82f6';
-const TEXT_PRIMARY = '#FFFFFF';
-const TEXT_SECONDARY = '#9ca3af';
-const SECTION_HEADER = '#9ca3af';
 
 function formatScheduledAt(scheduledAt: string | undefined): string {
   if (!scheduledAt) return '';
@@ -43,7 +37,8 @@ function formatScheduledAt(scheduledAt: string | undefined): string {
 export default function RateExperienceScreen() {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const { orderId, navRef } = useLocalSearchParams<{ orderId: string; navRef?: string }>();
+  const colors = useThemeColors();
+  const { orderId } = useLocalSearchParams<{ orderId: string; navRef?: string }>();
   const insets = useSafeAreaInsets();
   const bottomInset = insets.bottom || (Platform.OS === 'android' ? 40 : 0);
 
@@ -61,12 +56,12 @@ export default function RateExperienceScreen() {
       setError(null);
       const data = await fetchOrderDetail(orderId);
       setOrderDetail(data);
-    } catch (e) {
+    } catch {
       setError(t('errors.requestFailed'));
     } finally {
       setLoading(false);
     }
-  }, [orderId, navRef]);
+  }, [orderId]);
 
   useEffect(() => {
     loadOrder();
@@ -74,7 +69,12 @@ export default function RateExperienceScreen() {
 
   const order = orderDetail?.order;
   const supplierId = order?.supplier_id ?? orderDetail?.supplier?.id;
-  const providerName = order?.supplier_name ?? order?.business_name ?? orderDetail?.supplier?.business_name?.trim() ?? orderDetail?.supplier?.full_name ?? t('orders.provider');
+  const providerName =
+    order?.supplier_name ??
+    order?.business_name ??
+    orderDetail?.supplier?.business_name?.trim() ??
+    orderDetail?.supplier?.full_name ??
+    t('orders.provider');
   const serviceName = order?.service_name ?? '';
   const scheduledLabel = formatScheduledAt(order?.scheduled_at);
 
@@ -130,9 +130,26 @@ export default function RateExperienceScreen() {
     router.push('/(tabs)/home');
   }, [router]);
 
+  const themed = useMemo(
+    () => ({
+      screenBg: colors.screenBackground,
+      headerBg: colors.card,
+      headerBorder: colors.cardBorder,
+      cardBg: colors.card,
+      cardBorder: colors.cardBorder,
+      textPrimary: colors.textPrimary,
+      textSecondary: colors.textSecondary,
+      sectionMuted: colors.textSecondary,
+      inputBg: colors.surfaceSecondary,
+      inputBorder: colors.border,
+      footerBg: colors.screenBackground,
+    }),
+    [colors],
+  );
+
   if (loading) {
     return (
-      <View style={[styles.container, styles.centered, { paddingTop: insets.top }]}>
+      <View style={[styles.container, styles.centered, { paddingTop: insets.top, backgroundColor: themed.screenBg }]}>
         <ActivityIndicator size="large" color={ACCENT} />
       </View>
     );
@@ -140,16 +157,16 @@ export default function RateExperienceScreen() {
 
   if (error || !order) {
     return (
-      <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset }]}>
-        <View style={[styles.header, { paddingTop: insets.top + 16, paddingBottom: 20 }]}>
+      <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset, backgroundColor: themed.screenBg }]}>
+        <View style={[styles.header, { paddingTop: insets.top + 16, paddingBottom: 20, backgroundColor: themed.headerBg, borderBottomWidth: 1, borderBottomColor: themed.headerBorder }]}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={24} color={TEXT_PRIMARY} />
+            <Ionicons name="arrow-back" size={24} color={themed.textPrimary} />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{t('rating.title')}</Text>
+          <Text style={[styles.headerTitle, { color: themed.textPrimary }]}>{t('rating.title')}</Text>
           <View style={styles.headerPlaceholder} />
         </View>
         <View style={styles.centered}>
-          <Text style={styles.errorText}>{error ?? t('errors.requestFailed')}</Text>
+          <Text style={[styles.errorText, { color: colors.textPrimary }]}>{error ?? t('errors.requestFailed')}</Text>
           <TouchableOpacity style={styles.retryButton} onPress={loadOrder}>
             <Text style={styles.retryText}>{t('chat.retry')}</Text>
           </TouchableOpacity>
@@ -161,18 +178,18 @@ export default function RateExperienceScreen() {
   const alreadyReviewed = Boolean(orderDetail?.client_has_reviewed);
   if (alreadyReviewed) {
     return (
-      <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset }]}>
-        <View style={[styles.header, { paddingTop: insets.top + 16, paddingBottom: 20 }]}>
+      <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset, backgroundColor: themed.screenBg }]}>
+        <View style={[styles.header, { paddingTop: insets.top + 16, paddingBottom: 20, backgroundColor: themed.headerBg, borderBottomWidth: 1, borderBottomColor: themed.headerBorder }]}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={24} color={TEXT_PRIMARY} />
+            <Ionicons name="arrow-back" size={24} color={themed.textPrimary} />
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{t('rating.title')}</Text>
+          <Text style={[styles.headerTitle, { color: themed.textPrimary }]}>{t('rating.title')}</Text>
           <View style={styles.headerPlaceholder} />
         </View>
         <View style={[styles.centered, { flex: 1 }]}>
-          <View style={styles.card}>
+          <View style={[styles.card, { backgroundColor: themed.cardBg, borderColor: themed.cardBorder }]}>
             <Ionicons name="checkmark-circle" size={56} color={ACCENT} style={{ marginBottom: 16 }} />
-            <Text style={styles.serviceTitle}>{t('rating.alreadyReviewed')}</Text>
+            <Text style={[styles.serviceTitle, { color: themed.textPrimary }]}>{t('rating.alreadyReviewed')}</Text>
           </View>
           <TouchableOpacity
             style={[styles.submitButton, { marginTop: 24, paddingVertical: 16 }]}
@@ -187,12 +204,12 @@ export default function RateExperienceScreen() {
   }
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset }]}>
-      <View style={[styles.header, { paddingTop: insets.top + 16, paddingBottom: 20 }]}>
+    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: bottomInset, backgroundColor: themed.screenBg }]}>
+      <View style={[styles.header, { paddingTop: insets.top + 16, paddingBottom: 20, backgroundColor: themed.headerBg, borderBottomWidth: 1, borderBottomColor: themed.headerBorder }]}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-          <Ionicons name="arrow-back" size={24} color={TEXT_PRIMARY} />
+          <Ionicons name="arrow-back" size={24} color={themed.textPrimary} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>{t('rating.title')}</Text>
+        <Text style={[styles.headerTitle, { color: themed.textPrimary }]}>{t('rating.title')}</Text>
         <View style={styles.headerPlaceholder} />
       </View>
 
@@ -201,44 +218,52 @@ export default function RateExperienceScreen() {
         contentContainerStyle={[styles.scrollContent, { paddingBottom: Math.max(bottomInset, 24) }]}
         showsVerticalScrollIndicator={false}
       >
-        <View style={styles.card}>
-          <Text style={styles.serviceTitle}>{serviceName || t('orders.service')}</Text>
-          <Text style={styles.providerName}>{providerName}</Text>
-          {scheduledLabel ? <Text style={styles.serviceDate}>{scheduledLabel}</Text> : null}
+        <View style={[styles.card, { backgroundColor: themed.cardBg, borderColor: themed.cardBorder }]}>
+          <Text style={[styles.serviceTitle, { color: themed.textPrimary }]}>{serviceName || t('orders.service')}</Text>
+          <Text style={[styles.providerName, { color: themed.textSecondary }]}>{providerName}</Text>
+          {scheduledLabel ? <Text style={[styles.serviceDate, { color: themed.textSecondary }]}>{scheduledLabel}</Text> : null}
         </View>
 
-        <Text style={styles.sectionQuestion}>{t('rating.howWasService')}</Text>
-        <View style={styles.card}>
+        <Text style={[styles.sectionQuestion, { color: themed.textPrimary }]}>{t('rating.howWasService')}</Text>
+        <View style={[styles.card, { backgroundColor: themed.cardBg, borderColor: themed.cardBorder }]}>
           <StarRating
             rating={rating}
             size={40}
             interactive
             onRatingChange={setRating}
           />
-          <Text style={styles.ratingHint}>{t('rating.tapToRate')}</Text>
+          <Text style={[styles.ratingHint, { color: themed.textSecondary }]}>{t('rating.tapToRate')}</Text>
         </View>
 
-        <Text style={styles.sectionLabel}>{t('rating.shareExperience')}</Text>
-        <View style={styles.card}>
-          <TextInput
-            style={styles.commentInput}
-            placeholder={t('rating.placeholder')}
-            placeholderTextColor={TEXT_SECONDARY}
-            value={comment}
-            onChangeText={setComment}
-            multiline
-            numberOfLines={6}
-            textAlignVertical="top"
-          />
-        </View>
+        <Text style={[styles.sectionLabel, { color: themed.sectionMuted }]}>{t('rating.shareExperience')}</Text>
+        <TextInput
+          style={[
+            styles.commentInput,
+            {
+              backgroundColor: themed.inputBg,
+              borderColor: themed.inputBorder,
+              color: themed.textPrimary,
+            },
+          ]}
+          placeholder={t('rating.placeholder')}
+          placeholderTextColor={colors.textTertiary}
+          value={comment}
+          onChangeText={setComment}
+          multiline
+          numberOfLines={6}
+          textAlignVertical="top"
+        />
 
-        <TouchableOpacity style={styles.photoButton} activeOpacity={0.8}>
+        <TouchableOpacity
+          style={[styles.photoButton, { borderColor: themed.inputBorder }]}
+          activeOpacity={0.8}
+        >
           <Ionicons name="camera-outline" size={24} color={ACCENT} />
           <Text style={styles.photoButtonText}>{t('rating.uploadPhotos')}</Text>
         </TouchableOpacity>
       </ScrollView>
 
-      <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, 16) }]}>
+      <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, 16), backgroundColor: themed.footerBg }]}>
         <TouchableOpacity
           style={[styles.submitButton, (rating === 0 || submitting) && styles.submitButtonDisabled]}
           onPress={handleSubmit}
@@ -252,7 +277,7 @@ export default function RateExperienceScreen() {
           )}
         </TouchableOpacity>
         <TouchableOpacity style={styles.skipButton} onPress={handleSkip} activeOpacity={0.7}>
-          <Text style={styles.skipButtonText}>{t('rating.skip')}</Text>
+          <Text style={[styles.skipButtonText, { color: colors.primary }]}>{t('rating.skip')}</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -262,7 +287,6 @@ export default function RateExperienceScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: BACKGROUND,
   },
   centered: {
     flex: 1,
@@ -275,7 +299,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingHorizontal: 20,
-    backgroundColor: HEADER_BG,
   },
   backButton: {
     width: 40,
@@ -286,7 +309,6 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontSize: 18,
     fontWeight: '600',
-    color: TEXT_PRIMARY,
   },
   headerPlaceholder: {
     width: 40,
@@ -300,7 +322,6 @@ const styles = StyleSheet.create({
   sectionQuestion: {
     fontSize: 16,
     fontWeight: '600',
-    color: TEXT_PRIMARY,
     textAlign: 'center',
     marginTop: 24,
     marginBottom: 12,
@@ -309,49 +330,39 @@ const styles = StyleSheet.create({
   sectionLabel: {
     fontSize: 12,
     fontWeight: '500',
-    color: SECTION_HEADER,
     letterSpacing: 0.5,
     marginTop: 24,
     marginBottom: 12,
   },
   card: {
-    backgroundColor: CARD_BG,
     borderRadius: 12,
     padding: 16,
     borderWidth: 1,
-    borderColor: CARD_BORDER,
     alignItems: 'center',
     marginBottom: 8,
   },
   serviceTitle: {
     fontSize: 18,
     fontWeight: '600',
-    color: TEXT_PRIMARY,
     marginBottom: 4,
     textAlign: 'center',
   },
   providerName: {
     fontSize: 15,
-    color: TEXT_SECONDARY,
     marginBottom: 4,
   },
   serviceDate: {
     fontSize: 13,
-    color: TEXT_SECONDARY,
   },
   ratingHint: {
     fontSize: 14,
-    color: TEXT_SECONDARY,
     marginTop: 12,
   },
   commentInput: {
-    backgroundColor: 'rgba(255,255,255,0.08)',
     borderRadius: 12,
     padding: 16,
     fontSize: 14,
-    color: TEXT_PRIMARY,
     borderWidth: 1,
-    borderColor: CARD_BORDER,
     minHeight: 120,
     width: '100%',
   },
@@ -362,7 +373,6 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     borderRadius: 12,
     borderWidth: 2,
-    borderColor: CARD_BORDER,
     borderStyle: 'dashed',
     marginTop: 8,
     marginBottom: 24,
@@ -394,7 +404,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingTop: 12,
     gap: 8,
-    backgroundColor: BACKGROUND,
   },
   submitButton: {
     backgroundColor: ACCENT,
@@ -415,8 +424,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   skipButtonText: {
-    color: TEXT_SECONDARY,
     fontSize: 15,
-    fontWeight: '500',
+    fontWeight: '600',
   },
 });

--- a/app/services/[categoryId]/index.tsx
+++ b/app/services/[categoryId]/index.tsx
@@ -1,6 +1,6 @@
 import { ProviderCard } from "@/components/ProviderCard";
 import { useAuth } from "@/contexts/AuthContext";
-import { useColorScheme } from "@/hooks/use-color-scheme";
+import { useTheme } from "@/contexts/ThemeContext";
 import { t } from "@/i18n";
 import { getAddresses } from "@/services/addresses";
 import { ApiError, CategoryWithSubcategories, fetchCategoryWithSubcategories } from "@/services/categories";
@@ -15,7 +15,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 export default function CategoryDetailScreen() {
   const router = useRouter();
   const { user } = useAuth();
-  const colorScheme = useColorScheme();
+  const { colorScheme, theme: themePreference } = useTheme();
   const { categoryId } = useLocalSearchParams<{ categoryId: string }>();
   const insets = useSafeAreaInsets();
   const [categoryData, setCategoryData] = useState<CategoryWithSubcategories | null>(null);
@@ -216,6 +216,8 @@ export default function CategoryDetailScreen() {
         </View>
       : <FlatList
           data={suppliers}
+          extraData={`${themePreference}-${colorScheme}`}
+          removeClippedSubviews={false}
           renderItem={({ item }) => {
             if (!item || !item.id) {
               return null;

--- a/app/services/search-results.tsx
+++ b/app/services/search-results.tsx
@@ -40,7 +40,7 @@ const FILTERS: FilterOption[] = [
 export default function SearchResultsScreen() {
   const router = useRouter();
   const { user } = useAuth();
-  const { colorScheme } = useTheme();
+  const { colorScheme, theme: themePreference } = useTheme();
   const insets = useSafeAreaInsets();
   const params = useLocalSearchParams<{ 
     query?: string; 
@@ -323,6 +323,8 @@ export default function SearchResultsScreen() {
       ) : (
         <PlatformFlashList
           data={suppliers}
+          extraData={`${themePreference}-${colorScheme}`}
+          removeClippedSubviews={false}
           renderItem={({ item }) => {
             // Validate item before rendering
             if (!item || !item.id) {

--- a/components/ProviderCard.tsx
+++ b/components/ProviderCard.tsx
@@ -1,10 +1,12 @@
-import { useFavorite } from '@/hooks/useFavorite';
 import { ProviderAvatar } from '@/components/ProviderAvatar';
-import { Supplier } from '@/services/suppliers';
-import { Ionicons } from '@expo/vector-icons';
-import React from 'react';
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useFavorite } from '@/hooks/useFavorite';
 import { t } from '@/i18n';
+import { Supplier } from '@/services/suppliers';
+import { getThemeColors, type ThemeColors } from '@/utils/themeStyles';
+import { Ionicons } from '@expo/vector-icons';
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 interface ProviderCardProps {
   supplier: Supplier;
@@ -12,20 +14,151 @@ interface ProviderCardProps {
   onBookPress?: () => void;
 }
 
+const BRAND = {
+  primary: '#3B82F6',
+  secondary: '#10B981',
+  rating: '#D97706',
+} as const;
+
+function createStyles(theme: ThemeColors, isDark: boolean) {
+  const availableBg = isDark ? 'rgba(16, 185, 129, 0.22)' : 'rgba(16, 185, 129, 0.18)';
+  const availableFg = isDark ? BRAND.secondary : '#047857';
+  const serviceCategory = isDark ? BRAND.secondary : '#047857';
+
+  return StyleSheet.create({
+    container: {
+      backgroundColor: theme.card,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 12,
+      borderWidth: 1,
+      borderColor: theme.cardBorder,
+    },
+    content: {
+      flexDirection: 'row',
+      gap: 14,
+    },
+    imageContainer: {
+      width: 80,
+      height: 80,
+      borderRadius: 14,
+      backgroundColor: theme.surfaceSecondary,
+      overflow: 'hidden',
+    },
+    image: {
+      width: 80,
+      height: 80,
+      borderRadius: 14,
+    },
+    info: {
+      flex: 1,
+    },
+    headerRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      marginBottom: 4,
+    },
+    name: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.textPrimary,
+      flex: 1,
+    },
+    favoriteButton: {
+      padding: 4,
+    },
+    serviceContainer: {
+      flexShrink: 1,
+      minWidth: 0,
+      marginBottom: 6,
+    },
+    service: {
+      fontSize: 14,
+      color: serviceCategory,
+    },
+    ratingRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      marginBottom: 8,
+    },
+    ratingText: {
+      fontSize: 13,
+      color: BRAND.rating,
+      fontWeight: '600',
+    },
+    distance: {
+      fontSize: 13,
+      color: theme.textSecondary,
+    },
+    footerRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: 12,
+      flexWrap: 'wrap',
+    },
+    priceSection: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      flex: 1,
+      flexShrink: 1,
+      minWidth: 0,
+    },
+    price: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: BRAND.primary,
+      margin: 0,
+      flexShrink: 0,
+    },
+    availableBadge: {
+      backgroundColor: availableBg,
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      borderRadius: 4,
+      flexShrink: 1,
+    },
+    availableText: {
+      fontSize: 10,
+      color: availableFg,
+      fontWeight: '700',
+    },
+    bookButton: {
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      backgroundColor: BRAND.primary,
+      borderRadius: 8,
+      flexShrink: 0,
+      minWidth: 80,
+    },
+    bookButtonText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: '#FFFFFF',
+    },
+  });
+}
+
 export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardProps) {
-  // Validate supplier data before rendering
-  if (!supplier || !supplier.id) {
+  const { colorScheme } = useTheme();
+  const isDark = colorScheme === 'dark';
+  const theme = useMemo(() => getThemeColors(isDark), [isDark]);
+  const styles = useMemo(() => createStyles(theme, isDark), [theme, isDark]);
+  const { isFavorite, isLoading: isFavoriteLoading, toggleFavorite } = useFavorite(supplier?.id);
+
+  if (!supplier?.id) {
     return null;
   }
 
-  const { isFavorite, isLoading: isFavoriteLoading, toggleFavorite } = useFavorite(supplier.id);
-  
-  const ratingValue = typeof supplier.rating === 'number' 
-    ? supplier.rating 
+  const ratingValue = typeof supplier.rating === 'number'
+    ? supplier.rating
     : (typeof supplier.rating === 'string' ? parseFloat(supplier.rating) : 0);
-  const safeRating = isNaN(ratingValue) ? 0 : ratingValue;
+  const safeRating = Number.isNaN(ratingValue) ? 0 : ratingValue;
 
-  const handleFavoritePress = (e: any) => {
+  const handleFavoritePress = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
     toggleFavorite();
   };
@@ -35,7 +168,6 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
   return (
     <TouchableOpacity style={styles.container} onPress={onPress} activeOpacity={0.7}>
       <View style={styles.content}>
-        {/* Profile Image - 80x80px, borderRadius 14px */}
         <View style={styles.imageContainer}>
           <ProviderAvatar
             profileImage={supplier.profile_image}
@@ -45,32 +177,28 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
           />
         </View>
 
-        {/* Info Section */}
         <View style={styles.info}>
-          {/* Name and Favorite Row */}
           <View style={styles.headerRow}>
             <Text style={styles.name} numberOfLines={1}>{supplier.business_name?.trim() || supplier.full_name || 'Unknown'}</Text>
-            <TouchableOpacity 
+            <TouchableOpacity
               style={styles.favoriteButton}
               onPress={handleFavoritePress}
               disabled={isFavoriteLoading}
             >
-              <Ionicons 
-                name={isFavorite ? "heart" : "heart-outline"} 
-                size={18} 
-                color={isFavorite ? "#EF4444" : "#9CA3AF"} 
+              <Ionicons
+                name={isFavorite ? 'heart' : 'heart-outline'}
+                size={18}
+                color={isFavorite ? '#EF4444' : theme.icon}
               />
             </TouchableOpacity>
           </View>
 
-          {/* Service Category */}
           {supplier.service_category && (
             <View style={styles.serviceContainer}>
               <Text style={styles.service} numberOfLines={1}>{supplier.service_category}</Text>
             </View>
           )}
 
-          {/* Rating and Distance Row */}
           <View style={styles.ratingRow}>
             <Text style={styles.ratingText}>
               ⭐ {safeRating.toFixed(1)} ({supplier.total_reviews || 0})
@@ -80,7 +208,6 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
             )}
           </View>
 
-          {/* Price, Availability and Book Button Row */}
           <View style={styles.footerRow}>
             <View style={styles.priceSection}>
               {supplier.hourly_rate && (
@@ -92,7 +219,7 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
                 </View>
               )}
             </View>
-            <TouchableOpacity 
+            <TouchableOpacity
               style={styles.bookButton}
               onPress={(e) => {
                 e.stopPropagation();
@@ -107,116 +234,3 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
     </TouchableOpacity>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: '#252542',
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 12,
-  },
-  content: {
-    flexDirection: 'row',
-    gap: 14,
-  },
-  imageContainer: {
-    width: 80,
-    height: 80,
-    borderRadius: 14,
-    backgroundColor: '#2d2d4a',
-    overflow: 'hidden',
-  },
-  image: {
-    width: 80,
-    height: 80,
-    borderRadius: 14,
-  },
-  info: {
-    flex: 1,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    marginBottom: 4,
-  },
-  name: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#FFFFFF',
-    flex: 1,
-  },
-  favoriteButton: {
-    padding: 4,
-  },
-  serviceContainer: {
-    flexShrink: 1,
-    minWidth: 0,
-    marginBottom: 6,
-  },
-  service: {
-    fontSize: 14,
-    color: '#10B981',
-  },
-  ratingRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    marginBottom: 8,
-  },
-  ratingText: {
-    fontSize: 13,
-    color: '#F59E0B',
-  },
-  distance: {
-    fontSize: 13,
-    color: '#9CA3AF',
-  },
-  footerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    gap: 12,
-    flexWrap: 'wrap',
-  },
-  priceSection: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    flex: 1,
-    flexShrink: 1,
-    minWidth: 0,
-  },
-  price: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: '#3B82F6',
-    margin: 0,
-    flexShrink: 0,
-  },
-  availableBadge: {
-    backgroundColor: 'rgba(16, 185, 129, 0.2)',
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 4,
-    flexShrink: 1,
-  },
-  availableText: {
-    fontSize: 10,
-    color: '#10B981',
-    fontWeight: '600',
-  },
-  bookButton: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    backgroundColor: '#3B82F6',
-    borderRadius: 8,
-    flexShrink: 0,
-    minWidth: 80,
-  },
-  bookButtonText: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: '#FFFFFF',
-  },
-});

--- a/components/common/ModeSwitch/ModeSwitch.tsx
+++ b/components/common/ModeSwitch/ModeSwitch.tsx
@@ -216,21 +216,23 @@ function PillVariant({
   const slideAnim = useRef(new Animated.Value(isClient ? 0 : sliderWidth)).current;
   const clientIconOpacity = useRef(new Animated.Value(isClient ? 1 : 0.35)).current;
   const providerIconOpacity = useRef(new Animated.Value(isClient ? 0.35 : 1)).current;
-  const clientTextOpacity = useRef(new Animated.Value(isClient ? 1 : 0.5)).current;
-  const providerTextOpacity = useRef(new Animated.Value(isClient ? 0.5 : 1)).current;
+  const clientTextOpacity = useRef(new Animated.Value(isClient ? 1 : 0.72)).current;
+  const providerTextOpacity = useRef(new Animated.Value(isClient ? 0.72 : 1)).current;
 
   const pillBg = colors.surfaceSecondary ?? COLORS.common.background;
   const pillBorder = colors.border ?? COLORS.common.border;
-  const activeText = colors.textOnDark ?? COLORS.common.activeText;
-  const inactiveText = colors.textSecondary ?? COLORS.common.inactiveText;
+  /** Labels/icons on the sliding gradient must stay white (textOnDark is dark in light theme). */
+  const labelOnGradient = COLORS.common.activeText;
+  /** Inactive side sits on the light track — use primary text, not faint secondary × low opacity. */
+  const labelOnTrack = colors.textPrimary ?? COLORS.common.inactiveText;
 
   useEffect(() => {
     Animated.parallel([
       Animated.timing(slideAnim, { toValue: isClient ? 0 : sliderWidth, duration: 300, useNativeDriver: true }),
       Animated.timing(clientIconOpacity, { toValue: isClient ? 1 : 0.35, duration: 200, useNativeDriver: true }),
       Animated.timing(providerIconOpacity, { toValue: isClient ? 0.35 : 1, duration: 200, useNativeDriver: true }),
-      Animated.timing(clientTextOpacity, { toValue: isClient ? 1 : 0.5, duration: 200, useNativeDriver: true }),
-      Animated.timing(providerTextOpacity, { toValue: isClient ? 0.5 : 1, duration: 200, useNativeDriver: true }),
+      Animated.timing(clientTextOpacity, { toValue: isClient ? 1 : 0.72, duration: 200, useNativeDriver: true }),
+      Animated.timing(providerTextOpacity, { toValue: isClient ? 0.72 : 1, duration: 200, useNativeDriver: true }),
     ]).start();
   }, [isClient, slideAnim, clientIconOpacity, providerIconOpacity, clientTextOpacity, providerTextOpacity, sliderWidth]);
 
@@ -297,14 +299,14 @@ function PillVariant({
               <Ionicons
                 name={isClient ? "person" : "person-outline"}
                 size={sizeConfig.iconSize}
-                color={isClient ? activeText : inactiveText}
+                color={isClient ? labelOnGradient : labelOnTrack}
               />
             </Animated.View>
             {showLabels && (
               <Animated.Text
                 style={[
                   styles.pillText,
-                  { opacity: clientTextOpacity, fontSize: sizeConfig.fontSize, color: isClient ? activeText : inactiveText, fontWeight: isClient ? '700' : '500' },
+                  { opacity: clientTextOpacity, fontSize: sizeConfig.fontSize, color: isClient ? labelOnGradient : labelOnTrack, fontWeight: isClient ? '700' : '500' },
                 ]}
               >
                 {t('mode.client')}
@@ -317,14 +319,14 @@ function PillVariant({
               <Ionicons
                 name={!isClient ? "construct" : "construct-outline"}
                 size={sizeConfig.iconSize}
-                color={!isClient ? activeText : inactiveText}
+                color={!isClient ? labelOnGradient : labelOnTrack}
               />
             </Animated.View>
             {showLabels && (
               <Animated.Text
                 style={[
                   styles.pillText,
-                  { opacity: providerTextOpacity, fontSize: sizeConfig.fontSize, color: !isClient ? activeText : inactiveText, fontWeight: !isClient ? '700' : '500' },
+                  { opacity: providerTextOpacity, fontSize: sizeConfig.fontSize, color: !isClient ? labelOnGradient : labelOnTrack, fontWeight: !isClient ? '700' : '500' },
                 ]}
               >
                 {t('mode.provider')}

--- a/constants/tiers.ts
+++ b/constants/tiers.ts
@@ -61,3 +61,19 @@ export function getOrdersToNextTier(
   if (!next) return null;
   return Math.max(0, CLIENT_TIERS[next].thresholdOrders - completedOrders);
 }
+
+/** Foreground for tier badge on light backgrounds (metallic hexes are too low-contrast on white). */
+export function getTierBadgeForeground(tier: ClientTier, isDark: boolean): string {
+  if (isDark) return CLIENT_TIERS[tier].color;
+  switch (tier) {
+    case "platinum":
+      return "#4338CA";
+    case "silver":
+      return "#475569";
+    case "gold":
+      return "#92400E";
+    case "bronze":
+    default:
+      return "#92400E";
+  }
+}


### PR DESCRIPTION
- ProviderCard: subscribe via ThemeContext, fix hook order (useFavorite before conditional return), remove unused Image import.
- Category detail and search results: FlatList/PlatformFlashList extraData tied to theme preference + colorScheme; removeClippedSubviews false so rows repaint when switching light/dark.
- Client QA: themed rate experience, address modals, profile tier badges, ModeSwitch inactive label contrast.
