### PR TITLE
feat(MDB-381): i18n for notifications and robust type handling

### DIFF
--- a/app/(provider-tabs)/notifications.tsx
+++ b/app/(provider-tabs)/notifications.tsx
@@ -2,7 +2,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { type Notification, type NotificationCategory, deleteAllNotifications, deleteNotification, fetchNotifications, getNotificationCategory, markAllNotificationsAsRead, markNotificationAsRead } from "@/services/notifications";
-import { getLocalizedNotificationDisplay } from "@/utils/notificationDisplay";
+import { formatNotificationRelativeTime, getLocalizedNotificationDisplay } from "@/utils/notificationDisplay";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
@@ -43,21 +43,6 @@ function NotificationCard({ notification, onPress, onDelete }: NotificationCardP
   const iconName = CATEGORY_ICONS[category];
   const display = getLocalizedNotificationDisplay(notification, "provider");
 
-  const formatTime = useCallback((dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / (1000 * 60));
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-    if (diffMins < 1) return t("providerDashboard.providerNotifications.now");
-    if (diffMins < 60) return `${diffMins} min`;
-    if (diffHours < 24) return `${diffHours}h`;
-    if (diffDays === 1) return t("providerDashboard.providerNotifications.yesterday");
-    if (diffDays < 7) return date.toLocaleDateString(undefined, { weekday: "short" });
-    return date.toLocaleDateString();
-  }, []);
-
   return (
     <View style={styles.cardWrapper}>
       <TouchableOpacity
@@ -76,7 +61,9 @@ function NotificationCard({ notification, onPress, onDelete }: NotificationCardP
             <Text style={[styles.cardTitle, !notification.read && styles.cardTitleUnread, { color: colors.textPrimary }]} numberOfLines={1}>
               {display.title}
             </Text>
-            <Text style={[styles.cardTime, { color: colors.textTertiary }]}>{formatTime(notification.created_at)}</Text>
+            <Text style={[styles.cardTime, { color: colors.textTertiary }]}>
+              {formatNotificationRelativeTime(notification.created_at, "compact")}
+            </Text>
           </View>
           <Text style={[styles.cardMessage, { color: colors.textSecondary }]} numberOfLines={2}>
             {display.message}

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -1,5 +1,5 @@
 import { useThemeColors } from '@/hooks/useThemeColors';
-import { t, getLocale } from '@/i18n';
+import { getLocaleSnapshot, t } from '@/i18n';
 import {
   Notification,
   NotificationType,
@@ -7,7 +7,11 @@ import {
   markNotificationAsRead,
   markAllNotificationsAsRead,
 } from '@/services/notifications';
-import { getLocalizedNotificationDisplay } from '@/utils/notificationDisplay';
+import {
+  formatNotificationRelativeTime,
+  formatNotificationSectionDateLabel,
+  getLocalizedNotificationDisplay,
+} from '@/utils/notificationDisplay';
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
@@ -53,52 +57,16 @@ function NotificationItem({ notification, onPress, colors }: NotificationItemPro
       case 'quote_approved':
         return { icon: '✅', bgColor: '#10B981' };
       case 'payment_received':
+      case 'new_paid_booking':
         return { icon: '💰', bgColor: '#10B981' };
       case 'new_review':
+      case 'job_pending_review':
+      case 'job_completed':
         return { icon: '⭐', bgColor: '#F59E0B' };
       case 'refund_issued':
         return { icon: '↩️', bgColor: '#10B981' };
       default:
         return { icon: '🔔', bgColor: '#6B7280' };
-    }
-  };
-
-  const formatTime = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / (1000 * 60));
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    const locale = getLocale();
-
-    if (diffMins < 1) {
-      return locale === 'es' ? 'Hace menos de 1 min' : 'Less than 1 min ago';
-    } else if (diffMins < 60) {
-      return locale === 'es' ? `Hace ${diffMins} min` : `${diffMins} min ago`;
-    } else if (diffHours < 24) {
-      return locale === 'es' ? `Hace ${diffHours} hora${diffHours > 1 ? 's' : ''}` : `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
-    } else if (diffDays === 1) {
-      const hours = date.getHours();
-      const minutes = date.getMinutes();
-      const ampm = hours >= 12 ? 'PM' : 'AM';
-      const displayHours = hours % 12 || 12;
-      const displayMinutes = minutes.toString().padStart(2, '0');
-      return locale === 'es' 
-        ? `Ayer, ${displayHours}:${displayMinutes} ${ampm}`
-        : `Yesterday, ${displayHours}:${displayMinutes} ${ampm}`;
-    } else {
-      const hours = date.getHours();
-      const minutes = date.getMinutes();
-      const ampm = hours >= 12 ? 'PM' : 'AM';
-      const displayHours = hours % 12 || 12;
-      const displayMinutes = minutes.toString().padStart(2, '0');
-      const day = date.getDate();
-      const month = date.getMonth() + 1;
-      return locale === 'es'
-        ? `${day}/${month}, ${displayHours}:${displayMinutes} ${ampm}`
-        : `${month}/${day}, ${displayHours}:${displayMinutes} ${ampm}`;
     }
   };
 
@@ -130,7 +98,7 @@ function NotificationItem({ notification, onPress, colors }: NotificationItemPro
           {display.message}
         </Text>
         <Text style={[styles.notificationTime, { color: colors.textTertiary }]}>
-          {formatTime(notification.created_at)}
+          {formatNotificationRelativeTime(notification.created_at, 'full')}
         </Text>
       </View>
       {!notification.read && (
@@ -240,16 +208,15 @@ export default function NotificationsScreen() {
       }
     });
 
-    const locale = getLocale();
     if (todayNotifications.length > 0) {
       groups.push({
-        label: locale === 'es' ? 'HOY' : 'TODAY',
+        label: t('notifications.today'),
         notifications: todayNotifications,
       });
     }
     if (yesterdayNotifications.length > 0) {
       groups.push({
-        label: locale === 'es' ? 'AYER' : 'YESTERDAY',
+        label: t('notifications.yesterday'),
         notifications: yesterdayNotifications,
       });
     }
@@ -265,19 +232,15 @@ export default function NotificationsScreen() {
         olderGroups.get(dateKey)!.push(notification);
       });
 
-      olderGroups.forEach((notifs, dateKey) => {
+      olderGroups.forEach((notifs) => {
         const date = new Date(notifs[0].created_at);
-        const locale = getLocale();
-        const months = locale === 'es'
-          ? ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
-          : ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-        const label = `${date.getDate()} ${months[date.getMonth()]}`;
+        const label = formatNotificationSectionDateLabel(date);
         groups.push({ label, notifications: notifs });
       });
     }
 
     return groups;
-  }, [notifications]);
+  }, [notifications, getLocaleSnapshot()]);
 
   const hasUnread = useMemo(
     () => notifications.some((n) => !n.read),

--- a/app/notifications/[id].tsx
+++ b/app/notifications/[id].tsx
@@ -53,6 +53,7 @@ function getClientEmoji(type: NotificationType): { icon: string; bg: string } {
       return { icon: '🎁', bg: '#EC4899' };
     case 'payment_processed':
     case 'payment_received':
+    case 'new_paid_booking':
       return { icon: '💳', bg: '#10B981' };
     case 'provider_on_way':
       return { icon: '📍', bg: '#8B5CF6' };
@@ -62,6 +63,8 @@ function getClientEmoji(type: NotificationType): { icon: string; bg: string } {
     case 'new_booking_request':
       return { icon: '📩', bg: '#8B5CF6' };
     case 'new_review':
+    case 'job_pending_review':
+    case 'job_completed':
       return { icon: '⭐', bg: '#F59E0B' };
     case 'refund_issued':
       return { icon: '↩️', bg: '#10B981' };

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1034,6 +1034,97 @@ export default {
     refundIssuedProviderMessage:
       "A refund of %{amount} was recorded for %{serviceName}. Reason: %{reason}.",
     refundServiceFallback: "your booking",
+    fallbackClient: "The client",
+    fallbackSupplier: "Your provider",
+    fallbackServiceShort: "this service",
+    relative: {
+      justNow: "Now",
+      lessThanMinute: "Less than a minute ago",
+      minutesAgo: "%{count} min ago",
+      oneHourAgo: "1 hour ago",
+      hoursAgo: "%{count} hours ago",
+      yesterdayAt: "Yesterday, %{time}",
+      yesterdayShort: "Yesterday",
+      dateAt: "%{date}, %{time}",
+      compactMinutes: "%{count} min",
+      compactHours: "%{count} h",
+    },
+    types: {
+      booking_confirmed: {
+        clientTitle: "Booking confirmed",
+        clientMessage: "%{supplierName} accepted your booking.",
+        clientMessageWithService: "%{supplierName} accepted your booking for %{serviceName}.",
+        providerTitle: "Booking confirmed",
+        providerMessage: "%{clientName}'s booking is confirmed.",
+      },
+      booking_cancelled: {
+        clientTitle: "Booking cancelled",
+        clientMessage: "%{supplierName} cancelled your booking.",
+        providerTitle: "Booking cancelled",
+        providerMessage: "%{clientName} cancelled their booking.",
+      },
+      payment_processed: {
+        clientTitle: "Payment processed",
+        clientMessage: "Your payment of %{amount} was processed. Waiting for the provider to confirm.",
+        clientMessageWithService:
+          "Your payment of %{amount} for %{serviceName} was processed. Waiting for the provider to confirm.",
+        clientMessageNoAmount: "Your payment is being processed. Waiting for the provider to confirm.",
+      },
+      payment_received: {
+        providerTitle: "New paid booking",
+        providerMessage: "%{clientName} booked and paid %{amount} for %{serviceName}. Accept the booking to confirm.",
+        clientTitle: "Payment received",
+        clientMessage: "We received your payment of %{amount}.",
+        clientMessageWithService: "We received your payment of %{amount} for %{serviceName}.",
+      },
+      provider_on_way: {
+        clientTitle: "Provider on the way",
+        clientMessage: "%{supplierName} is on the way to your appointment.",
+        clientMessageWithService: "%{supplierName} is on the way for %{serviceName}.",
+      },
+      quote_received: {
+        clientTitle: "New quote",
+        clientMessage: "You have a new quote from %{supplierName}.",
+        providerTitle: "Quote request",
+        providerMessage: "%{clientName} is waiting for your quote.",
+        providerMessageWithService: "%{clientName} requested a quote for %{serviceName}.",
+      },
+      quote_approved: {
+        clientTitle: "Quote approved",
+        clientMessage: "%{supplierName}'s quote is ready to pay.",
+        providerTitle: "Quote approved",
+        providerMessage: "%{clientName} approved your quote.",
+      },
+      new_booking_request: {
+        providerTitle: "New booking request",
+        providerMessage: "%{clientName} sent a new booking request.",
+        providerMessageWithService: "%{clientName} sent a new booking request for %{serviceName}.",
+      },
+      new_review: {
+        providerTitle: "New review",
+        providerMessage: "%{clientName} left a %{stars}-star review for %{serviceName}.",
+        providerMessageNoStars: "%{clientName} left a review for %{serviceName}.",
+      },
+      rate_service: {
+        clientTitle: "Rate your service",
+        clientMessage: "How was your experience with %{supplierName}?",
+      },
+      offer: {
+        clientTitle: "Offer for you",
+        clientMessage: "You have a new offer or promotion.",
+        providerTitle: "Offer",
+        providerMessage: "You have a new offer or promotion.",
+      },
+      new_message: {
+        title: "New message",
+      },
+      job_review: {
+        clientTitle: "Rate your experience",
+        clientMessage: "Share feedback about your booking with %{supplierName}.",
+        providerTitle: "Review reminder",
+        providerMessage: "%{clientName} can leave a review.",
+      },
+    },
     detail: {
       screenTitle: "Notification",
       openRelated: "View in app",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -1035,6 +1035,97 @@ export default {
     refundIssuedProviderMessage:
       "Se registró un reembolso de %{amount} por %{serviceName}. Motivo: %{reason}.",
     refundServiceFallback: "tu reserva",
+    fallbackClient: "El cliente",
+    fallbackSupplier: "Tu proveedor",
+    fallbackServiceShort: "este servicio",
+    relative: {
+      justNow: "Ahora",
+      lessThanMinute: "Hace menos de un minuto",
+      minutesAgo: "Hace %{count} min",
+      oneHourAgo: "Hace 1 hora",
+      hoursAgo: "Hace %{count} horas",
+      yesterdayAt: "Ayer, %{time}",
+      yesterdayShort: "Ayer",
+      dateAt: "%{date}, %{time}",
+      compactMinutes: "%{count} min",
+      compactHours: "%{count} h",
+    },
+    types: {
+      booking_confirmed: {
+        clientTitle: "Reserva confirmada",
+        clientMessage: "%{supplierName} aceptó tu reserva.",
+        clientMessageWithService: "%{supplierName} aceptó tu reserva de %{serviceName}.",
+        providerTitle: "Reserva confirmada",
+        providerMessage: "La reserva de %{clientName} está confirmada.",
+      },
+      booking_cancelled: {
+        clientTitle: "Reserva cancelada",
+        clientMessage: "%{supplierName} canceló tu reserva.",
+        providerTitle: "Reserva cancelada",
+        providerMessage: "%{clientName} canceló su reserva.",
+      },
+      payment_processed: {
+        clientTitle: "Pago procesado",
+        clientMessage: "Tu pago de %{amount} se procesó. Esperando a que el proveedor confirme.",
+        clientMessageWithService:
+          "Tu pago de %{amount} por %{serviceName} se procesó. Esperando a que el proveedor confirme.",
+        clientMessageNoAmount: "Tu pago se está procesando. Esperando a que el proveedor confirme.",
+      },
+      payment_received: {
+        providerTitle: "Nueva reserva pagada",
+        providerMessage: "%{clientName} reservó y pagó %{amount} por %{serviceName}. Acepta la reserva para confirmar.",
+        clientTitle: "Pago recibido",
+        clientMessage: "Recibimos tu pago de %{amount}.",
+        clientMessageWithService: "Recibimos tu pago de %{amount} por %{serviceName}.",
+      },
+      provider_on_way: {
+        clientTitle: "El proveedor va en camino",
+        clientMessage: "%{supplierName} va en camino a tu cita.",
+        clientMessageWithService: "%{supplierName} va en camino para %{serviceName}.",
+      },
+      quote_received: {
+        clientTitle: "Nueva cotización",
+        clientMessage: "Tienes una nueva cotización de %{supplierName}.",
+        providerTitle: "Solicitud de cotización",
+        providerMessage: "%{clientName} espera tu cotización.",
+        providerMessageWithService: "%{clientName} solicitó una cotización para %{serviceName}.",
+      },
+      quote_approved: {
+        clientTitle: "Cotización aprobada",
+        clientMessage: "La cotización de %{supplierName} está lista para pagar.",
+        providerTitle: "Cotización aprobada",
+        providerMessage: "%{clientName} aprobó tu cotización.",
+      },
+      new_booking_request: {
+        providerTitle: "Nueva solicitud de reserva",
+        providerMessage: "%{clientName} envió una nueva solicitud de reserva.",
+        providerMessageWithService: "%{clientName} envió una nueva solicitud de reserva para %{serviceName}.",
+      },
+      new_review: {
+        providerTitle: "Nueva reseña",
+        providerMessage: "%{clientName} dejó una reseña de %{stars} estrellas sobre %{serviceName}.",
+        providerMessageNoStars: "%{clientName} dejó una reseña sobre %{serviceName}.",
+      },
+      rate_service: {
+        clientTitle: "Valora tu servicio",
+        clientMessage: "¿Cómo fue tu experiencia con %{supplierName}?",
+      },
+      offer: {
+        clientTitle: "Oferta para ti",
+        clientMessage: "Tienes una nueva oferta o promoción.",
+        providerTitle: "Oferta",
+        providerMessage: "Tienes una nueva oferta o promoción.",
+      },
+      new_message: {
+        title: "Nuevo mensaje",
+      },
+      job_review: {
+        clientTitle: "Valora tu experiencia",
+        clientMessage: "Comparte tu opinión sobre tu reserva con %{supplierName}.",
+        providerTitle: "Recordatorio de reseña",
+        providerMessage: "%{clientName} puede dejar una reseña.",
+      },
+    },
     detail: {
       screenTitle: "Notificación",
       openRelated: "Ver en la app",

--- a/services/notifications.ts
+++ b/services/notifications.ts
@@ -32,12 +32,15 @@ export type NotificationType =
   | 'offer'
   | 'payment_processed'
   | 'payment_received'
+  | 'new_paid_booking'
   | 'provider_on_way'
   | 'new_booking_request'
   | 'quote_received'
   | 'quote_approved'
   | 'new_review'
-  | 'refund_issued';
+  | 'refund_issued'
+  | 'job_pending_review'
+  | 'job_completed';
 
 export interface NotificationsResponse {
   notifications: Notification[];
@@ -148,10 +151,13 @@ export function getNotificationCategory(type: NotificationType): NotificationCat
       return 'jobs';
     case 'payment_processed':
     case 'payment_received':
+    case 'new_paid_booking':
     case 'refund_issued':
       return 'payments';
     case 'rate_service':
     case 'new_review':
+    case 'job_pending_review':
+    case 'job_completed':
       return 'reviews';
     case 'offer':
     default:

--- a/utils/notificationDisplay.ts
+++ b/utils/notificationDisplay.ts
@@ -1,25 +1,96 @@
 import { getLocale, t } from '@/i18n';
-import type { Notification } from '@/services/notifications';
+import type { Notification, NotificationType } from '@/services/notifications';
+import { canonicalNotificationType } from '@/utils/notificationTypeCanonical';
+
+export type NotificationViewerRole = 'client' | 'provider';
+
+function metadataRecord(notification: Notification): Record<string, unknown> {
+  const raw = notification.metadata;
+  if (raw == null) return {};
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+function pickString(m: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = m[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+function pickNumber(m: Record<string, unknown>, ...keys: string[]): number | undefined {
+  for (const k of keys) {
+    const v = m[k];
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string' && v.trim()) {
+      const n = Number(v);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return undefined;
+}
 
 function formatRefundCurrency(amount: number): string {
   const locale = getLocale() === 'es' ? 'es-MX' : 'en-US';
   return new Intl.NumberFormat(locale, { style: 'currency', currency: 'MXN' }).format(amount);
 }
 
-export type NotificationViewerRole = 'client' | 'provider';
+function formatNotificationMoney(m: Record<string, unknown>): string {
+  const n = pickNumber(m, 'amount', 'totalAmount', 'total_amount', 'paymentAmount', 'paidAmount', 'price', 'total');
+  if (n == null) return '';
+  const locale = getLocale() === 'es' ? 'es-MX' : 'en-US';
+  return new Intl.NumberFormat(locale, { style: 'currency', currency: 'MXN' }).format(n);
+}
 
-/**
- * Localized title/body for known types; others pass through API strings.
- */
-export function getLocalizedNotificationDisplay(
-  notification: Notification,
-  viewerRole: NotificationViewerRole,
-): { title: string; message: string } {
-  if (notification.type !== 'refund_issued') {
-    return { title: notification.title, message: notification.message };
-  }
+/** When type is missing or unknown, map common English API titles to our notification types. */
+function inferNotificationTypeFromEnglishTitle(title: string | undefined): string | null {
+  if (!title?.trim()) return null;
+  const k = title.trim().toLowerCase();
+  const map: Record<string, string> = {
+    'new paid booking': 'payment_received',
+    'payment received': 'payment_received',
+    'nueva reserva pagada': 'payment_received',
+    'pago recibido': 'payment_received',
+    'booking confirmed': 'booking_confirmed',
+    'reserva confirmada': 'booking_confirmed',
+    'booking cancelled': 'booking_cancelled',
+    'reserva cancelada': 'booking_cancelled',
+    'payment processed': 'payment_processed',
+    'pago procesado': 'payment_processed',
+    'new quote': 'quote_received',
+    'quote received': 'quote_received',
+    'nueva cotización': 'quote_received',
+    'new message': 'new_message',
+    'nuevo mensaje': 'new_message',
+    'new review': 'new_review',
+    'nueva reseña': 'new_review',
+    'rate your service': 'rate_service',
+    'provider on the way': 'provider_on_way',
+    'new booking request': 'new_booking_request',
+    'quote approved': 'quote_approved',
+    'cotización aprobada': 'quote_approved',
+    'refund issued': 'refund_issued',
+    'refund recorded': 'refund_issued',
+    'reembolso emitido': 'refund_issued',
+  };
+  return map[k] ?? null;
+}
 
-  const m = notification.metadata ?? {};
+function refundDisplay(notification: Notification, viewerRole: NotificationViewerRole): { title: string; message: string } {
+  const m = metadataRecord(notification);
   const rawAmount = m.refundAmount;
   const amountNum = typeof rawAmount === 'number' ? rawAmount : Number(rawAmount);
   const amountStr = Number.isFinite(amountNum) ? formatRefundCurrency(amountNum) : '';
@@ -53,3 +124,268 @@ export function getLocalizedNotificationDisplay(
   };
 }
 
+function typedDisplay(
+  notification: Notification,
+  viewerRole: NotificationViewerRole,
+  type: string,
+  m: Record<string, unknown>,
+): { title: string; message: string } | null {
+  const supplierName =
+    pickString(m, 'supplierName', 'supplier_name', 'providerName', 'provider_name', 'businessName', 'business_name') ??
+    t('notifications.fallbackSupplier');
+  const clientName =
+    pickString(m, 'clientName', 'client_name', 'customerName', 'customer_name', 'userName', 'user_name') ??
+    t('notifications.fallbackClient');
+  const serviceName = pickString(m, 'serviceName', 'service_name', 'service') ?? '';
+  const amountStr = formatNotificationMoney(m);
+  const stars = pickNumber(m, 'stars', 'rating', 'starRating', 'reviewRating');
+  const starsLabel = stars != null && Number.isFinite(stars) ? String(Math.round(stars)) : '';
+
+  switch (type) {
+    case 'booking_confirmed': {
+      if (viewerRole === 'client') {
+        return {
+          title: t('notifications.types.booking_confirmed.clientTitle'),
+          message: serviceName
+            ? t('notifications.types.booking_confirmed.clientMessageWithService', {
+                supplierName,
+                serviceName,
+              })
+            : t('notifications.types.booking_confirmed.clientMessage', { supplierName }),
+        };
+      }
+      return {
+        title: t('notifications.types.booking_confirmed.providerTitle'),
+        message: t('notifications.types.booking_confirmed.providerMessage', { clientName }),
+      };
+    }
+    case 'booking_cancelled': {
+      if (viewerRole === 'client') {
+        return {
+          title: t('notifications.types.booking_cancelled.clientTitle'),
+          message: t('notifications.types.booking_cancelled.clientMessage', { supplierName }),
+        };
+      }
+      return {
+        title: t('notifications.types.booking_cancelled.providerTitle'),
+        message: t('notifications.types.booking_cancelled.providerMessage', { clientName }),
+      };
+    }
+    case 'payment_processed': {
+      if (viewerRole !== 'client') return null;
+      return {
+        title: t('notifications.types.payment_processed.clientTitle'),
+        message: amountStr
+          ? serviceName
+            ? t('notifications.types.payment_processed.clientMessageWithService', { amount: amountStr, serviceName })
+            : t('notifications.types.payment_processed.clientMessage', { amount: amountStr })
+          : t('notifications.types.payment_processed.clientMessageNoAmount', { serviceName }),
+      };
+    }
+    case 'payment_received': {
+      if (viewerRole === 'provider') {
+        const hasMeta = !!(pickString(m, 'clientName', 'client_name') && (amountStr || serviceName));
+        return {
+          title: t('notifications.types.payment_received.providerTitle'),
+          message: hasMeta
+            ? t('notifications.types.payment_received.providerMessage', {
+                clientName,
+                amount: amountStr,
+                serviceName,
+              })
+            : notification.message,
+        };
+      }
+      return {
+        title: t('notifications.types.payment_received.clientTitle'),
+        message: amountStr
+          ? serviceName
+            ? t('notifications.types.payment_received.clientMessageWithService', { amount: amountStr, serviceName })
+            : t('notifications.types.payment_received.clientMessage', { amount: amountStr })
+          : notification.message,
+      };
+    }
+    case 'provider_on_way': {
+      if (viewerRole !== 'client') return null;
+      return {
+        title: t('notifications.types.provider_on_way.clientTitle'),
+        message: serviceName
+          ? t('notifications.types.provider_on_way.clientMessageWithService', { supplierName, serviceName })
+          : t('notifications.types.provider_on_way.clientMessage', { supplierName }),
+      };
+    }
+    case 'quote_received': {
+      if (viewerRole === 'client') {
+        return {
+          title: t('notifications.types.quote_received.clientTitle'),
+          message: t('notifications.types.quote_received.clientMessage', { supplierName, serviceName }),
+        };
+      }
+      return {
+        title: t('notifications.types.quote_received.providerTitle'),
+        message: serviceName
+          ? t('notifications.types.quote_received.providerMessageWithService', { clientName, serviceName })
+          : t('notifications.types.quote_received.providerMessage', { clientName }),
+      };
+    }
+    case 'quote_approved': {
+      if (viewerRole === 'client') {
+        return {
+          title: t('notifications.types.quote_approved.clientTitle'),
+          message: t('notifications.types.quote_approved.clientMessage', { supplierName }),
+        };
+      }
+      return {
+        title: t('notifications.types.quote_approved.providerTitle'),
+        message: t('notifications.types.quote_approved.providerMessage', { clientName }),
+      };
+    }
+    case 'new_booking_request': {
+      if (viewerRole !== 'provider') return null;
+      return {
+        title: t('notifications.types.new_booking_request.providerTitle'),
+        message: serviceName
+          ? t('notifications.types.new_booking_request.providerMessageWithService', { clientName, serviceName })
+          : t('notifications.types.new_booking_request.providerMessage', { clientName }),
+      };
+    }
+    case 'new_review': {
+      if (viewerRole !== 'provider') return null;
+      const serviceLabel = serviceName || t('notifications.fallbackServiceShort');
+      return {
+        title: t('notifications.types.new_review.providerTitle'),
+        message: starsLabel
+          ? t('notifications.types.new_review.providerMessage', {
+              clientName,
+              stars: starsLabel,
+              serviceName: serviceLabel,
+            })
+          : t('notifications.types.new_review.providerMessageNoStars', {
+              clientName,
+              serviceName: serviceLabel,
+            }),
+      };
+    }
+    case 'rate_service': {
+      if (viewerRole !== 'client') return null;
+      return {
+        title: t('notifications.types.rate_service.clientTitle'),
+        message: t('notifications.types.rate_service.clientMessage', { supplierName }),
+      };
+    }
+    case 'offer': {
+      if (viewerRole === 'client') {
+        return {
+          title: t('notifications.types.offer.clientTitle'),
+          message: t('notifications.types.offer.clientMessage'),
+        };
+      }
+      return {
+        title: t('notifications.types.offer.providerTitle'),
+        message: t('notifications.types.offer.providerMessage'),
+      };
+    }
+    case 'new_message': {
+      const preview = pickString(m, 'preview', 'messagePreview', 'snippet', 'body');
+      return {
+        title: t('notifications.types.new_message.title'),
+        message: preview ?? notification.message,
+      };
+    }
+    case 'job_pending_review':
+    case 'job_completed': {
+      if (viewerRole === 'client') {
+        return {
+          title: t('notifications.types.job_review.clientTitle'),
+          message: t('notifications.types.job_review.clientMessage', { supplierName }),
+        };
+      }
+      return {
+        title: t('notifications.types.job_review.providerTitle'),
+        message: t('notifications.types.job_review.providerMessage', { clientName }),
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Localized title/body per notification type and role; uses metadata when present, otherwise API strings.
+ */
+export function getLocalizedNotificationDisplay(
+  notification: Notification,
+  viewerRole: NotificationViewerRole,
+): { title: string; message: string } {
+  if (canonicalNotificationType(notification.type) === 'refund_issued') {
+    return refundDisplay(notification, viewerRole);
+  }
+
+  /** Prefer API user_type so supplier-targeted rows use provider copy even if app mode is wrong. */
+  const roleForTemplate: NotificationViewerRole =
+    notification.user_type === 'supplier'
+      ? 'provider'
+      : notification.user_type === 'client'
+        ? 'client'
+        : viewerRole;
+
+  const m = metadataRecord(notification);
+  let typeKey = canonicalNotificationType(notification.type);
+  let localized = typedDisplay(notification, roleForTemplate, typeKey, m);
+  if (!localized) {
+    const inferred = inferNotificationTypeFromEnglishTitle(notification.title);
+    if (inferred) {
+      localized = typedDisplay(notification, roleForTemplate, inferred, m);
+    }
+  }
+  if (localized) return localized;
+
+  return { title: notification.title, message: notification.message };
+}
+
+/**
+ * Relative time for notification lists (full phrases, locale-aware).
+ */
+export function formatNotificationRelativeTime(dateString: string, variant: 'full' | 'compact' = 'full'): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (variant === 'compact') {
+    if (diffMins < 1) return t('notifications.relative.justNow');
+    if (diffMins < 60) return t('notifications.relative.compactMinutes', { count: diffMins });
+    if (diffHours < 24) return t('notifications.relative.compactHours', { count: diffHours });
+    if (diffDays === 1) return t('notifications.relative.yesterdayShort');
+    if (diffDays < 7) {
+      const locale = getLocale() === 'es' ? 'es-ES' : 'en-US';
+      return date.toLocaleDateString(locale, { weekday: 'short' });
+    }
+    const locale = getLocale() === 'es' ? 'es-ES' : 'en-US';
+    return date.toLocaleDateString(locale, { day: 'numeric', month: 'short' });
+  }
+
+  if (diffMins < 1) return t('notifications.relative.lessThanMinute');
+  if (diffMins < 60) return t('notifications.relative.minutesAgo', { count: diffMins });
+  if (diffHours < 24) {
+    if (diffHours === 1) return t('notifications.relative.oneHourAgo');
+    return t('notifications.relative.hoursAgo', { count: diffHours });
+  }
+  if (diffDays === 1) {
+    const locale = getLocale() === 'es' ? 'es-ES' : 'en-US';
+    const timePart = date.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' });
+    return t('notifications.relative.yesterdayAt', { time: timePart });
+  }
+  const locale = getLocale() === 'es' ? 'es-ES' : 'en-US';
+  const datePart = date.toLocaleDateString(locale, { day: 'numeric', month: 'numeric' });
+  const timePart = date.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' });
+  return t('notifications.relative.dateAt', { date: datePart, time: timePart });
+}
+
+/** Section header for grouped notifications (older than yesterday). */
+export function formatNotificationSectionDateLabel(d: Date): string {
+  const locale = getLocale() === 'es' ? 'es-ES' : 'en-US';
+  return d.toLocaleDateString(locale, { day: 'numeric', month: 'long' });
+}

--- a/utils/notificationNavigation.ts
+++ b/utils/notificationNavigation.ts
@@ -1,6 +1,17 @@
 import type { Notification } from '@/services/notifications';
-import { fetchOrderDetail } from '@/services/orders';
+import { fetchOrderDetail, type OrderStatus } from '@/services/orders';
 import type { UserMode } from '@/contexts/ModeContext';
+import { canonicalNotificationType } from '@/utils/notificationTypeCanonical';
+
+/** Order is past the “review quote on quote screen” phase for clients. */
+const CLIENT_ORDER_DETAIL_FOR_QUOTE_NOTIFICATION: OrderStatus[] = [
+  'pending_payment',
+  'pending_for_provider',
+  'accepted',
+  'in_progress',
+  'pending_review',
+  'completed',
+];
 
 /** API may send camelCase or snake_case; metadata may rarely arrive as a JSON string. */
 function coerceMetadata(notification: Notification): Record<string, unknown> {
@@ -23,7 +34,7 @@ function coerceMetadata(notification: Notification): Record<string, unknown> {
 }
 
 function metaOrderId(m: Record<string, unknown>): string | undefined {
-  const v = m.orderId ?? m.order_id;
+  const v = m.orderId ?? m.order_id ?? m.bookingId ?? m.booking_id;
   return typeof v === 'string' && v.length > 0 ? v : undefined;
 }
 
@@ -34,12 +45,12 @@ function metaConversationId(m: Record<string, unknown>): string | undefined {
 
 function syncHrefForNotification(notification: Notification, mode: UserMode): string | null {
   const metadata = coerceMetadata(notification);
-  const type = notification.type as string;
+  const typeKey = canonicalNotificationType(notification.type);
   const orderId = metaOrderId(metadata);
   const conversationId = metaConversationId(metadata);
 
   if (mode === 'client') {
-    switch (notification.type) {
+    switch (typeKey) {
       case 'quote_received':
         return orderId ? `/booking/quote/${orderId}` : null;
       case 'booking_confirmed':
@@ -56,14 +67,14 @@ function syncHrefForNotification(notification: Notification, mode: UserMode): st
       case 'offer':
         return '/(tabs)/home';
       default:
-        if (type === 'job_pending_review' || type === 'job_completed') {
+        if (typeKey === 'job_pending_review' || typeKey === 'job_completed') {
           return orderId ? `/orders/rate/${orderId}` : null;
         }
         return null;
     }
   }
 
-  switch (notification.type) {
+  switch (typeKey) {
     case 'booking_confirmed':
     case 'booking_cancelled':
     case 'provider_on_way':
@@ -114,8 +125,9 @@ export async function resolveNotificationRelatedHref(
   const metadata = coerceMetadata(notification);
   const orderId = metaOrderId(metadata);
   const conversationId = metaConversationId(metadata);
+  const typeKey = canonicalNotificationType(notification.type);
 
-  if (notification.type === 'new_message' && !conversationId && orderId) {
+  if (typeKey === 'new_message' && !conversationId && orderId) {
     try {
       const detail = await fetchOrderDetail(orderId);
       if (detail.conversation_id) {
@@ -126,5 +138,24 @@ export async function resolveNotificationRelatedHref(
     }
     return null;
   }
+
+  // “Quote received” is often still the persisted type after pay/confirm; quote payload may be gone.
+  // Opening /booking/quote in that state shows a misleading “Quote not found” — order detail is correct.
+  if (mode === 'client' && typeKey === 'quote_received' && orderId) {
+    try {
+      const detail = await fetchOrderDetail(orderId);
+      const status = detail.order?.status;
+      const noQuote = detail.quote == null;
+      if (
+        noQuote ||
+        (status != null && CLIENT_ORDER_DETAIL_FOR_QUOTE_NOTIFICATION.includes(status))
+      ) {
+        return `/orders/${orderId}`;
+      }
+    } catch {
+      // Fall through to sync href (quote screen); user still gets a concrete screen.
+    }
+  }
+
   return syncHrefForNotification(notification, mode);
 }

--- a/utils/notificationTypeCanonical.ts
+++ b/utils/notificationTypeCanonical.ts
@@ -1,0 +1,21 @@
+/**
+ * Normalizes API notification.type values so switches match (snake_case, suffix after dots, aliases).
+ */
+export function canonicalNotificationType(raw: unknown): string {
+  if (typeof raw !== 'string') return '';
+  let s = raw.trim();
+  if (!s) return '';
+  if (s.includes('.')) {
+    const parts = s.split('.');
+    const last = parts[parts.length - 1]?.trim();
+    if (last) s = last;
+  }
+  const withUnderscores = s
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_');
+  const lower = withUnderscores.toLowerCase();
+  if (lower === 'new_paid_booking' || lower === 'paid_booking' || lower === 'booking_paid') {
+    return 'payment_received';
+  }
+  return lower;
+}


### PR DESCRIPTION
Localize notification titles and bodies by type and role (en/es), with relative time helpers shared between client and provider lists.

Add canonicalNotificationType for API type variants and title-based inference so supplier-facing rows use provider copy under Spanish UI.

Extend notification types (new_paid_booking, job review aliases) and align navigation category mapping.
