### PR TITLE
fix(MDB-411): guardar códigos de respaldo 2FA con selector nativo

### DIFF
--- a/app/(provider-tabs)/profile/security.tsx
+++ b/app/(provider-tabs)/profile/security.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/services/settings';
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
-import * as FileSystem from 'expo-file-system';
+import { Directory } from 'expo-file-system';
 import { useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -257,15 +257,23 @@ export default function ProviderSecurityScreen() {
   }, [buildBackupCodesBody, showToast]);
 
   const handleDownloadCodes = useCallback(async (codes: string[]) => {
+    const fileName = `mordobo-backup-codes-${Date.now()}.txt`;
+    const body = buildBackupCodesBody(codes);
+
+    let directory: Directory | undefined;
     try {
-      const fileName = `mordobo-backup-codes-${Date.now()}.txt`;
-      const dir = FileSystem.documentDirectory ?? FileSystem.cacheDirectory ?? '';
-      const uri = `${dir}${fileName}`;
-      await FileSystem.writeAsStringAsync(uri, buildBackupCodesBody(codes), { encoding: FileSystem.EncodingType.UTF8 });
-      await Share.share({ url: uri, message: buildBackupCodesBody(codes), title: fileName });
+      directory = await Directory.pickDirectoryAsync();
+    } catch {
+      return;
+    }
+    if (!directory) return;
+
+    try {
+      const file = directory.createFile(fileName, 'text/plain');
+      file.write(body);
       showToast(t(`${I18N}.backupCodesSaved`, { file: fileName }), 'success');
     } catch {
-      showToast(t('errors.copyFailed'), 'error');
+      showToast(t('errors.saveFileFailed'), 'error');
     }
   }, [buildBackupCodesBody, showToast]);
 

--- a/app/account/security.tsx
+++ b/app/account/security.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/services/settings';
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
-import * as FileSystem from 'expo-file-system';
+import { Directory } from 'expo-file-system';
 import { useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -254,15 +254,23 @@ export default function ClientSecurityScreen() {
   }, [buildBackupCodesBody, showToast]);
 
   const handleDownloadCodes = useCallback(async (codes: string[]) => {
+    const fileName = `mordobo-backup-codes-${Date.now()}.txt`;
+    const body = buildBackupCodesBody(codes);
+
+    let directory: Directory | undefined;
     try {
-      const fileName = `mordobo-backup-codes-${Date.now()}.txt`;
-      const dir = FileSystem.documentDirectory ?? FileSystem.cacheDirectory ?? '';
-      const uri = `${dir}${fileName}`;
-      await FileSystem.writeAsStringAsync(uri, buildBackupCodesBody(codes), { encoding: FileSystem.EncodingType.UTF8 });
-      await Share.share({ url: uri, message: buildBackupCodesBody(codes), title: fileName });
+      directory = await Directory.pickDirectoryAsync();
+    } catch {
+      return;
+    }
+    if (!directory) return;
+
+    try {
+      const file = directory.createFile(fileName, 'text/plain');
+      file.write(body);
       showToast(t(`${I18N}.backupCodesSaved`, { file: fileName }), 'success');
     } catch {
-      showToast(t('errors.copyFailed'), 'error');
+      showToast(t('errors.saveFileFailed'), 'error');
     }
   }, [buildBackupCodesBody, showToast]);
 

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -196,6 +196,7 @@ export default {
     regenerateBackupCodesFailed: "Failed to regenerate backup codes. Please try again.",
     copiedToClipboard: "Copied to clipboard",
     copyFailed: "Failed to copy. Please try again.",
+    saveFileFailed: "Could not save the file. Please try again.",
     getSessionsFailed: "Failed to load sessions. Please try again.",
     revokeSessionFailed: "Failed to revoke session. Please try again.",
     deleteAccountFailed: "Failed to delete account. Please try again.",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -197,6 +197,7 @@ export default {
     regenerateBackupCodesFailed: "Error al regenerar los códigos de respaldo. Por favor intenta de nuevo.",
     copiedToClipboard: "Copiado al portapapeles",
     copyFailed: "No se pudo copiar. Inténtalo de nuevo.",
+    saveFileFailed: "No se pudo guardar el archivo. Inténtalo de nuevo.",
     getSessionsFailed: "Error al cargar sesiones. Por favor intenta de nuevo.",
     revokeSessionFailed: "Error al revocar sesión. Por favor intenta de nuevo.",
     deleteAccountFailed: "Error al eliminar cuenta. Por favor intenta de nuevo.",


### PR DESCRIPTION
- Migra handleDownloadCodes a la API nueva de expo-file-system v19 (Directory.pickDirectoryAsync + createFile + write); la API legacy (writeAsStringAsync, documentDirectory, EncodingType) ya no funciona desde la importación por defecto en SDK 54 y arrojaba en runtime.
- "Guardar archivo" ahora abre el diálogo nativo del SO (SAF en Android, Document Picker en iOS) en lugar de la hoja de Compartir, que es lo esperado para esta acción y queda separada del botón "Compartir".
- Si el usuario cancela el selector, no se muestra error.
- Añade clave i18n dedicada errors.saveFileFailed (en/es) en vez de reusar errors.copyFailed, que producía el mensaje engañoso "No se pudo copiar. Inténtalo de nuevo." al fallar el guardado.
- Aplicado tanto en app/account/security.tsx (cliente) como en app/(provider-tabs)/profile/security.tsx (proveedor).