### PR TITLE
fix(MDB-370): provider UI after client pays quote

### DIFF
--- a/app/(provider-tabs)/messages.tsx
+++ b/app/(provider-tabs)/messages.tsx
@@ -31,6 +31,7 @@ const STATUS_COLORS: Record<string, string> = {
   completed: '#6B7280',
   inquiry: '#F59E0B',
   quote: '#EC4899',
+  paid_confirm: '#22C55E',
 };
 
 type FilterType = 'all' | 'unread' | 'active' | 'archived';
@@ -39,6 +40,9 @@ type FilterType = 'all' | 'unread' | 'active' | 'archived';
 function getConversationStatus(conversation: Conversation): string | null {
   const status = conversation.active_order_status;
   if (!status) return null;
+  if (status === 'pending_for_provider' && conversation.active_order_has_client_payment) {
+    return 'paid_confirm';
+  }
   switch (status) {
     case 'in_progress':
     case 'pending_review':
@@ -379,6 +383,8 @@ function getStatusLabel(statusKey: string): string {
       return t('providerDashboard.inbox.statusInquiry');
     case 'quote':
       return t('providerDashboard.inbox.statusQuote');
+    case 'paid_confirm':
+      return t('providerDashboard.inbox.statusPaidConfirm');
     default:
       return t('providerDashboard.inbox.statusInquiry');
   }

--- a/app/booking/quote/[orderId].tsx
+++ b/app/booking/quote/[orderId].tsx
@@ -4,7 +4,7 @@ import { useThemeColors } from '@/hooks/useThemeColors';
 import { t } from '@/i18n';
 import { fetchConversation, fetchConversations } from '@/services/conversations';
 import { ApiError, fetchOrderDetail, OrderDetailResponse, rejectQuote, withdrawQuote } from '@/services/orders';
-import { cancelOrderByProvider } from '@/services/providerDashboard';
+import { acceptOrder, cancelOrderByProvider } from '@/services/providerDashboard';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -367,6 +367,7 @@ export default function QuoteScreen() {
   const [showWithdrawConfirm, setShowWithdrawConfirm] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [confirmingBooking, setConfirmingBooking] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const quote = useMemo(
@@ -595,6 +596,26 @@ export default function QuoteScreen() {
     setShowCancelConfirm(true);
   }, []);
 
+  const handleConfirmPaidBooking = useCallback(async () => {
+    if (!orderId) return;
+    try {
+      setConfirmingBooking(true);
+      await acceptOrder(orderId);
+      await loadData();
+      router.replace(`/(provider-tabs)/jobs/${orderId}`);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        await loadData();
+        router.replace(`/(provider-tabs)/jobs/${orderId}`);
+        return;
+      }
+      const message = err instanceof ApiError ? err.message : t('quote.acceptBookingFailed');
+      Alert.alert(t('common.error'), message);
+    } finally {
+      setConfirmingBooking(false);
+    }
+  }, [orderId, loadData, router]);
+
   const handleEditQuote = () => {
     router.push({
       pathname: '/chat/create-quote',
@@ -679,6 +700,9 @@ export default function QuoteScreen() {
   const order = orderData.order;
   const isSupplier = user?.id === order.supplier_id;
   const isClient = !isSupplier;
+  const hasClientPaid =
+    orderData.has_completed_client_payment === true ||
+    (order.status === 'pending_for_provider' && quote.status === 'approved');
   const theme = isClient ? clientStyles : isSupplier ? providerStyles : null;
   const { supplier, client } = orderData;
   const serviceDate = quote.scheduled_at || order.scheduled_at;
@@ -848,6 +872,11 @@ export default function QuoteScreen() {
 
         {/* Service Info */}
         <View style={[styles.section, theme?.section]}>
+          {isSupplier && hasClientPaid && order.status === 'pending_for_provider' ? (
+            <Text style={[styles.description, theme?.description, { marginBottom: 12 }]}>
+              {t('quote.confirmBookingAfterPaymentHint')}
+            </Text>
+          ) : null}
           <View style={[styles.serviceHeader, theme?.serviceHeader]}>
             <Ionicons name="brush-outline" size={24} color={serviceIconColor} />
             <Text style={[styles.serviceTitle, theme?.serviceTitle]}>{order.service_name || t('orders.service')}</Text>
@@ -889,6 +918,21 @@ export default function QuoteScreen() {
 
       {/* Actions */}
       <View style={[styles.actions, theme?.actions, { paddingBottom: 20 + insets.bottom }]}>
+        {isSupplier && hasClientPaid && order.status === 'pending_for_provider' && (
+          <TouchableOpacity
+            style={[styles.approveButton, theme?.approveButton]}
+            onPress={handleConfirmPaidBooking}
+            disabled={confirmingBooking}
+          >
+            {confirmingBooking ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : (
+              <Text style={[styles.approveButtonText, theme?.approveButtonText]}>
+                {t('quote.confirmBookingAfterPayment')}
+              </Text>
+            )}
+          </TouchableOpacity>
+        )}
         {isClient && order.status === 'pending_for_client' && (
           <>
             <TouchableOpacity
@@ -922,7 +966,8 @@ export default function QuoteScreen() {
             <Text style={[styles.approveButtonText, theme?.approveButtonText]}>{t('orders.completePayment')}</Text>
           </TouchableOpacity>
         )}
-        {isSupplier && (order.status === 'pending_for_client' || order.status === 'pending_for_provider') && (
+        {isSupplier &&
+          (order.status === 'pending_for_client' || (order.status === 'pending_for_provider' && !hasClientPaid)) && (
           <>
             {order.status === 'pending_for_client' && (
               <TouchableOpacity

--- a/app/chat/[conversationId].tsx
+++ b/app/chat/[conversationId].tsx
@@ -703,9 +703,9 @@ export default function ChatScreen() {
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await Promise.all([loadMessages(false), refreshActiveQuote()]);
+    await Promise.all([loadMessages(false), refreshActiveQuote(), refreshActiveOrder()]);
     setRefreshing(false);
-  }, [loadMessages, refreshActiveQuote]);
+  }, [loadMessages, refreshActiveQuote, refreshActiveOrder]);
 
   const handleCall = () => {
     const phone = conversation?.supplier_phone_number;
@@ -803,7 +803,12 @@ export default function ChatScreen() {
   const handleViewOrder = () => {
     if (!activeOrder) return;
     if (isProvider) {
-      router.push(`/(provider-tabs)/jobs/${activeOrder.id}`);
+      const preAccepted: OrderStatus[] = ["pending_for_provider", "pending_for_client", "pending_payment"];
+      if (preAccepted.includes(activeOrder.status)) {
+        router.push(`/booking/quote/${activeOrder.id}`);
+      } else {
+        router.push(`/(provider-tabs)/jobs/${activeOrder.id}`);
+      }
     } else {
       router.push(`/orders/${activeOrder.id}`);
     }
@@ -875,15 +880,18 @@ export default function ChatScreen() {
 
   const displayMessages = messages;
 
-  const jobStatusLabel =
-    activeOrder ?
-      activeOrder.status === "in_progress" ? t("chat.jobBannerInProgress")
-      : activeOrder.status === "accepted" ? t("chat.jobBannerScheduled")
-      : activeOrder.status === "pending_payment" ? t("chat.jobBannerPendingPayment")
-      : activeOrder.status === "pending_review" ? t("chat.jobBannerPendingReview")
-      : activeOrder.status === "pending_for_provider" ? t("chat.jobBannerPending")
-      : ""
-    : "";
+  const jobStatusLabel = (() => {
+    if (!activeOrder) return "";
+    if (activeOrder.status === "in_progress") return t("chat.jobBannerInProgress");
+    if (activeOrder.status === "accepted") return t("chat.jobBannerScheduled");
+    if (activeOrder.status === "pending_payment") return t("chat.jobBannerPendingPayment");
+    if (activeOrder.status === "pending_review") return t("chat.jobBannerPendingReview");
+    if (activeOrder.status === "pending_for_provider") {
+      if (activeQuote?.status === "approved") return t("chat.jobBannerPaidConfirm");
+      return t("chat.jobBannerPending");
+    }
+    return "";
+  })();
 
   const renderClientMessage = ({ item, index }: { item: Message; index: number }, list: Message[]) => {
     const isMine = isMyMessage(item);

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -473,6 +473,7 @@ export default {
     jobBannerPending: "Pending",
     jobBannerPendingPayment: "Pending Payment",
     jobBannerPendingReview: "Pending Review",
+    jobBannerPaidConfirm: "Paid — confirm",
     appointmentScheduled: "Appointment scheduled for today {{time}}",
     sharedLocation: "Shared location",
     openExample: "Open chat example",
@@ -523,6 +524,10 @@ export default {
     durationHours_other: "{{count}} hrs",
     durationDays: "{{count}} day",
     durationDays_other: "{{count}} days",
+    confirmBookingAfterPayment: "Confirm booking",
+    confirmBookingAfterPaymentHint:
+      "The client has paid. Confirm this booking to add it to your schedule.",
+    acceptBookingFailed: "Could not confirm the booking. Please try again.",
   },
   createQuote: {
     title: "New Quote",
@@ -1800,6 +1805,7 @@ export default {
       statusCompleted: "Completed",
       statusInquiry: "Inquiry",
       statusQuote: "Quote",
+      statusPaidConfirm: "Paid — confirm",
       now: "Now",
       failedToLoad: "Failed to load conversations",
       retry: "Retry",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -474,6 +474,7 @@ export default {
     jobBannerPending: "Pendiente",
     jobBannerPendingPayment: "Pendiente de pago",
     jobBannerPendingReview: "Pendiente de reseña",
+    jobBannerPaidConfirm: "Pagado — confirmar",
     appointmentScheduled: "Cita agendada para hoy {{time}}",
     sharedLocation: "Ubicación compartida",
     openExample: "Ver ejemplo de chat",
@@ -524,6 +525,10 @@ export default {
     durationHours_other: "{{count}} hrs",
     durationDays: "{{count}} día",
     durationDays_other: "{{count}} días",
+    confirmBookingAfterPayment: "Confirmar reserva",
+    confirmBookingAfterPaymentHint:
+      "El cliente ya pagó. Confirma la reserva para agendarla en tu calendario.",
+    acceptBookingFailed: "No se pudo confirmar la reserva. Intenta de nuevo.",
   },
   createQuote: {
     title: "Nueva Cotización",
@@ -1802,6 +1807,7 @@ export default {
       statusCompleted: "Completado",
       statusInquiry: "Consulta",
       statusQuote: "Cotización",
+      statusPaidConfirm: "Pagado — confirmar",
       now: "Ahora",
       failedToLoad: "Error al cargar conversaciones",
       retry: "Reintentar",

--- a/services/conversations.ts
+++ b/services/conversations.ts
@@ -9,6 +9,8 @@ export interface Conversation {
   order_id: string | null;
   /** Real active order status for this client-supplier pair; null when no active order. */
   active_order_status: OrderStatus | null;
+  /** True when the current active order has a completed client payment (same order as active_order_status). */
+  active_order_has_client_payment?: boolean;
   last_message_at: string | null;
   created_at: string;
   other_user_name: string;
@@ -70,6 +72,9 @@ export const fetchConversations = async (role?: ConversationRole): Promise<Conve
       other_user_image: conv.other_user_image || null,
       unread_count: typeof conv.unread_count === 'number' ? conv.unread_count : 0,
       active_order_status: conv.active_order_status ?? null,
+      active_order_has_client_payment: Boolean(
+        (conv as { active_order_has_client_payment?: boolean }).active_order_has_client_payment,
+      ),
     }));
   } catch (error) {
     if (error instanceof ApiError) throw error;

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -105,6 +105,8 @@ export interface OrderDetailResponse {
   conversation_id?: string | null;
   /** When true, client already submitted a review for this order (rate screen shows "already reviewed" state) */
   client_has_reviewed?: boolean;
+  /** True when at least one non-refunded completed payment exists for this order (post–quote payment). */
+  has_completed_client_payment?: boolean;
 }
 
 // Re-export ApiError from auth service for backward compatibility


### PR DESCRIPTION
Route Ver orden to quote screen for pre-accepted orders; show confirm booking and paid-state labels; refresh active order on pull-to-refresh; inbox badge when client payment completed; i18n en/es.

