### PR TITLE
feat(notifications): MDB-400 i18n for job_started and provider paymen…

### DIFF
--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -51,6 +51,7 @@ function NotificationItem({ notification, onPress, colors, viewerRole }: Notific
       case 'payment_processed':
         return { icon: '💳', bgColor: '#10B981' };
       case 'provider_on_way':
+      case 'job_started':
         return { icon: '📍', bgColor: '#8B5CF6' };
       case 'quote_received':
         return { icon: '📋', bgColor: '#6366F1' };

--- a/app/notifications/[id].tsx
+++ b/app/notifications/[id].tsx
@@ -56,6 +56,7 @@ function getClientEmoji(type: NotificationType): { icon: string; bg: string } {
     case 'new_paid_booking':
       return { icon: '💳', bg: '#10B981' };
     case 'provider_on_way':
+    case 'job_started':
       return { icon: '📍', bg: '#8B5CF6' };
     case 'quote_received':
     case 'quote_approved':

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1122,6 +1122,11 @@ export default {
       new_message: {
         title: "New message",
       },
+      job_started: {
+        clientTitle: "Job started",
+        clientMessage: "%{supplierName} has started working on your service",
+        clientMessageWithService: "%{supplierName} has started working on your %{serviceName} service",
+      },
       job_review: {
         clientTitle: "Rate your experience",
         clientMessage: "Share feedback about your booking with %{supplierName}.",

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -1123,6 +1123,11 @@ export default {
       new_message: {
         title: "Nuevo mensaje",
       },
+      job_started: {
+        clientTitle: "Trabajo iniciado",
+        clientMessage: "%{supplierName} ha comenzado a trabajar en tu servicio",
+        clientMessageWithService: "%{supplierName} ha comenzado a trabajar en tu servicio de %{serviceName}",
+      },
       job_review: {
         clientTitle: "Valora tu experiencia",
         clientMessage: "Comparte tu opinión sobre tu reserva con %{supplierName}.",

--- a/services/notifications.ts
+++ b/services/notifications.ts
@@ -40,7 +40,8 @@ export type NotificationType =
   | 'new_review'
   | 'refund_issued'
   | 'job_pending_review'
-  | 'job_completed';
+  | 'job_completed'
+  | 'job_started';
 
 export interface NotificationsResponse {
   notifications: Notification[];
@@ -144,6 +145,7 @@ export function getNotificationCategory(type: NotificationType): NotificationCat
     case 'booking_confirmed':
     case 'booking_cancelled':
     case 'provider_on_way':
+    case 'job_started':
     case 'new_booking_request':
     case 'quote_received':
     case 'quote_approved':

--- a/utils/notificationDisplay.ts
+++ b/utils/notificationDisplay.ts
@@ -43,6 +43,51 @@ function pickNumber(m: Record<string, unknown>, ...keys: string[]): number | und
   return undefined;
 }
 
+/** When the API stores English copy in `message` but omits numeric metadata, recover fields for localized templates. */
+function parseProviderPaymentFromMessage(message: string | undefined): {
+  clientName: string;
+  amountStr: string;
+  serviceName: string;
+} | null {
+  if (!message?.trim()) return null;
+  const s = message.trim();
+  let m = /^(.+?)\s+has booked and paid\s+(\S+)\s+for\s+(.+?)\./i.exec(s);
+  if (m) {
+    return { clientName: m[1].trim(), amountStr: m[2].trim(), serviceName: m[3].trim() };
+  }
+  m = /^(.+?)\s+has paid\s+(\S+)\./i.exec(s);
+  if (m) {
+    return { clientName: m[1].trim(), amountStr: m[2].trim(), serviceName: '' };
+  }
+  m = /^(.+?)\s+reservó y pagó\s+(\S+)\s+por\s+(.+?)\./i.exec(s);
+  if (m) {
+    return { clientName: m[1].trim(), amountStr: m[2].trim(), serviceName: m[3].trim() };
+  }
+  m = /^(.+?)\s+reservo y pago\s+(\S+)\s+por\s+(.+?)\./i.exec(s);
+  if (m) {
+    return { clientName: m[1].trim(), amountStr: m[2].trim(), serviceName: m[3].trim() };
+  }
+  return null;
+}
+
+function parseStarsFromReviewMessage(message: string | undefined): number | undefined {
+  if (!message?.trim()) return undefined;
+  const starMatch =
+    /\bleft a (\d+)-star review\b/i.exec(message) ?? /\bdejó una reseña de (\d+) estrellas\b/i.exec(message);
+  if (!starMatch) return undefined;
+  const n = Number(starMatch[1]);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parseClientNameFromReviewMessage(message: string | undefined): string | undefined {
+  if (!message?.trim()) return undefined;
+  const nameMatch =
+    /^(.+?)\s+left a \d+-star review\b/i.exec(message) ?? /^(.+?)\s+dejó una reseña de \d+ estrellas\b/i.exec(message);
+  if (!nameMatch) return undefined;
+  const name = nameMatch[1].trim();
+  return name.length > 0 ? name : undefined;
+}
+
 function formatRefundCurrency(amount: number): string {
   const locale = getLocale() === 'es' ? 'es-MX' : 'en-US';
   return new Intl.NumberFormat(locale, { style: 'currency', currency: 'MXN' }).format(amount);
@@ -84,6 +129,9 @@ function inferNotificationTypeFromEnglishTitle(title: string | undefined): strin
     'nueva cotización': 'quote_received',
     'new message': 'new_message',
     'nuevo mensaje': 'new_message',
+    'job started': 'job_started',
+    'trabajo iniciado': 'job_started',
+    'servicio iniciado': 'job_started',
     'new review': 'new_review',
     'nueva reseña': 'new_review',
     'rate your service': 'rate_service',
@@ -118,6 +166,13 @@ function inferNotificationTypeFromMessageBody(message: string | undefined): stri
     /\breservo y pago\b/.test(m)
   ) {
     return 'payment_received';
+  }
+  if (
+    /\bhas started working on your service\b/.test(m) ||
+    /\bha comenzado a trabajar en tu servicio\b/.test(m) ||
+    /\bcomenzó a trabajar en tu servicio\b/.test(m)
+  ) {
+    return 'job_started';
   }
   if (/\bhas paid\b/.test(m) && /\baccept the booking\b/.test(m)) {
     return 'payment_received';
@@ -184,8 +239,6 @@ function typedDisplay(
     t('notifications.fallbackClient');
   const serviceName = pickString(m, 'serviceName', 'service_name', 'service') ?? '';
   const amountStr = formatNotificationMoney(m);
-  const stars = pickNumber(m, 'stars', 'rating', 'starRating', 'reviewRating');
-  const starsLabel = stars != null && Number.isFinite(stars) ? String(Math.round(stars)) : '';
 
   switch (type) {
     case 'booking_confirmed': {
@@ -230,14 +283,26 @@ function typedDisplay(
     }
     case 'payment_received': {
       if (viewerRole === 'provider') {
-        const hasMeta = !!(pickString(m, 'clientName', 'client_name') && (amountStr || serviceName));
+        const parsed = parseProviderPaymentFromMessage(notification.message);
+        const effClientName =
+          pickString(m, 'clientName', 'client_name', 'customerName', 'customer_name', 'userName', 'user_name') ??
+          parsed?.clientName ??
+          '';
+        const effAmountStr = amountStr || parsed?.amountStr || '';
+        const effServiceName =
+          pickString(m, 'serviceName', 'service_name', 'service') ?? parsed?.serviceName ?? '';
+        const hasMeta = !!(effClientName.trim() && (effAmountStr || effServiceName.trim()));
+        const svc =
+          effServiceName.trim() ||
+          serviceName ||
+          t('notifications.fallbackServiceShort');
         return {
           title: t('notifications.types.payment_received.providerTitle'),
           message: hasMeta
             ? t('notifications.types.payment_received.providerMessage', {
-                clientName,
-                amount: amountStr,
-                serviceName,
+                clientName: effClientName.trim() || clientName,
+                amount: effAmountStr,
+                serviceName: svc,
               })
             : notification.message,
         };
@@ -298,16 +363,23 @@ function typedDisplay(
     case 'new_review': {
       if (viewerRole !== 'provider') return null;
       const serviceLabel = serviceName || t('notifications.fallbackServiceShort');
+      const clientFromMeta = pickString(m, 'clientName', 'client_name', 'customerName', 'customer_name', 'userName', 'user_name');
+      const clientLabel =
+        clientFromMeta ?? parseClientNameFromReviewMessage(notification.message) ?? clientName;
+      const starsFromMeta = pickNumber(m, 'stars', 'rating', 'starRating', 'reviewRating');
+      const starsResolved = starsFromMeta ?? parseStarsFromReviewMessage(notification.message);
+      const starsResolvedLabel =
+        starsResolved != null && Number.isFinite(starsResolved) ? String(Math.round(starsResolved)) : '';
       return {
         title: t('notifications.types.new_review.providerTitle'),
-        message: starsLabel
+        message: starsResolvedLabel
           ? t('notifications.types.new_review.providerMessage', {
-              clientName,
-              stars: starsLabel,
+              clientName: clientLabel,
+              stars: starsResolvedLabel,
               serviceName: serviceLabel,
             })
           : t('notifications.types.new_review.providerMessageNoStars', {
-              clientName,
+              clientName: clientLabel,
               serviceName: serviceLabel,
             }),
       };
@@ -336,6 +408,15 @@ function typedDisplay(
       return {
         title: t('notifications.types.new_message.title'),
         message: preview ?? notification.message,
+      };
+    }
+    case 'job_started': {
+      if (viewerRole !== 'client') return null;
+      return {
+        title: t('notifications.types.job_started.clientTitle'),
+        message: serviceName
+          ? t('notifications.types.job_started.clientMessageWithService', { supplierName, serviceName })
+          : t('notifications.types.job_started.clientMessage', { supplierName }),
       };
     }
     case 'job_pending_review':

--- a/utils/notificationNavigation.ts
+++ b/utils/notificationNavigation.ts
@@ -58,6 +58,7 @@ function syncHrefForNotification(notification: Notification, mode: UserMode): st
       case 'payment_processed':
       case 'payment_received':
       case 'provider_on_way':
+      case 'job_started':
       case 'refund_issued':
         return orderId ? `/orders/${orderId}` : null;
       case 'new_message':

--- a/utils/notificationTypeCanonical.ts
+++ b/utils/notificationTypeCanonical.ts
@@ -9,6 +9,7 @@
 const KNOWN_NOTIFICATION_TYPES_DESC: string[] = [
   'new_booking_request',
   'job_pending_review',
+  'job_started',
   'booking_confirmed',
   'booking_cancelled',
   'payment_processed',


### PR DESCRIPTION
…t/review copy

- Add canonical type job_started with ES/EN strings and navigation to order.
- Parse English/Spanish provider payment bodies when metadata is missing so localized templates apply under Spanish locale.
- Infer job_started from title/body; improve new_review stars/client from message.
- Extend NotificationType and list/detail emoji mapping for job_started.