### PR TITLE
fix(provider): prevent duplicate accept/reject and false error alerts…

### DIFF
--- a/app/(provider-tabs)/index.tsx
+++ b/app/(provider-tabs)/index.tsx
@@ -116,6 +116,8 @@ export default function ProviderDashboardScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [actionLoadingId, setActionLoadingId] = useState<string | null>(null);
+  /** Prevents double taps from firing two accepts/rejects before React re-renders disabled state. */
+  const orderActionInFlightRef = useRef<Set<string>>(new Set());
   const [headerAvatarFailed, setHeaderAvatarFailed] = useState(false);
 
   const { data: providerProfile } = useQuery({
@@ -177,27 +179,42 @@ export default function ProviderDashboardScreen() {
   }, [loadAll]);
 
   const handleAccept = useCallback(async (id: string) => {
+    if (orderActionInFlightRef.current.has(id)) return;
+    orderActionInFlightRef.current.add(id);
     setActionLoadingId(id);
     try {
       await acceptOrder(id);
       setRequests((prev) => prev.filter((r) => r.id !== id));
     } catch (e) {
+      // Second in-flight request after a successful accept often returns 409; treat like success.
+      if (e instanceof ApiError && e.status === 409) {
+        setRequests((prev) => prev.filter((r) => r.id !== id));
+        return;
+      }
       const message = e instanceof ApiError ? e.message : t("providerDashboard.errors.acceptFailed");
       Alert.alert(t("common.error"), message);
     } finally {
+      orderActionInFlightRef.current.delete(id);
       setActionLoadingId(null);
     }
   }, []);
 
   const handleReject = useCallback(async (id: string) => {
+    if (orderActionInFlightRef.current.has(id)) return;
+    orderActionInFlightRef.current.add(id);
     setActionLoadingId(id);
     try {
       await rejectOrder(id);
       setRequests((prev) => prev.filter((r) => r.id !== id));
     } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        setRequests((prev) => prev.filter((r) => r.id !== id));
+        return;
+      }
       const message = e instanceof ApiError ? e.message : t("providerDashboard.errors.rejectFailed");
       Alert.alert(t("common.error"), message);
     } finally {
+      orderActionInFlightRef.current.delete(id);
       setActionLoadingId(null);
     }
   }, []);
@@ -283,7 +300,9 @@ export default function ProviderDashboardScreen() {
               <View style={[styles.card, cardStyle]}>
                 <Text style={[styles.emptyText, { color: colors.textSecondary }]}>{t("providerDashboard.emptyRequests")}</Text>
               </View>
-            : requests.slice(0, 3).map((req) => (
+            : requests.slice(0, 3).map((req) => {
+                const canAcceptOrReject = !req.status || req.status === "pending_for_provider";
+                return (
                 <View key={req.id} style={[styles.requestCard, cardStyle]}>
                   <View style={styles.requestRow}>
                     <View style={styles.requestLeft}>
@@ -296,6 +315,7 @@ export default function ProviderDashboardScreen() {
                       <Text style={[styles.requestTime, { color: colors.textTertiary }]}>{req.scheduledAt ? formatScheduleTime(req.scheduledAt) : "—"}</Text>
                     </View>
                   </View>
+                  {canAcceptOrReject && (
                   <View style={styles.requestActions}>
                     <TouchableOpacity style={styles.rejectBtn} onPress={() => handleReject(req.id)} disabled={actionLoadingId === req.id}>
                       {actionLoadingId === req.id ?
@@ -308,8 +328,10 @@ export default function ProviderDashboardScreen() {
                       : <Text style={styles.acceptBtnText}>{t("providerDashboard.accept")}</Text>}
                     </TouchableOpacity>
                   </View>
+                  )}
                 </View>
-              ))
+              );
+              })
             }
 
             {/* Today's schedule */}

--- a/app/(provider-tabs)/requests.tsx
+++ b/app/(provider-tabs)/requests.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
+import { ApiError } from "@/services/auth";
 import {
     acceptOrder,
     getDashboardRequestCounts,
@@ -14,7 +15,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { PlatformFlashList } from "@/components/PlatformFlashList";
 import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     ActivityIndicator,
     Alert,
@@ -144,6 +145,8 @@ export default function ProviderRequestsScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
   const [declineModalId, setDeclineModalId] = useState<string | null>(null);
+  /** Blocks duplicate accept/reject before React applies disabled state (double tap). */
+  const orderActionInFlightRef = useRef<Set<string>>(new Set());
 
   const loadRequests = useCallback(async () => {
     if (!isAuthenticated) {
@@ -207,6 +210,8 @@ export default function ProviderRequestsScreen() {
   }, [loadRequests, loadCounts]);
 
   const handleAccept = useCallback(async (id: string) => {
+    if (orderActionInFlightRef.current.has(id)) return;
+    orderActionInFlightRef.current.add(id);
     setActionId(id);
     try {
       await acceptOrder(id);
@@ -214,8 +219,15 @@ export default function ProviderRequestsScreen() {
       await loadCounts();
     } catch (e) {
       console.error("[ProviderRequests] accept error:", e);
-      Alert.alert(t("common.error"), t("providerDashboard.errors.acceptFailed"));
+      if (e instanceof ApiError && e.status === 409) {
+        setRequests((prev) => prev.filter((r) => r.id !== id));
+        await loadCounts();
+        return;
+      }
+      const message = e instanceof ApiError ? e.message : t("providerDashboard.errors.acceptFailed");
+      Alert.alert(t("common.error"), message);
     } finally {
+      orderActionInFlightRef.current.delete(id);
       setActionId(null);
     }
   }, [loadCounts]);
@@ -228,6 +240,8 @@ export default function ProviderRequestsScreen() {
     const id = declineModalId;
     setDeclineModalId(null);
     if (!id) return;
+    if (orderActionInFlightRef.current.has(id)) return;
+    orderActionInFlightRef.current.add(id);
     setActionId(id);
     try {
       await rejectOrder(id);
@@ -235,8 +249,15 @@ export default function ProviderRequestsScreen() {
       await loadCounts();
     } catch (e) {
       console.error("[ProviderRequests] reject error:", e);
-      Alert.alert(t("common.error"), t("providerDashboard.errors.rejectFailed"));
+      if (e instanceof ApiError && e.status === 409) {
+        setRequests((prev) => prev.filter((r) => r.id !== id));
+        await loadCounts();
+        return;
+      }
+      const message = e instanceof ApiError ? e.message : t("providerDashboard.errors.rejectFailed");
+      Alert.alert(t("common.error"), message);
     } finally {
+      orderActionInFlightRef.current.delete(id);
       setActionId(null);
     }
   }, [declineModalId, loadCounts]);


### PR DESCRIPTION
… (MDB-367)

- Use a ref Set to block concurrent order actions before React re-renders disabled state.
- Treat HTTP 409 on accept/reject as idempotent success.
- Show accept/reject on provider home only when status is pending_for_provider.
- Surface API error messages on the requests screen.

