### PR TITLE
fix(MDB-366): normalize provider avatar fields across API shapes

### DIFF
--- a/services/favorites.ts
+++ b/services/favorites.ts
@@ -1,6 +1,6 @@
 import { request, ApiError as AuthApiError } from './auth';
 import { t } from '@/i18n';
-import { Supplier } from './suppliers';
+import { coerceSupplierProfileImage, Supplier } from './suppliers';
 
 export interface FavoriteSupplier extends Supplier {
   favorite_id: string;
@@ -36,7 +36,11 @@ export const fetchFavorites = async (): Promise<FavoritesResponse> => {
       },
       t('errors.requestFailed')
     );
-    return data;
+    const favorites = (data.favorites ?? []).map((f) => ({
+      ...f,
+      profile_image: coerceSupplierProfileImage(f as Record<string, unknown>),
+    }));
+    return { ...data, favorites };
   } catch (error) {
     if (error instanceof AuthApiError) {
       throw new ApiError(error.message, error.status, error.data);

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -1,4 +1,5 @@
 import { t } from '@/i18n';
+import { coerceSupplierProfileImage } from '@/services/suppliers';
 import { ApiError as AuthApiError, request } from './auth';
 
 export type OrderStatus = 'pending_for_provider' | 'pending_for_client' | 'pending_payment' | 'accepted' | 'in_progress' | 'pending_review' | 'completed' | 'cancelled';
@@ -178,13 +179,17 @@ export const fetchOrders = async (): Promise<Order[]> => {
 // GET /orders/:id - Fetch order details
 export const fetchOrderDetail = async (orderId: string): Promise<OrderDetailResponse> => {
   try {
-    return await request<OrderDetailResponse>(
+    const res = await request<OrderDetailResponse>(
       `/orders/${orderId}`,
       {
         method: 'GET',
       },
       t('errors.requestFailed')
     );
+    if (!res.supplier) return res;
+    const profile_image =
+      coerceSupplierProfileImage(res.supplier as Record<string, unknown>) ?? res.supplier.profile_image;
+    return { ...res, supplier: { ...res.supplier, profile_image } };
   } catch (error) {
     if (error instanceof AuthApiError) {
       throw new ApiError(error.message, error.status, error.data);

--- a/services/suppliers.ts
+++ b/services/suppliers.ts
@@ -2,6 +2,19 @@ import { API_BASE } from '@/utils/apiConfig';
 import { getToken } from '@/utils/userStorage';
 import { createApiHeaders } from '@/utils/apiHeaders';
 
+/**
+ * Picks the first non-empty image URL from shapes the API may use after migrations
+ * (provider profile uses avatar_url; list/detail endpoints may use profile_image*).
+ */
+export function coerceSupplierProfileImage(raw: Record<string, unknown>): string | undefined {
+  const keys = ['profile_image_url', 'profile_image', 'profileImage', 'avatar_url', 'avatarUrl'] as const;
+  for (const key of keys) {
+    const v = raw[key];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
 export interface Supplier {
   id: string;
   full_name: string;
@@ -154,11 +167,11 @@ export const fetchSuppliers = async (
     }
 
     // Ensure suppliers is always an array and normalize profile_image (API may send snake_case;
-    // accept profile_image_url from API when present so images stay in sync with provider avatars)
+    // accept profile_image_url / avatar_url when present so images stay in sync with provider avatars)
     const rawSuppliers = Array.isArray(jsonData.suppliers) ? jsonData.suppliers : [];
     const suppliers = rawSuppliers.map((s: Record<string, unknown>) => ({
       ...s,
-      profile_image: (s.profile_image_url as string) ?? (s.profile_image as string) ?? (s.profileImage as string) ?? undefined,
+      profile_image: coerceSupplierProfileImage(s),
     }));
     
     // Ensure total is always a number
@@ -206,11 +219,7 @@ export const fetchSupplierProfile = async (
 
     const data: SupplierProfileResponse = await response.json();
     const raw = data.supplier as Record<string, unknown>;
-    // API may return profile_image_url (resolved) and/or profile_image (raw); ensure profile_image is set for UI
-    const profileImage =
-      (raw.profile_image_url as string | undefined) ??
-      (raw.profile_image as string | undefined) ??
-      (raw.profileImage as string | undefined);
+    const profileImage = coerceSupplierProfileImage(raw);
     return { ...raw, profile_image: profileImage } as Supplier;
   } catch (error) {
     if (error instanceof ApiError) {


### PR DESCRIPTION
Add coerceSupplierProfileImage to map profile_image_url, profile_image, profileImage, avatar_url, and avatarUrl. Use it for supplier list/detail, favorites, and order detail so provider photos load after API migrations.

