### PR TITLE
fix(MDB-407): evitar envío involuntario de onboarding al pulsar Atrás

### DIFF
--- a/app/(provider-tabs)/_layout.tsx
+++ b/app/(provider-tabs)/_layout.tsx
@@ -27,14 +27,19 @@ export default function ProviderTabLayout() {
   const [providerStatusCheck, setProviderStatusCheck] = useState<{
     loading: boolean;
     status: string | null;
-  }>({ loading: true, status: null });
+    onboardingCompleted: boolean;
+  }>({ loading: true, status: null, onboardingCompleted: false });
 
   const refreshProviderStatus = useCallback(async () => {
     try {
       const res = await checkProviderStatus();
-      setProviderStatusCheck({ loading: false, status: res.status ?? null });
+      setProviderStatusCheck({
+        loading: false,
+        status: res.status ?? null,
+        onboardingCompleted: Boolean(res.onboardingCompleted),
+      });
     } catch {
-      setProviderStatusCheck({ loading: false, status: null });
+      setProviderStatusCheck({ loading: false, status: null, onboardingCompleted: false });
     }
   }, []);
 
@@ -43,13 +48,24 @@ export default function ProviderTabLayout() {
     refreshProviderStatus();
   }, [user, isFocused, refreshProviderStatus]);
 
-  // When provider is not active, redirect to Request Sent screen (provider-onboarding/verification).
+  // When provider is not active: send users who still need onboarding to the flow (not verification).
+  // Verification auto-submits step 7 on mount; sending incomplete onboarding there caused bogus
+  // "request sent" submissions when Android back popped to this layout under the welcome screen.
   useEffect(() => {
     if (providerStatusCheck.loading || !isFocused) return;
-    if (providerStatusCheck.status !== ACTIVE_STATUS) {
+    if (providerStatusCheck.status === ACTIVE_STATUS) return;
+    if (!providerStatusCheck.onboardingCompleted) {
+      router.replace("/provider-onboarding");
+    } else {
       router.replace("/provider-onboarding/verification");
     }
-  }, [providerStatusCheck.loading, providerStatusCheck.status, isFocused, router]);
+  }, [
+    providerStatusCheck.loading,
+    providerStatusCheck.status,
+    providerStatusCheck.onboardingCompleted,
+    isFocused,
+    router,
+  ]);
 
   // MDB-257: When Profile tab is pressed from a nested route (e.g. /profile/security), navigate to profile root.
   const isNestedProfileRoute =

--- a/app/provider-onboarding/index.tsx
+++ b/app/provider-onboarding/index.tsx
@@ -1,21 +1,44 @@
-import { LinearGradient } from 'expo-linear-gradient';
-import { useRouter } from 'expo-router';
-import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Ionicons } from '@expo/vector-icons';
-import { t } from '@/i18n';
 import { ProgressBar } from '@/components/onboarding/ProgressBar';
+import { useMode } from '@/contexts/ModeContext';
+import { t } from '@/i18n';
+import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useFocusEffect, useRouter } from 'expo-router';
+import React, { useCallback } from 'react';
+import { BackHandler, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const TOTAL_STEPS = 8;
 
 export default function ProviderOnboardingWelcomeScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const { setMode } = useMode();
 
   const handleGetStarted = () => {
     router.push('/provider-onboarding/business');
   };
+
+  // Android hardware back: leave provider onboarding instead of popping to (provider-tabs), which
+  // would re-run gate logic and previously could open verification (step 7 submit) by mistake.
+  useFocusEffect(
+    useCallback(() => {
+      const onHardwareBack = () => {
+        void (async () => {
+          try {
+            await setMode('client');
+            router.replace('/(tabs)');
+          } catch (e) {
+            console.error('[ProviderOnboarding welcome] Exit on back failed:', e);
+            router.replace('/(tabs)');
+          }
+        })();
+        return true;
+      };
+      const sub = BackHandler.addEventListener('hardwareBackPress', onHardwareBack);
+      return () => sub.remove();
+    }, [router, setMode]),
+  );
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>


### PR DESCRIPTION
- Redirigir a /provider-onboarding si onboarding no está completo en lugar de verification (que hace submit del paso 7 al montar).
- En la pantalla de bienvenida, Back de Android sale a modo cliente e inicio.
