### PR TITLE
fix(i18n): apply account language on login and cold start

### DIFF
--- a/app/(provider-tabs)/profile/language.tsx
+++ b/app/(provider-tabs)/profile/language.tsx
@@ -2,6 +2,7 @@ import { Toast } from '@/components/Toast';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { t, setLocale, getLocale } from '@/i18n';
 import { getSettings, updateSettings } from '@/services/settings';
+import { normalizeAppLanguage, persistUserLanguage } from '@/utils/userLanguagePreference';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -43,10 +44,13 @@ export default function ProviderLanguageScreen() {
     try {
       setLoading(true);
       const response = await getSettings();
-      const lang = response.settings.language;
-      setCurrentLanguage(lang);
-      if (lang === 'es' || lang === 'en') {
+      const lang = normalizeAppLanguage(response.settings.language);
+      if (lang) {
+        setCurrentLanguage(lang);
         setLocale(lang);
+        await persistUserLanguage(lang);
+      } else {
+        setCurrentLanguage(getLocale() as Language);
       }
     } catch {
       // Fallback to local locale
@@ -68,6 +72,7 @@ export default function ProviderLanguageScreen() {
       setCurrentLanguage(lang);
       setLocale(lang);
       await updateSettings({ language: lang });
+      await persistUserLanguage(lang);
       setToast({ message: t(`${I18N}.languageUpdated`), type: 'success' });
     } catch {
       setCurrentLanguage(previous);

--- a/app/account/language.tsx
+++ b/app/account/language.tsx
@@ -2,6 +2,7 @@ import { Toast } from '@/components/Toast';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { t, setLocale, getLocale } from '@/i18n';
 import { getSettings, updateSettings } from '@/services/settings';
+import { normalizeAppLanguage, persistUserLanguage } from '@/utils/userLanguagePreference';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -43,10 +44,13 @@ export default function ClientLanguageScreen() {
     try {
       setLoading(true);
       const response = await getSettings();
-      const lang = response.settings.language;
-      setCurrentLanguage(lang);
-      if (lang === 'es' || lang === 'en') {
+      const lang = normalizeAppLanguage(response.settings.language);
+      if (lang) {
+        setCurrentLanguage(lang);
         setLocale(lang);
+        await persistUserLanguage(lang);
+      } else {
+        setCurrentLanguage(getLocale() as Language);
       }
     } catch {
       // Fallback to local locale
@@ -68,6 +72,7 @@ export default function ClientLanguageScreen() {
       setCurrentLanguage(lang);
       setLocale(lang);
       await updateSettings({ language: lang });
+      await persistUserLanguage(lang);
       setToast({ message: t(`${I18N}.languageUpdated`), type: 'success' });
     } catch {
       setCurrentLanguage(previous);

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import { ApiError, refreshTokens, setTokenUpdateCallback, clearTokenState } from
 import { getProfile } from '@/services/profile';
 import { queryClient } from '@/services/queryClient';
 import { authEvents } from '@/utils/authEvents';
+import { applyCachedUserLanguage } from '@/utils/userLanguagePreference';
 import { getTimeUntilExpiryMs, isTokenExpiringSoon } from '@/utils/tokenUtils';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { createContext, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
@@ -102,7 +103,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const parsedUser = JSON.parse(userData);
         console.log('AuthContext - Parsed user:', parsedUser);
         setUser(parsedUser);
-        
+
+        if (parsedUser.authToken) {
+          await applyCachedUserLanguage();
+        }
+
         // If user has auth token, sync profile from backend to get latest data (including country)
         // Add timeout to prevent blocking if backend is unavailable
         if (parsedUser.authToken) {
@@ -187,6 +192,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       authEvents.reset();
       setUser(userData);
       await AsyncStorage.setItem('user', JSON.stringify(userData));
+      await applyCachedUserLanguage();
       console.log('AuthContext - User set and saved to storage');
     } catch (error) {
       console.error('Error saving user to storage:', error);

--- a/contexts/ModeContext.tsx
+++ b/contexts/ModeContext.tsx
@@ -1,6 +1,11 @@
 import { setLocale } from '@/i18n';
 import { getSettings, updateSettings } from '@/services/settings';
 import { checkProviderStatus } from '@/services/providers';
+import {
+  applyCachedUserLanguage,
+  normalizeAppLanguage,
+  persistUserLanguage,
+} from '@/utils/userLanguagePreference';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
@@ -67,10 +72,12 @@ export const ModeProvider: React.FC<ModeProviderProps> = ({ children, isAuthenti
   const loadModeFromSettings = async () => {
     try {
       setIsLoading(true);
+      await applyCachedUserLanguage();
       const response = await getSettings();
-      const lang = response.settings.language;
-      if (lang === 'es' || lang === 'en') {
+      const lang = normalizeAppLanguage(response.settings.language);
+      if (lang) {
         setLocale(lang);
+        await persistUserLanguage(lang);
       }
       const userMode = response.settings.user_mode;
       if (userMode === 'client' || userMode === 'provider') {

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -26,9 +26,8 @@ export function getLocaleSnapshot(): string {
   return i18n.locale;
 }
 
-// Determine best language from device settings
+// Determine best language from device settings (overridden when session restores saved preference)
 const locales = Localization.getLocales();
-console.log('locales', locales);
 const primary = locales && locales.length > 0 ? locales[0] : undefined;
 const languageCode = primary?.languageCode?.toLowerCase() ?? 'en';
 

--- a/utils/userLanguagePreference.ts
+++ b/utils/userLanguagePreference.ts
@@ -1,0 +1,32 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { setLocale } from '@/i18n';
+
+const LANGUAGE_STORAGE_KEY = '@mordobo_user_language';
+
+export type AppLanguage = 'en' | 'es';
+
+export function normalizeAppLanguage(raw: unknown): AppLanguage | null {
+  if (raw === 'en' || raw === 'es') return raw;
+  if (typeof raw === 'string') {
+    const l = raw.trim().toLowerCase();
+    if (l === 'en' || l.startsWith('en-')) return 'en';
+    if (l === 'es' || l.startsWith('es-')) return 'es';
+  }
+  return null;
+}
+
+export async function persistUserLanguage(lang: AppLanguage): Promise<void> {
+  await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+}
+
+/** Applies last known account language so UI matches server preference before settings fetch completes. */
+export async function applyCachedUserLanguage(): Promise<void> {
+  try {
+    const raw = await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY);
+    const lang = normalizeAppLanguage(raw);
+    if (lang) setLocale(lang);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
Persist user language preference in AsyncStorage and hydrate before settings fetch. Align UI with server language instead of device-only default. Normalize API language values.
