### PR TITLE
fix(provider-jobs): sync client avatar across related screens

### DIFF
--- a/app/(provider-tabs)/jobs/[id].tsx
+++ b/app/(provider-tabs)/jobs/[id].tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/contexts/AuthContext";
+import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
 import { hasProviderRatedClient } from "@/utils/providerClientRatedOrders";
@@ -158,9 +159,12 @@ export default function ProviderJobDetailScreen() {
         {/* Client card */}
         <View style={[styles.card, styles.section, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
           <View style={styles.clientRow}>
-            <View style={[styles.avatar, { backgroundColor: colors.background }]}>
-              <Ionicons name="person" size={28} color={colors.textSecondary} />
-            </View>
+            <ProviderAvatar
+              profileImage={job.clientProfileImage}
+              size={56}
+              rounded
+              style={[styles.avatar, { backgroundColor: colors.background }]}
+            />
             <View style={styles.clientInfo}>
               <Text style={[styles.clientName, { color: colors.textPrimary }]}>{job.clientName}</Text>
               {ratingLabel ?

--- a/app/(provider-tabs)/jobs/in-progress.tsx
+++ b/app/(provider-tabs)/jobs/in-progress.tsx
@@ -1,6 +1,7 @@
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
+import { ProviderAvatar } from "@/components/ProviderAvatar";
 import {
   getJobInProgressData,
   startJob,
@@ -349,9 +350,12 @@ export default function InProgressScreen() {
       <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Client Info */}
         <View style={[styles.clientCard, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
-          <View style={styles.clientAvatar}>
-            <Ionicons name="person" size={24} color={colors.icon} />
-          </View>
+          <ProviderAvatar
+            profileImage={data.client.profile_image}
+            size={44}
+            rounded
+            style={styles.clientAvatar}
+          />
           <View style={styles.clientInfo}>
             <Text style={[styles.clientName, { color: colors.textPrimary }]}>{data.client.fullName}</Text>
             <Text style={[styles.clientService, { color: colors.textSecondary }]}>{data.order.serviceName}</Text>

--- a/app/(provider-tabs)/jobs/rate-client.tsx
+++ b/app/(provider-tabs)/jobs/rate-client.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/contexts/AuthContext";
+import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
@@ -60,7 +61,7 @@ export default function RateClientScreen() {
 
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
-  const [clientData, setClientData] = useState<{ fullName: string; serviceName: string } | null>(null);
+  const [clientData, setClientData] = useState<{ fullName: string; serviceName: string; profileImage?: string } | null>(null);
   const [orderStatus, setOrderStatus] = useState<string | null>(null);
   const [rating, setRating] = useState(5);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -77,6 +78,7 @@ export default function RateClientScreen() {
         setClientData({
           fullName: data.client.fullName,
           serviceName: data.order.serviceName,
+          profileImage: data.client.profile_image,
         });
         setOrderStatus(data.order.status ?? null);
       } catch (err) {
@@ -175,9 +177,12 @@ export default function RateClientScreen() {
       >
         {/* Client Avatar & Info */}
         <View style={styles.clientSection}>
-          <View style={[styles.clientAvatarLarge, { backgroundColor: colors.card }]}>
-            <Ionicons name="person" size={40} color={colors.textSecondary} />
-          </View>
+          <ProviderAvatar
+            profileImage={clientData?.profileImage}
+            size={80}
+            rounded
+            style={[styles.clientAvatarLarge, { backgroundColor: colors.card }]}
+          />
           <Text style={[styles.clientNameLarge, { color: colors.textPrimary }]}>{clientData?.fullName ?? "—"}</Text>
           <Text style={[styles.clientServiceLabel, { color: colors.textTertiary }]}>{clientData?.serviceName ?? ""}</Text>
         </View>

--- a/services/providerDashboard.ts
+++ b/services/providerDashboard.ts
@@ -1,6 +1,7 @@
 import { t } from "@/i18n";
 import { request } from "./auth";
 import { getProviderServices } from "./providerServices";
+import { coerceSupplierProfileImage } from "./suppliers";
 
 export interface ProviderDashboardStats {
   todayEarnings: number;
@@ -206,6 +207,7 @@ export interface ProviderActiveJob {
   orderId: string;
   clientId: string;
   clientName: string;
+  clientProfileImage?: string;
   clientPhone?: string;
   serviceId: string;
   serviceName: string;
@@ -457,6 +459,7 @@ export interface JobCompletionData {
   client: {
     id: string;
     fullName: string;
+    profile_image?: string;
   };
   lineItems: JobCompletionLineItem[];
   subtotal: number;
@@ -490,7 +493,7 @@ export interface CompleteJobResponse {
 }
 
 export const getJobCompletionData = async (orderId: string): Promise<JobCompletionData> => {
-  return request<JobCompletionData>(
+  const data = await request<JobCompletionData>(
     `/api/providers/orders/${orderId}/completion-data`,
     {
       method: "GET",
@@ -498,6 +501,20 @@ export const getJobCompletionData = async (orderId: string): Promise<JobCompleti
     },
     t("providerDashboard.completeJob.errors.loadFailed"),
   );
+  const raw = data as unknown as Record<string, unknown>;
+  const rawClient =
+    raw.client && typeof raw.client === "object" && !Array.isArray(raw.client)
+      ? (raw.client as Record<string, unknown>)
+      : null;
+  const profileImage = coerceSupplierProfileImage(rawClient ?? raw);
+  if (!profileImage) return data;
+  return {
+    ...data,
+    client: {
+      ...data.client,
+      profile_image: profileImage,
+    },
+  };
 };
 
 export const completeJob = async (orderId: string, data: CompleteJobPayload): Promise<CompleteJobResponse> => {
@@ -537,6 +554,7 @@ export interface JobInProgressData {
     id: string;
     fullName: string;
     phone: string | null;
+    profile_image?: string;
   };
   tasks: JobTask[];
   agreedPrice: number;
@@ -544,7 +562,7 @@ export interface JobInProgressData {
 }
 
 export const getJobInProgressData = async (orderId: string): Promise<JobInProgressData> => {
-  return request<JobInProgressData>(
+  const data = await request<JobInProgressData>(
     `/api/providers/orders/${orderId}/in-progress`,
     {
       method: "GET",
@@ -552,6 +570,20 @@ export const getJobInProgressData = async (orderId: string): Promise<JobInProgre
     },
     t("providerDashboard.inProgress.errors.loadFailed"),
   );
+  const raw = data as unknown as Record<string, unknown>;
+  const rawClient =
+    raw.client && typeof raw.client === "object" && !Array.isArray(raw.client)
+      ? (raw.client as Record<string, unknown>)
+      : null;
+  const profileImage = coerceSupplierProfileImage(rawClient ?? raw);
+  if (!profileImage) return data;
+  return {
+    ...data,
+    client: {
+      ...data.client,
+      profile_image: profileImage,
+    },
+  };
 };
 
 export const updateJobTask = async (
@@ -695,7 +727,15 @@ export const getProviderActiveJobs = async (): Promise<ProviderActiveJob[]> => {
     },
     t("providerDashboard.errors.activeJobsFailed"),
   );
-  return res?.jobs ?? [];
+  const jobs = res?.jobs ?? [];
+  return jobs.map((job) => {
+    const profileImage = coerceSupplierProfileImage(job as unknown as Record<string, unknown>);
+    if (!profileImage) return job;
+    return {
+      ...job,
+      clientProfileImage: profileImage,
+    };
+  });
 };
 
 // ========== PAYMENT METHODS (BANK ACCOUNTS) ==========


### PR DESCRIPTION
Normalize client profile image fields from provider dashboard endpoints and render avatars with ProviderAvatar in Job Detail, In Progress, and Rate Client screens so the same client photo shown in chat is consistently displayed across provider job flows.