### PR TITLE
fix(profile): load app version from platform settings

### DIFF
--- a/components/profile/ProfileFooter.tsx
+++ b/components/profile/ProfileFooter.tsx
@@ -1,10 +1,10 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { t } from "@/i18n";
+import { fetchPlatformStatus, PLATFORM_STATUS_QUERY_KEY } from "@/services/platformStatus";
+import { useQuery } from "@tanstack/react-query";
+import Constants from "expo-constants";
 import React from "react";
 import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
-
-/** Version label shown in profile footer for both Client and Provider. */
-const PROFILE_VERSION_LABEL = "3.0.10";
 
 /**
  * Shared footer for Client and Provider profile screens: app version label and logout button.
@@ -12,6 +12,13 @@ const PROFILE_VERSION_LABEL = "3.0.10";
  */
 export function ProfileFooter() {
   const { logout } = useAuth();
+  const { data: platformStatus } = useQuery({
+    queryKey: PLATFORM_STATUS_QUERY_KEY,
+    queryFn: fetchPlatformStatus,
+    staleTime: 15_000,
+  });
+  const bundledVersion = Constants.nativeAppVersion ?? Constants.expoConfig?.version ?? "0.0.0";
+  const visibleVersion = platformStatus?.app_version?.trim() || bundledVersion;
 
   const handleLogout = () => {
     const performLogout = async () => {
@@ -45,7 +52,7 @@ export function ProfileFooter() {
         </TouchableOpacity>
       </View>
       <View style={styles.versionContainer}>
-        <Text style={styles.versionText}>{t("profile.version")} {PROFILE_VERSION_LABEL}</Text>
+        <Text style={styles.versionText}>{t("profile.version")} {visibleVersion}</Text>
       </View>
     </View>
   );

--- a/services/platformStatus.ts
+++ b/services/platformStatus.ts
@@ -2,6 +2,8 @@ import { API_BASE } from '@/utils/apiConfig';
 
 export interface PlatformStatusResponse {
   maintenance_mode: boolean;
+  app_version?: string | null;
+  backoffice_version?: string | null;
 }
 
 export const PLATFORM_STATUS_QUERY_KEY = ['platform-status'] as const;
@@ -25,10 +27,30 @@ function parsePlatformStatusPayload(data: unknown): PlatformStatusResponse | nul
   }
   const record = data as Record<string, unknown>;
   if ('maintenance_mode' in record) {
-    return { maintenance_mode: coerceMaintenanceBoolean(record.maintenance_mode) };
+    return {
+      maintenance_mode: coerceMaintenanceBoolean(record.maintenance_mode),
+      app_version:
+        typeof record.app_version === 'string' || record.app_version == null
+          ? (record.app_version as string | null | undefined)
+          : undefined,
+      backoffice_version:
+        typeof record.backoffice_version === 'string' || record.backoffice_version == null
+          ? (record.backoffice_version as string | null | undefined)
+          : undefined,
+    };
   }
   if ('maintenanceMode' in record) {
-    return { maintenance_mode: coerceMaintenanceBoolean(record.maintenanceMode) };
+    return {
+      maintenance_mode: coerceMaintenanceBoolean(record.maintenanceMode),
+      app_version:
+        typeof record.appVersion === 'string' || record.appVersion == null
+          ? (record.appVersion as string | null | undefined)
+          : undefined,
+      backoffice_version:
+        typeof record.backofficeVersion === 'string' || record.backofficeVersion == null
+          ? (record.backofficeVersion as string | null | undefined)
+          : undefined,
+    };
   }
   if ('data' in record) {
     return parsePlatformStatusPayload(record.data);


### PR DESCRIPTION
Replace the hardcoded profile footer version with app_version from platform status, with a native bundled version fallback so the UI stays aligned with configured releases.
