### PR TITLE
fix(complaints): send submitter type from active app mode

### DIFF
--- a/app/account/complaints.tsx
+++ b/app/account/complaints.tsx
@@ -1,6 +1,7 @@
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { t } from '@/i18n';
 import { ApiError } from '@/services/auth';
+import { useMode } from '@/contexts/ModeContext';
 import {
   createComplaint,
   getComplaintMessages,
@@ -62,6 +63,7 @@ export default function ComplaintsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const { mode } = useMode();
   const queryClient = useQueryClient();
 
   const [type, setType] = useState<ComplaintType>('complaint');
@@ -89,6 +91,7 @@ export default function ComplaintsScreen() {
         subject: subject.trim(),
         description: description.trim(),
         order_id: orderId.trim() || undefined,
+        submitter_type: mode,
       }),
     onSuccess: () => {
       setSubject('');

--- a/services/complaints.ts
+++ b/services/complaints.ts
@@ -40,6 +40,7 @@ export interface CreateComplaintPayload {
   subject: string;
   description: string;
   order_id?: string | null;
+  submitter_type?: 'client' | 'provider';
 }
 
 export async function listComplaints(page = 1, limit = 20): Promise<ListComplaintsResponse> {
@@ -64,6 +65,7 @@ export async function createComplaint(
         subject: payload.subject.trim(),
         description: payload.description.trim(),
         order_id: payload.order_id?.trim() || undefined,
+        submitter_type: payload.submitter_type,
       }),
     },
     t('complaints.submitError')


### PR DESCRIPTION
Include submitter_type in complaint creation payload so provider-mode submissions are attributed correctly in backoffice instead of defaulting to client.
