### PR TITLE
fix(MDB-400): localize notifications for namespaced API types

### DIFF
--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -1,3 +1,4 @@
+import { useMode } from '@/contexts/ModeContext';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { getLocaleSnapshot, t } from '@/i18n';
 import {
@@ -31,9 +32,10 @@ interface NotificationItemProps {
   notification: Notification;
   onPress: () => void;
   colors: ReturnType<typeof useThemeColors>;
+  viewerRole: 'client' | 'provider';
 }
 
-function NotificationItem({ notification, onPress, colors }: NotificationItemProps) {
+function NotificationItem({ notification, onPress, colors, viewerRole }: NotificationItemProps) {
   const getNotificationConfig = (type: NotificationType) => {
     switch (type) {
       case 'booking_confirmed':
@@ -71,7 +73,7 @@ function NotificationItem({ notification, onPress, colors }: NotificationItemPro
   };
 
   const config = getNotificationConfig(notification.type);
-  const display = getLocalizedNotificationDisplay(notification, 'client');
+  const display = getLocalizedNotificationDisplay(notification, viewerRole);
 
   return (
     <TouchableOpacity
@@ -117,6 +119,8 @@ export default function NotificationsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const { mode } = useMode();
+  const listViewerRole = mode === 'provider' ? 'provider' : 'client';
 
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
@@ -309,6 +313,7 @@ export default function NotificationsScreen() {
                   notification={notification}
                   onPress={() => handleNotificationPress(notification)}
                   colors={colors}
+                  viewerRole={listViewerRole}
                 />
               ))}
             </View>

--- a/utils/notificationDisplay.ts
+++ b/utils/notificationDisplay.ts
@@ -55,10 +55,19 @@ function formatNotificationMoney(m: Record<string, unknown>): string {
   return new Intl.NumberFormat(locale, { style: 'currency', currency: 'MXN' }).format(n);
 }
 
+function normalizeInferKey(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/\u00a0/g, ' ')
+    .replace(/[’']/g, "'")
+    .replace(/\s+/g, ' ');
+}
+
 /** When type is missing or unknown, map common English API titles to our notification types. */
 function inferNotificationTypeFromEnglishTitle(title: string | undefined): string | null {
   if (!title?.trim()) return null;
-  const k = title.trim().toLowerCase();
+  const k = normalizeInferKey(title);
   const map: Record<string, string> = {
     'new paid booking': 'payment_received',
     'payment received': 'payment_received',
@@ -87,6 +96,43 @@ function inferNotificationTypeFromEnglishTitle(title: string | undefined): strin
     'reembolso emitido': 'refund_issued',
   };
   return map[k] ?? null;
+}
+
+/** Infer type from API message body when title is missing or not in the title map (namespaced types). */
+function inferNotificationTypeFromMessageBody(message: string | undefined): string | null {
+  if (!message?.trim()) return null;
+  const m = normalizeInferKey(message);
+
+  if (
+    /\bhas cancelled their booking\b/.test(m) ||
+    /\bcancelled their booking\b/.test(m) ||
+    /\bcanceló su reserva\b/.test(m) ||
+    /\bcancelo su reserva\b/.test(m)
+  ) {
+    return 'booking_cancelled';
+  }
+  if (
+    /\bhas booked and paid\b/.test(m) ||
+    /\bbooked and paid\b/.test(m) ||
+    /\breservó y pagó\b/.test(m) ||
+    /\breservo y pago\b/.test(m)
+  ) {
+    return 'payment_received';
+  }
+  if (/\bhas paid\b/.test(m) && /\baccept the booking\b/.test(m)) {
+    return 'payment_received';
+  }
+  if (
+    /\bleft a \d+-star review\b/.test(m) ||
+    /\bdejó una reseña\b/.test(m) ||
+    /\b\d+\s*estrellas\b/.test(m)
+  ) {
+    return 'new_review';
+  }
+  if (/^[^:]+:\s*\S/.test(m) && m.length <= 500) {
+    return 'new_message';
+  }
+  return null;
 }
 
 function refundDisplay(notification: Notification, viewerRole: NotificationViewerRole): { title: string; message: string } {
@@ -333,7 +379,9 @@ export function getLocalizedNotificationDisplay(
   let typeKey = canonicalNotificationType(notification.type);
   let localized = typedDisplay(notification, roleForTemplate, typeKey, m);
   if (!localized) {
-    const inferred = inferNotificationTypeFromEnglishTitle(notification.title);
+    const inferred =
+      inferNotificationTypeFromEnglishTitle(notification.title) ??
+      inferNotificationTypeFromMessageBody(notification.message);
     if (inferred) {
       localized = typedDisplay(notification, roleForTemplate, inferred, m);
     }

--- a/utils/notificationTypeCanonical.ts
+++ b/utils/notificationTypeCanonical.ts
@@ -1,21 +1,78 @@
 /**
+ * Normalizes API notification.type values so switches match (snake_case, dotted namespaces, aliases).
+ *
+ * Many backends send namespaced types like `domain.booking.cancelled`. Taking only the last segment
+ * (`cancelled`) breaks template matching and the UI falls back to English API title/message.
+ */
+
+/** Canonical types used by `notificationDisplay` / navigation (longest first for suffix matching). */
+const KNOWN_NOTIFICATION_TYPES_DESC: string[] = [
+  'new_booking_request',
+  'job_pending_review',
+  'booking_confirmed',
+  'booking_cancelled',
+  'payment_processed',
+  'payment_received',
+  'provider_on_way',
+  'quote_received',
+  'quote_approved',
+  'job_completed',
+  'refund_issued',
+  'rate_service',
+  'new_review',
+  'new_message',
+  'offer',
+];
+
+function normalizeTypeFragment(s: string): string {
+  let x = s.trim().replace(/\./g, '_');
+  x = x.replace(/([a-z0-9])([A-Z])/g, '$1_$2').replace(/[-\s]+/g, '_');
+  return x.toLowerCase();
+}
+
+function applyAliases(lower: string): string {
+  if (lower === 'new_paid_booking' || lower === 'paid_booking' || lower === 'booking_paid') {
+    return 'payment_received';
+  }
+  if (lower === 'booking_canceled') {
+    return 'booking_cancelled';
+  }
+  return lower;
+}
+
+function matchKnownCanonical(lower: string): string | null {
+  const withAliases = applyAliases(lower);
+  if (withAliases !== lower) return withAliases;
+
+  for (const kt of KNOWN_NOTIFICATION_TYPES_DESC) {
+    if (lower === kt || lower.endsWith(`_${kt}`)) return kt;
+  }
+  return null;
+}
+
+/**
  * Normalizes API notification.type values so switches match (snake_case, suffix after dots, aliases).
  */
 export function canonicalNotificationType(raw: unknown): string {
   if (typeof raw !== 'string') return '';
-  let s = raw.trim();
-  if (!s) return '';
-  if (s.includes('.')) {
-    const parts = s.split('.');
-    const last = parts[parts.length - 1]?.trim();
-    if (last) s = last;
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+
+  const fullNormalized = normalizeTypeFragment(trimmed);
+  const fromFull = matchKnownCanonical(fullNormalized);
+  if (fromFull) return fromFull;
+
+  // Legacy: single trailing segment (handles `com.app.NewMessage` → last segment normalizes to new_message)
+  if (trimmed.includes('.')) {
+    const parts = trimmed.split('.');
+    const last = parts[parts.length - 1]?.trim() ?? '';
+    if (last) {
+      const lastNorm = normalizeTypeFragment(last);
+      const fromLast = matchKnownCanonical(lastNorm);
+      if (fromLast) return fromLast;
+      return lastNorm;
+    }
   }
-  const withUnderscores = s
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .replace(/[-\s]+/g, '_');
-  const lower = withUnderscores.toLowerCase();
-  if (lower === 'new_paid_booking' || lower === 'paid_booking' || lower === 'booking_paid') {
-    return 'payment_received';
-  }
-  return lower;
+
+  return fullNormalized;
 }


### PR DESCRIPTION
- Match canonical notification types on full dotted paths, not only the last segment.
- Add booking_canceled alias and suffix-based matching for known types.
- Infer type from message body when title inference fails (EN/ES patterns).
- Use app mode (client vs provider) for notification list copy on client tabs.
