### PR TITLE
fix(profile-images): show avatars on bookings, jobs list, and top pro…

### DIFF
--- a/app/(provider-tabs)/jobs/index.tsx
+++ b/app/(provider-tabs)/jobs/index.tsx
@@ -1,3 +1,4 @@
+import { ProviderAvatar } from "@/components/ProviderAvatar";
 import { useAuth } from "@/contexts/AuthContext";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { t } from "@/i18n";
@@ -127,9 +128,12 @@ function JobCard({
       <View style={styles.cardBody}>
         <View style={styles.cardHeader}>
           <View style={styles.cardHeaderLeft}>
-            <View style={styles.avatar}>
-              <Ionicons name="person" size={22} color={colors.textTertiary} />
-            </View>
+            <ProviderAvatar
+              profileImage={job.clientProfileImage}
+              size={44}
+              rounded
+              style={styles.avatar}
+            />
             <View>
               <Text style={[styles.clientName, { color: colors.textPrimary }]}>{job.clientName}</Text>
               <Text style={styles.serviceName}>{job.serviceName}</Text>

--- a/app/(tabs)/bookings.tsx
+++ b/app/(tabs)/bookings.tsx
@@ -1,4 +1,5 @@
 import { EmptyState } from '@/components/EmptyState';
+import { ProviderAvatar } from '@/components/ProviderAvatar';
 import { t, getLocale } from '@/i18n';
 import { getOrCreateConversation } from '@/services/conversations';
 import { fetchOrders, Order, OrderStatus } from '@/services/orders';
@@ -8,7 +9,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
-  Image,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -150,9 +150,12 @@ function BookingCard({ order, onPress, onMessagePress, onReviewQuote, onPayPress
       </View>
 
       <View style={styles.bookingContent}>
-        <View style={[styles.providerImage, { backgroundColor: themeColors.surfaceSecondary }]}>
-          <Ionicons name="person" size={24} color={themeColors.textSecondary} />
-        </View>
+        <ProviderAvatar
+          profileImage={order.supplier_profile_image}
+          size={48}
+          rounded
+          style={[styles.providerImage, { backgroundColor: themeColors.surfaceSecondary }]}
+        />
         
         <View style={styles.bookingInfo}>
           <Text style={[styles.providerName, { color: themeColors.textPrimary }]}>

--- a/services/orders.ts
+++ b/services/orders.ts
@@ -25,6 +25,7 @@ export interface Order {
   service_description?: string;
   supplier_name?: string;
   business_name?: string;
+  supplier_profile_image?: string;
 }
 
 export interface Quote {
@@ -165,7 +166,12 @@ export const fetchOrders = async (): Promise<Order[]> => {
       },
       t('errors.requestFailed')
     );
-    return data.orders || [];
+    const orders = data.orders ?? [];
+    return orders.map((order) => {
+      const profile_image = coerceSupplierProfileImage(order as unknown as Record<string, unknown>);
+      if (!profile_image) return order;
+      return { ...order, supplier_profile_image: profile_image };
+    });
   } catch (error) {
     if (error instanceof AuthApiError) {
       throw new ApiError(error.message, error.status, error.data);

--- a/services/suppliers.ts
+++ b/services/suppliers.ts
@@ -7,10 +7,27 @@ import { createApiHeaders } from '@/utils/apiHeaders';
  * (provider profile uses avatar_url; list/detail endpoints may use profile_image*).
  */
 export function coerceSupplierProfileImage(raw: Record<string, unknown>): string | undefined {
-  const keys = ['profile_image_url', 'profile_image', 'profileImage', 'avatar_url', 'avatarUrl'] as const;
+  // Prefer raw profile_image so the app resolves URLs with EXPO_PUBLIC_API_URL (avoids stale API_PUBLIC_URL absolutes).
+  const keys = [
+    'profile_image',
+    'profileImage',
+    'profile_image_url',
+    'avatar_url',
+    'avatarUrl',
+    'clientProfileImage',
+    'client_profile_image',
+    'client_avatar',
+    'clientAvatar',
+    'supplier_profile_image',
+    'supplierProfileImage',
+  ] as const;
   for (const key of keys) {
     const v = raw[key];
     if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  const nested = raw.client;
+  if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+    return coerceSupplierProfileImage(nested as Record<string, unknown>);
   }
   return undefined;
 }
@@ -169,10 +186,10 @@ export const fetchSuppliers = async (
     // Ensure suppliers is always an array and normalize profile_image (API may send snake_case;
     // accept profile_image_url / avatar_url when present so images stay in sync with provider avatars)
     const rawSuppliers = Array.isArray(jsonData.suppliers) ? jsonData.suppliers : [];
-    const suppliers = rawSuppliers.map((s: Record<string, unknown>) => ({
-      ...s,
-      profile_image: coerceSupplierProfileImage(s),
-    }));
+    const suppliers = rawSuppliers.map((s: Record<string, unknown>) => {
+      const profile_image = coerceSupplierProfileImage(s);
+      return profile_image ? { ...s, profile_image } : s;
+    }) as Supplier[];
     
     // Ensure total is always a number
     const total = typeof jsonData.total === 'number' ? jsonData.total : suppliers.length;


### PR DESCRIPTION
…viders

- Extend coerceSupplierProfileImage for client/supplier API field aliases and nested client objects; prefer raw profile_image so URLs resolve with EXPO_PUBLIC_API_URL.
- Map supplier_profile_image from GET /orders for My Bookings cards.
- Replace placeholder icons with ProviderAvatar on client bookings and provider jobs list.