### PR TITLE
fix(realtime): avoid orphaned Supabase channels on fast unmount

### DIFF
--- a/hooks/useRealtimeConversationMessages.ts
+++ b/hooks/useRealtimeConversationMessages.ts
@@ -51,10 +51,12 @@ export function useRealtimeConversationMessages(
     const supabase = getSupabaseClient();
     if (!supabase) return;
 
+    let cancelled = false;
     const channelRef = { current: null as RealtimeChannel | null };
 
     const setup = async () => {
       const token = await getToken();
+      if (cancelled) return;
       setSupabaseAuth(token || '');
 
       const ch = supabase
@@ -75,12 +77,18 @@ export function useRealtimeConversationMessages(
           }
         )
         .subscribe();
+
+      if (cancelled) {
+        supabase.removeChannel(ch);
+        return;
+      }
       channelRef.current = ch;
     };
 
-    setup();
+    void setup();
 
     return () => {
+      cancelled = true;
       if (channelRef.current) {
         supabase.removeChannel(channelRef.current);
         channelRef.current = null;

--- a/hooks/useRealtimeOrderMessages.ts
+++ b/hooks/useRealtimeOrderMessages.ts
@@ -49,10 +49,12 @@ export function useRealtimeOrderMessages(
     const supabase = getSupabaseClient();
     if (!supabase) return;
 
+    let cancelled = false;
     const channelRef = { current: null as RealtimeChannel | null };
 
     const setup = async () => {
       const token = await getToken();
+      if (cancelled) return;
       setSupabaseAuth(token || '');
 
       const ch = supabase
@@ -73,12 +75,18 @@ export function useRealtimeOrderMessages(
           }
         )
         .subscribe();
+
+      if (cancelled) {
+        supabase.removeChannel(ch);
+        return;
+      }
       channelRef.current = ch;
     };
 
-    setup();
+    void setup();
 
     return () => {
+      cancelled = true;
       if (channelRef.current) {
         supabase.removeChannel(channelRef.current);
         channelRef.current = null;


### PR DESCRIPTION
Use a cancelled flag so async setup after getToken does not leave channels subscribed when the effect cleans up or conversationId /orderId changes. Applies to conversation and order message hooks.
