### PR TITLE
docs(rules): document API and Backoffice paths for cross-repo work

### DIFF
--- a/.cursor/rules/crossrepochanges.mdc
+++ b/.cursor/rules/crossrepochanges.mdc
@@ -2,11 +2,18 @@
 name: Cross-Repo Feature Development
 alwaysApply: true
 ---
+When a feature affects mobile, API, and/or Backoffice:
+
+**Rutas absolutas:** Mobile `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/mobile`, API `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/API`, Backoffice dashboard `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/Backoffice/admin-dashboard` (ver regla *Cross-Repo Architecture*).
+
+- **Solo admin / Netlify backoffice:** implementar en `Backoffice/admin-dashboard`; tocar **API** solo si hace falta endpoint, permiso o dato nuevo.
+- **Solo app móvil + backend:** flujo habitual mobile + API (sin Backoffice).
+
 When a feature affects both mobile and API repositories:
 
 0. REUSE BEFORE CREATING:
    - Before creating any new database structure or API endpoint, check if it already exists or can be reused.
-   - Search the codebase (mobile/services/, API/src/routes/) and API documentation for existing endpoints, tables, and columns.
+   - Search the codebase (mobile/services/, API/src/routes/, Backoffice/admin-dashboard/src/ when relevant) and API documentation for existing endpoints, tables, and columns.
    - Prefer extending existing endpoints or tables over adding new ones when the data fits the same domain.
 
 1. BACKEND FIRST (Mordobo/API):
@@ -25,7 +32,11 @@ When a feature affects both mobile and API repositories:
    - Create API client function in mobile/services/
    - Implement call to backend endpoint
    - Handle loading and error states
-   - Update components that consume the service4. VERIFY:
+   - Update components that consume the service
+
+4. VERIFY:
    - Test end-to-end flow
    - Verify type synchronization
-   - Check error handlingAlways check if changes require backend modifications BEFORE starting implementation.
+   - Check error handling
+
+Always check if changes require backend modifications BEFORE starting implementation.

--- a/.cursor/rules/crossrepostructure.mdc
+++ b/.cursor/rules/crossrepostructure.mdc
@@ -2,16 +2,35 @@
 name: Cross-Repo Architecture
 alwaysApply: true
 ---
-This is a multi-repository project:MOBILE (This repo): /Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/mobile
-- Contains React Native/Expo frontend
-- mobile/services/ contains API CLIENT code (calls backend)
-- mobile/services/auth.ts calls POST /auth/login from backendAPI (Separate repo): /Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/API
-- Contains Express.js backend
-- API/src/routes/ contains API ENDPOINTS
-- API/src/routes/auth.ts defines POST /auth/login endpoint
 
-When implementing features:
-1. Backend endpoints go in Mordobo/API/src/routes/
-2. Frontend API clients go in mobile/services/
-3. Always verify which repo you're working in before creating files
-4. Never create API endpoints in mobile/services/ - those belong in API repo
+# Mordobo: dónde está cada repositorio
+
+El trabajo puede pedirse desde el workspace **mobile**, pero los cambios en API o Backoffice deben hacerse **en su carpeta**, usando rutas absolutas con las herramientas (lectura, búsqueda, edición, terminal).
+
+## Mobile (esta app — React Native / Expo)
+
+- **Raíz:** `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/mobile`
+- **Cliente HTTP hacia el backend:** `mobile/services/` (solo llamadas; **no** son rutas Express)
+
+## API (backend Express)
+
+- **Raíz:** `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/API`
+- **Rutas HTTP:** `API/src/routes/`
+- **Servidor / arranque:** `API/src/index.ts`, `API/src/db.ts`
+
+## Backoffice (admin web — Netlify)
+
+- **Raíz del monorepo:** `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/Backoffice`
+- **App del dashboard (Vite + React):** `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/Backoffice/admin-dashboard`
+- **Código principal del admin:** `Backoffice/admin-dashboard/src/` (páginas, componentes, hooks, llamadas al API admin)
+- **Otro paquete en el mismo repo:** `Backoffice/admin-auth-api/` — solo si la tarea es explícitamente auth/servidor auxiliar de admin
+
+## Cómo enrutar la tarea al repo correcto
+
+| Tema | Repo |
+|------|------|
+| Pantallas admin, proveedores, tablas backoffice, `mordobobackoffice.netlify.app` | `Backoffice/admin-dashboard` |
+| Endpoints REST, SQL, Zod, rate limits, `BRUNO_API_DOCUMENTATION.md` | `API` |
+| App móvil Expo, tabs, booking, modo cliente/proveedor | `mobile` |
+
+**Reglas:** No crear endpoints Express dentro de `mobile/services/`. Los endpoints viven en **API**; el cliente en **mobile** o en **admin-dashboard** según consuma la app.

--- a/.cursor/rules/rulepriority.mdc
+++ b/.cursor/rules/rulepriority.mdc
@@ -12,4 +12,6 @@ CLAUDE.md files exist in:
 - Mobile: /Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/mobile/CLAUDE.md
 - API: /Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/API/CLAUDE.md
 
-Always consult relevant CLAUDE.md before making changes.
+Backoffice (admin): `/Users/angelorivas/Desktop/Proyectos_Personales/Mordobo/Backoffice/admin-dashboard` — no hay CLAUDE.md en ese paquete; seguir README del repo, patrones existentes en `src/`, y la regla *Cross-Repo Architecture*.
+
+Always consult relevant CLAUDE.md (cuando exista) before making changes.


### PR DESCRIPTION
- Expand cross-repo architecture with absolute paths and admin-dashboard
- Note backoffice-only vs mobile+API flows in crossrepochanges
- Rule priority: admin-dashboard has no CLAUDE.md
