### PR TITLE
MDB-375: Re-render UI on locale change, translate categories and clie…

### DIFF
--- a/app/(provider-tabs)/profile/language.tsx
+++ b/app/(provider-tabs)/profile/language.tsx
@@ -43,7 +43,11 @@ export default function ProviderLanguageScreen() {
     try {
       setLoading(true);
       const response = await getSettings();
-      setCurrentLanguage(response.settings.language);
+      const lang = response.settings.language;
+      setCurrentLanguage(lang);
+      if (lang === 'es' || lang === 'en') {
+        setLocale(lang);
+      }
     } catch {
       // Fallback to local locale
     } finally {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -8,6 +8,7 @@ import { HapticTab } from '@/components/haptic-tab';
 import { useAuth } from '@/contexts/AuthContext';
 import { useMode } from '@/contexts/ModeContext';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { t } from '@/i18n';
 import { fetchUnreadCount } from '@/services/conversations';
 import { fetchUnreadNotificationCount } from '@/services/notifications';
 
@@ -141,7 +142,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="home"
         options={{
-          title: 'Home',
+          title: t('clientTabs.home'),
           tabBarIcon: ({ color, focused }) => (
             <Ionicons name={focused ? 'home' : 'home-outline'} size={20} color={color} />
           ),
@@ -150,7 +151,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="bookings"
         options={{
-          title: 'Reservas', // From JSX: 'Reservas'
+          title: t('clientTabs.bookings'),
           tabBarIcon: ({ color, focused }) => (
             <Ionicons name={focused ? 'calendar' : 'calendar-outline'} size={20} color={color} />
           ),
@@ -159,14 +160,14 @@ export default function TabLayout() {
       <Tabs.Screen
         name="chat"
         options={{
-          title: 'Chat',
+          title: t('clientTabs.chat'),
           tabBarIcon: ({ color, focused }) => <ChatTabIcon color={color} focused={focused} />,
         }}
       />
       <Tabs.Screen
         name="notifications"
         options={{
-          title: 'Alertas', // From JSX: 'Alertas'
+          title: t('clientTabs.notifications'),
           tabBarIcon: ({ color, focused }) => (
             <NotificationsTabIcon color={color} focused={focused} />
           ),
@@ -175,7 +176,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="profile"
         options={{
-          title: 'Perfil', // From JSX: 'Perfil'
+          title: t('clientTabs.profile'),
           tabBarIcon: ({ color, focused }) => (
             <Ionicons name={focused ? 'person' : 'person-outline'} size={20} color={color} />
           ),

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -9,7 +9,7 @@ import { Category, fetchCategories } from "@/services/categories";
 import { fetchPromotions, type Promotion } from "@/services/promotions";
 import { Supplier, fetchSuppliers } from "@/services/suppliers";
 import { useFavoritesStore } from "@/stores/favoritesStore";
-import { getCategoryColor, getCategoryDisplayName, getCategoryEmoji } from "@/utils/categoryDisplay";
+import { getCategoryColor, getCategoryDisplayName, getCategoryEmoji, getTranslatedServiceCategory } from "@/utils/categoryDisplay";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect, useRouter } from "expo-router";
@@ -354,7 +354,7 @@ export default function HomeScreen() {
                   id={item.id}
                   name={item.business_name?.trim() || item.full_name}
                   profileImage={item.profile_image}
-                  serviceCategory={item.service_category}
+                  serviceCategory={getTranslatedServiceCategory(item.service_category, t)}
                   rating={item.rating}
                   reviewCount={item.total_reviews}
                   hourlyRate={item.hourly_rate}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,7 +14,8 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { ApiError } from "@/services/auth";
 import { fetchPlatformStatus, PLATFORM_STATUS_QUERY_KEY } from "@/services/platformStatus";
 import { queryClient } from "@/services/queryClient";
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
+import { getLocaleSnapshot, subscribeLocale } from "@/i18n";
 
 
 export const unstable_settings = {
@@ -24,6 +25,8 @@ export const unstable_settings = {
 function RootLayoutNav() {
   const { isLoading } = useAuth();
   const colorScheme = useColorScheme();
+  // Re-render the tree when the user changes language so all `t()` strings update.
+  useSyncExternalStore(subscribeLocale, getLocaleSnapshot, getLocaleSnapshot);
 
   const {
     data: platformStatus,

--- a/app/account/favorites.tsx
+++ b/app/account/favorites.tsx
@@ -10,6 +10,7 @@ import {
 import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
+import { getTranslatedServiceCategory } from '@/utils/categoryDisplay';
 import { useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
@@ -134,8 +135,8 @@ export default function FavoritesScreen() {
   };
 
   const getServiceName = (supplier: FavoriteSupplier): string => {
-    // Try to get service category name, fallback to service_category field
-    return supplier.service_category || t('favorites.service');
+    const translated = getTranslatedServiceCategory(supplier.service_category, t);
+    return translated || t('favorites.service');
   };
 
   const formatRating = (rating: number | string | null | undefined): string => {

--- a/app/account/language.tsx
+++ b/app/account/language.tsx
@@ -43,7 +43,11 @@ export default function ClientLanguageScreen() {
     try {
       setLoading(true);
       const response = await getSettings();
-      setCurrentLanguage(response.settings.language);
+      const lang = response.settings.language;
+      setCurrentLanguage(lang);
+      if (lang === 'es' || lang === 'en') {
+        setLocale(lang);
+      }
     } catch {
       // Fallback to local locale
     } finally {

--- a/app/booking/date-time.tsx
+++ b/app/booking/date-time.tsx
@@ -24,6 +24,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { t } from '@/i18n';
+import { getSupplierServiceDisplayName } from '@/utils/categoryDisplay';
 
 // Get service duration in hours from service description or category
 const getServiceDurationHours = (service: SupplierService | null): number => {
@@ -290,7 +291,7 @@ export default function BookingDateTimeScreen() {
   const providerCardInfo: BookingDateTimePickerProviderCard | undefined = supplier && service
     ? {
         name: supplier.business_name?.trim() || supplier.full_name,
-        serviceInfo: `${service.name?.trim() || service.category_name || 'Service'} • $${service.price ?? 0}`,
+        serviceInfo: `${getSupplierServiceDisplayName(service, t)} • $${service.price ?? 0}`,
         profileImage: supplier.profile_image,
       }
     : undefined;

--- a/app/booking/summary.tsx
+++ b/app/booking/summary.tsx
@@ -4,6 +4,7 @@ import { getLocale, t } from "@/i18n";
 import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { Address, getAddresses } from "@/services/addresses";
 import { ApiError, fetchSupplierProfile, fetchSupplierServices, Supplier, SupplierService } from "@/services/suppliers";
+import { getSupplierServiceDisplayName } from "@/utils/categoryDisplay";
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import React, { useEffect, useMemo, useState } from "react";
@@ -465,7 +466,7 @@ export default function BookingSummaryScreen() {
             {/* Service */}
             <View style={styles.detailRow}>
               <Text style={styles.detailLabel}>{t("booking.service")}</Text>
-              <Text style={styles.detailValue}>{service.name?.trim() || service.category_name || service.description || "Service"}</Text>
+              <Text style={styles.detailValue}>{getSupplierServiceDisplayName(service, t)}</Text>
             </View>
 
             {/* Date */}
@@ -514,7 +515,7 @@ export default function BookingSummaryScreen() {
             {/* Service cost (fixed price) */}
             <View style={styles.priceRow}>
               <Text style={styles.priceLabel}>
-                {service.name?.trim() || service.category_name || "Service"}
+                {getSupplierServiceDisplayName(service, t)}
               </Text>
               <Text style={styles.priceValue}>${pricing.serviceCost.toFixed(2)}</Text>
             </View>

--- a/app/services/suppliers/[supplierId].tsx
+++ b/app/services/suppliers/[supplierId].tsx
@@ -29,6 +29,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { t } from '@/i18n';
+import { getSupplierServiceDisplayName, getTranslatedServiceCategory } from '@/utils/categoryDisplay';
 
 /** Brand accents (same in light/dark); surfaces and text come from `getThemeColors`. */
 const BRAND = {
@@ -566,7 +567,9 @@ export default function ProviderDetailScreen() {
                 )}
               </View>
               {supplier.service_category && (
-                <Text style={styles.profession}>{supplier.service_category}</Text>
+                <Text style={styles.profession}>
+                  {getTranslatedServiceCategory(supplier.service_category, t)}
+                </Text>
               )}
               {supplier.location && (
                 <View style={styles.locationRow}>
@@ -634,7 +637,7 @@ export default function ProviderDetailScreen() {
                   >
                     <View style={styles.serviceInfo}>
                       <Text style={styles.serviceName}>
-                        {service.name?.trim() || service.category_name || 'Service'}
+                        {getSupplierServiceDisplayName(service, t)}
                       </Text>
                       <View style={styles.serviceDurationRow}>
                         <Ionicons name="time-outline" size={14} color={theme.textSecondary} />

--- a/components/ProviderCard.tsx
+++ b/components/ProviderCard.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { useFavorite } from '@/hooks/useFavorite';
 import { t } from '@/i18n';
 import { Supplier } from '@/services/suppliers';
+import { getTranslatedServiceCategory } from '@/utils/categoryDisplay';
 import { getThemeColors, type ThemeColors } from '@/utils/themeStyles';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useMemo } from 'react';
@@ -195,7 +196,9 @@ export function ProviderCard({ supplier, onPress, onBookPress }: ProviderCardPro
 
           {supplier.service_category && (
             <View style={styles.serviceContainer}>
-              <Text style={styles.service} numberOfLines={1}>{supplier.service_category}</Text>
+              <Text style={styles.service} numberOfLines={1}>
+                {getTranslatedServiceCategory(supplier.service_category, t)}
+              </Text>
             </View>
           )}
 

--- a/contexts/ModeContext.tsx
+++ b/contexts/ModeContext.tsx
@@ -1,3 +1,4 @@
+import { setLocale } from '@/i18n';
 import { getSettings, updateSettings } from '@/services/settings';
 import { checkProviderStatus } from '@/services/providers';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -67,6 +68,10 @@ export const ModeProvider: React.FC<ModeProviderProps> = ({ children, isAuthenti
     try {
       setIsLoading(true);
       const response = await getSettings();
+      const lang = response.settings.language;
+      if (lang === 'es' || lang === 'en') {
+        setLocale(lang);
+      }
       const userMode = response.settings.user_mode;
       if (userMode === 'client' || userMode === 'provider') {
         setModeState(userMode);

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -2,17 +2,29 @@ import { I18n } from 'i18n-js';
 import * as Localization from 'expo-localization';
 import en from './locales/en';
 import es from './locales/es';
-import { useEffect } from 'react';
+
+const i18n = new I18n({ en, es });
+
+/** Subscribers notified when `setLocale` runs so React can re-render translated UI. */
+const localeListeners = new Set<() => void>();
+
+function notifyLocaleListeners() {
+  localeListeners.forEach((listener) => listener());
+}
 
 /**
- * Set the locale to the default locale
+ * Subscribe to app locale changes (for `useSyncExternalStore` in root layout).
  */
-/*
-useEffect(() => {
-    setLocale('en'); // o 'es'
-  }, []);
-*/
-const i18n = new I18n({ en, es });
+export function subscribeLocale(listener: () => void) {
+  localeListeners.add(listener);
+  return () => {
+    localeListeners.delete(listener);
+  };
+}
+
+export function getLocaleSnapshot(): string {
+  return i18n.locale;
+}
 
 // Determine best language from device settings
 const locales = Localization.getLocales();
@@ -30,7 +42,9 @@ export function t(key: string, options?: Record<string, any>) {
 }
 
 export function setLocale(locale: 'en' | 'es') {
+  if (i18n.locale === locale) return;
   i18n.locale = locale;
+  notifyLocaleListeners();
 }
 
 export function getLocale() {

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -231,6 +231,13 @@ export default {
     tagline2: "services made",
     tagline3: "easy",
   },
+  clientTabs: {
+    home: "Home",
+    bookings: "Bookings",
+    chat: "Chat",
+    notifications: "Alerts",
+    profile: "Profile",
+  },
   home: {
     location: "Santo Domingo",
     locationLabel: "📍 Your location",
@@ -434,6 +441,7 @@ export default {
     selectService: "Please select a service before booking",
     location: "Location",
     cannotChatWithSelf: "You cannot start a conversation with your own provider profile.",
+    defaultServiceLabel: "Service",
   },
   chat: {
     title: "Chat",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -232,6 +232,13 @@ export default {
     tagline2: "a domicilio",
     tagline3: "fáciles",
   },
+  clientTabs: {
+    home: "Inicio",
+    bookings: "Reservas",
+    chat: "Chat",
+    notifications: "Alertas",
+    profile: "Perfil",
+  },
   home: {
     location: "Santo Domingo",
     locationLabel: "📍 Tu ubicación",
@@ -435,6 +442,7 @@ export default {
     selectService: "Por favor selecciona un servicio antes de reservar",
     location: "Ubicación",
     cannotChatWithSelf: "No puedes iniciar una conversación con tu propio perfil de proveedor.",
+    defaultServiceLabel: "Servicio",
   },
   chat: {
     title: "Chat",

--- a/utils/categoryDisplay.ts
+++ b/utils/categoryDisplay.ts
@@ -1,4 +1,5 @@
 import type { Category } from "@/services/categories";
+import type { SupplierService } from "@/services/suppliers";
 
 const DEFAULT_COLOR = "#6B7280";
 const DEFAULT_EMOJI = "📋";
@@ -37,11 +38,112 @@ export function getCategoryColor(category: Category): string {
 
 type TranslateFn = (key: string) => string;
 
+function isMissingTranslation(translated: unknown, fullKey: string): boolean {
+  if (typeof translated !== "string") return true;
+  if (translated === fullKey) return true;
+  if (translated.includes("[missing")) return true;
+  if (translated.includes("translation]")) return true;
+  return false;
+}
+
+/** When the API sends a human label (often English) instead of name_key, map slug → catalog key. */
+const SERVICE_CATEGORY_SLUG_ALIASES: Record<string, string> = {
+  electrician: "electrical",
+  plumber: "plumbing",
+  plumbers: "plumbing",
+  cleaning_services: "cleaning",
+  house_cleaning: "cleaning",
+  home_cleaning: "cleaning",
+};
+
+function slugifyCatalogLabel(label: string): string {
+  return label
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[''`]/g, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+function expandSlugKeyCandidates(slug: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (s: string) => {
+    if (!s || seen.has(s)) return;
+    seen.add(s);
+    out.push(s);
+  };
+  let current = slug;
+  for (let i = 0; i < 16 && current; i++) {
+    push(current);
+    const withoutAnd = current.replace(/_and_/g, "_");
+    if (withoutAnd === current) break;
+    current = withoutAnd;
+  }
+  return out;
+}
+
+function tryTranslateCategoryItem(nameKey: string, t: TranslateFn): string | null {
+  const fullKey = `categories.items.${nameKey}`;
+  const translated = t(fullKey);
+  if (isMissingTranslation(translated, fullKey)) return null;
+  return translated;
+}
+
+/**
+ * Localizes a supplier's main category label when the API sends English display text or a catalog name_key.
+ * Falls back to the original string if no matching `categories.items.*` entry exists.
+ */
+export function getTranslatedServiceCategory(label: string | undefined | null, t: TranslateFn): string {
+  if (label == null || typeof label !== "string") return "";
+  const trimmed = label.trim();
+  if (!trimmed) return "";
+
+  if (/^[a-z][a-z0-9_]*$/.test(trimmed)) {
+    const direct = tryTranslateCategoryItem(trimmed, t);
+    if (direct) return direct;
+    const aliased = SERVICE_CATEGORY_SLUG_ALIASES[trimmed];
+    if (aliased) {
+      const viaAlias = tryTranslateCategoryItem(aliased, t);
+      if (viaAlias) return viaAlias;
+    }
+  }
+
+  let slug = slugifyCatalogLabel(trimmed);
+  slug = SERVICE_CATEGORY_SLUG_ALIASES[slug] ?? slug;
+
+  for (const candidate of expandSlugKeyCandidates(slug)) {
+    const resolved = tryTranslateCategoryItem(candidate, t);
+    if (resolved) return resolved;
+  }
+
+  return trimmed;
+}
+
+/** Row title for a catalog service: custom provider name wins; otherwise translated category, then description. */
+export function getSupplierServiceDisplayName(
+  service: Pick<SupplierService, "name" | "category_name" | "category_key" | "description">,
+  t: TranslateFn
+): string {
+  const custom = service.name?.trim();
+  if (custom) return custom;
+  const fromKey = getTranslatedServiceCategory(service.category_key, t);
+  if (fromKey) return fromKey;
+  const fromName = getTranslatedServiceCategory(service.category_name, t);
+  if (fromName) return fromName;
+  const desc = service.description?.trim();
+  if (desc) return desc;
+  return t("supplier.defaultServiceLabel");
+}
+
 export function getCategoryDisplayName(category: Category, t: TranslateFn): string {
   if (!category.name_key) return category.name;
   const key = `categories.items.${category.name_key}`;
   const translated = t(key);
-  if (typeof translated !== "string" || translated.includes("[missing") || translated.includes("translation]") || translated === key) {
+  if (isMissingTranslation(translated, key)) {
     return category.name;
   }
   return translated;


### PR DESCRIPTION
…nt tabs

- Subscribe React tree to setLocale via useSyncExternalStore in root layout
- Sync i18n from user settings on login (ModeContext) and language screens
- Localize supplier service_category via categories.items keys (categoryDisplay)
- Add clientTabs strings; replace hardcoded tab titles in client tabs layout
- Add supplier.defaultServiceLabel; use getSupplierServiceDisplayName in booking flows
