### PR TITLE
fix(complaints): correct submitter_type for support tickets (MDB-406)

### DIFF
--- a/app/account/complaints.tsx
+++ b/app/account/complaints.tsx
@@ -1,7 +1,7 @@
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { t } from '@/i18n';
 import { ApiError } from '@/services/auth';
-import { useMode } from '@/contexts/ModeContext';
+import { useMode, type UserMode } from '@/contexts/ModeContext';
 import {
   createComplaint,
   getComplaintMessages,
@@ -38,6 +38,10 @@ function typeLabel(type: ComplaintType): string {
   return t('complaints.typeSuggestion');
 }
 
+function submitterRoleLabel(m: UserMode): string {
+  return m === 'provider' ? t('complaints.submittingAsProvider') : t('complaints.submittingAsClient');
+}
+
 function statusLabel(status: string): string {
   switch (status) {
     case 'open':
@@ -63,7 +67,8 @@ export default function ComplaintsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
-  const { mode } = useMode();
+  const { mode, isLoading: isModeLoading } = useMode();
+  const isProviderContext = !isModeLoading && mode === 'provider';
   const queryClient = useQueryClient();
 
   const [type, setType] = useState<ComplaintType>('complaint');
@@ -203,6 +208,28 @@ export default function ComplaintsScreen() {
         >
           <Text style={[styles.subtitle, { color: colors.textTertiary }]}>{t('complaints.subtitle')}</Text>
 
+          {!isModeLoading ? (
+            <View
+              style={[
+                styles.roleBanner,
+                {
+                  backgroundColor: mode === 'provider' ? colors.primary + '22' : colors.card,
+                  borderColor: mode === 'provider' ? colors.primary + '55' : colors.cardBorder,
+                },
+              ]}
+            >
+              <Text style={[styles.roleBannerLabel, { color: colors.textSecondary }]}>
+                {t('complaints.submittingAsLabel')}
+              </Text>
+              <Text style={[styles.roleBannerValue, { color: colors.textPrimary }]}>
+                {submitterRoleLabel(mode)}
+              </Text>
+              <Text style={[styles.roleBannerHint, { color: colors.textTertiary }]}>
+                {mode === 'provider' ? t('complaints.contextHintProvider') : t('complaints.contextHintClient')}
+              </Text>
+            </View>
+          ) : null}
+
           <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>{t('complaints.typeLabel')}</Text>
           <View style={styles.typeRow}>
             {TYPES.map((tOption) => (
@@ -261,7 +288,7 @@ export default function ComplaintsScreen() {
           />
 
           <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>
-            {t('complaints.orderIdLabel')}
+            {isProviderContext ? t('complaints.orderIdLabelProvider') : t('complaints.orderIdLabel')}
           </Text>
           <TextInput
             style={[
@@ -270,7 +297,9 @@ export default function ComplaintsScreen() {
             ]}
             value={orderId}
             onChangeText={setOrderId}
-            placeholder={t('complaints.orderIdPlaceholder')}
+            placeholder={
+              isProviderContext ? t('complaints.orderIdPlaceholderProvider') : t('complaints.orderIdPlaceholder')
+            }
             placeholderTextColor={colors.textTertiary}
             autoCapitalize="none"
             autoCorrect={false}
@@ -282,13 +311,19 @@ export default function ComplaintsScreen() {
               {
                 backgroundColor: colors.primary,
                 opacity:
-                  submitMutation.isPending || subject.trim().length < 3 || description.trim().length < 10
+                  submitMutation.isPending ||
+                  isModeLoading ||
+                  subject.trim().length < 3 ||
+                  description.trim().length < 10
                     ? 0.5
                     : 1,
               },
             ]}
             disabled={
-              submitMutation.isPending || subject.trim().length < 3 || description.trim().length < 10
+              submitMutation.isPending ||
+              isModeLoading ||
+              subject.trim().length < 3 ||
+              description.trim().length < 10
             }
             onPress={() => {
               if (subject.trim().length < 3) {
@@ -335,7 +370,10 @@ export default function ComplaintsScreen() {
                     />
                   </View>
                   <Text style={[styles.cardMeta, { color: colors.textTertiary }]}>
-                    {typeLabel(item.type)} · {statusLabel(item.status)}
+                    {typeLabel(item.type)} · {statusLabel(item.status)} ·{' '}
+                    {item.submitterType === 'provider'
+                      ? t('complaints.submittingAsProvider')
+                      : t('complaints.submittingAsClient')}
                   </Text>
                   {expandedId !== item.id ? (
                     <Text style={[styles.cardPreview, { color: colors.textSecondary }]} numberOfLines={2}>
@@ -414,7 +452,16 @@ const styles = StyleSheet.create({
   headerPlaceholder: { width: 32 },
   scroll: { flex: 1 },
   scrollContent: { paddingHorizontal: 20, paddingTop: 16 },
-  subtitle: { fontSize: 14, lineHeight: 20, marginBottom: 20 },
+  subtitle: { fontSize: 14, lineHeight: 20, marginBottom: 16 },
+  roleBanner: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 14,
+    marginBottom: 20,
+  },
+  roleBannerLabel: { fontSize: 12, fontWeight: '600', marginBottom: 4 },
+  roleBannerValue: { fontSize: 16, fontWeight: '700', marginBottom: 8 },
+  roleBannerHint: { fontSize: 13, lineHeight: 18 },
   fieldLabel: { fontSize: 13, fontWeight: '600', marginBottom: 8, marginTop: 4 },
   typeRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
   typeChip: {

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -2111,6 +2111,13 @@ export default {
   complaints: {
     title: "Complaints & suggestions",
     subtitle: "Submit a formal complaint, claim, or suggestion. Our team will respond from the support center.",
+    submittingAsLabel: "You are submitting as",
+    submittingAsClient: "Client",
+    submittingAsProvider: "Provider",
+    contextHintClient:
+      "This submission is filed as a client. If you add an order, it must be one where you participated as the client.",
+    contextHintProvider:
+      "This submission is filed as a provider. If you add an order, it must be one where you were the assigned supplier.",
     typeLabel: "Type",
     typeComplaint: "Complaint",
     typeClaim: "Claim",
@@ -2120,7 +2127,9 @@ export default {
     descriptionLabel: "Description",
     descriptionPlaceholder: "Describe your case in detail",
     orderIdLabel: "Related order (optional)",
+    orderIdLabelProvider: "Related job order (optional)",
     orderIdPlaceholder: "Order ID if applicable",
+    orderIdPlaceholderProvider: "Order UUID where you were the provider",
     submit: "Submit",
     submitting: "Sending…",
     successTitle: "Received",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -2113,6 +2113,13 @@ export default {
   complaints: {
     title: "Quejas y sugerencias",
     subtitle: "Envía una queja formal, reclamación o sugerencia. Nuestro equipo responderá desde el centro de soporte.",
+    submittingAsLabel: "Estás enviando como",
+    submittingAsClient: "Cliente",
+    submittingAsProvider: "Proveedor",
+    contextHintClient:
+      "Lo que envíes queda registrado como cliente. Si añades un pedido, debe ser uno donde participaste como cliente.",
+    contextHintProvider:
+      "Lo que envíes queda registrado como proveedor. Si añades un pedido, debe ser uno donde fuiste el proveedor asignado.",
     typeLabel: "Tipo",
     typeComplaint: "Queja",
     typeClaim: "Reclamación",
@@ -2122,7 +2129,9 @@ export default {
     descriptionLabel: "Descripción",
     descriptionPlaceholder: "Describe tu caso con detalle",
     orderIdLabel: "Pedido relacionado (opcional)",
+    orderIdLabelProvider: "Pedido de tu trabajo (opcional)",
     orderIdPlaceholder: "ID del pedido si aplica",
+    orderIdPlaceholderProvider: "UUID del pedido donde fuiste proveedor",
     submit: "Enviar",
     submitting: "Enviando…",
     successTitle: "Recibido",

--- a/services/complaints.ts
+++ b/services/complaints.ts
@@ -65,7 +65,8 @@ export async function createComplaint(
         subject: payload.subject.trim(),
         description: payload.description.trim(),
         order_id: payload.order_id?.trim() || undefined,
-        submitter_type: payload.submitter_type,
+        // Always send explicitly so the key is never dropped (JSON.stringify omits undefined).
+        submitter_type: payload.submitter_type ?? 'client',
       }),
     },
     t('complaints.submitError')


### PR DESCRIPTION
- Block submit until user mode has loaded from settings so submitter_type is not sent as the default client while the UI is still in provider mode.
- Always JSON-serialize submitter_type (default client) so the field is never omitted when undefined.
- Show submitting-as Client/Provider context on the complaints form with new i18n keys (en/es) so users see which persona the ticket is filed under.