### PR TITLE
fix(profile-images): resolve provider/client avatar URLs for chat and…

### DIFF
--- a/services/conversations.ts
+++ b/services/conversations.ts
@@ -1,6 +1,35 @@
 import { request, ApiError } from './auth';
 import { t } from '@/i18n';
 import type { OrderStatus } from './orders';
+import { coerceSupplierProfileImage } from './suppliers';
+
+function normalizeConversationDetail(conv: ConversationDetail): ConversationDetail {
+  const raw = conv as unknown as Record<string, unknown>;
+  const supplierImage = coerceSupplierProfileImage({
+    supplier_image: raw.supplier_image,
+    profile_image: raw.supplier_image,
+  });
+  const clientImage = coerceSupplierProfileImage({
+    client_image: raw.client_image,
+    profile_image: raw.client_image,
+  });
+  return {
+    ...conv,
+    supplier_image: supplierImage ?? conv.supplier_image ?? null,
+    client_image: clientImage ?? conv.client_image ?? null,
+  };
+}
+
+function normalizeConversationListItem(conv: Conversation): Conversation {
+  const image = coerceSupplierProfileImage({
+    other_user_image: conv.other_user_image,
+    profile_image: conv.other_user_image,
+  });
+  return {
+    ...conv,
+    other_user_image: image ?? conv.other_user_image ?? null,
+  };
+}
 
 export interface Conversation {
   id: string;
@@ -65,17 +94,19 @@ export const fetchConversations = async (role?: ConversationRole): Promise<Conve
     if (!data.conversations) {
       throw new ApiError('Invalid response format: missing conversations', 500);
     }
-    return data.conversations.map((conv) => ({
-      ...conv,
-      last_message_at: conv.last_message_at || null,
-      last_message: conv.last_message || null,
-      other_user_image: conv.other_user_image || null,
-      unread_count: typeof conv.unread_count === 'number' ? conv.unread_count : 0,
-      active_order_status: conv.active_order_status ?? null,
-      active_order_has_client_payment: Boolean(
-        (conv as { active_order_has_client_payment?: boolean }).active_order_has_client_payment,
-      ),
-    }));
+    return data.conversations.map((conv) =>
+      normalizeConversationListItem({
+        ...conv,
+        last_message_at: conv.last_message_at || null,
+        last_message: conv.last_message || null,
+        other_user_image: conv.other_user_image || null,
+        unread_count: typeof conv.unread_count === 'number' ? conv.unread_count : 0,
+        active_order_status: conv.active_order_status ?? null,
+        active_order_has_client_payment: Boolean(
+          (conv as { active_order_has_client_payment?: boolean }).active_order_has_client_payment,
+        ),
+      }),
+    );
   } catch (error) {
     if (error instanceof ApiError) throw error;
     throw new ApiError('Network error. Please check your connection.', 0, error);
@@ -102,7 +133,7 @@ export const getOrCreateConversation = async (
   orderId?: string
 ): Promise<{ conversation: ConversationDetail; created: boolean }> => {
   try {
-    return await request<{ conversation: ConversationDetail; created: boolean }>(
+    const result = await request<{ conversation: ConversationDetail; created: boolean }>(
       '/conversations',
       {
         method: 'POST',
@@ -110,6 +141,10 @@ export const getOrCreateConversation = async (
       },
       'Failed to create conversation'
     );
+    return {
+      ...result,
+      conversation: normalizeConversationDetail(result.conversation),
+    };
   } catch (error) {
     if (error instanceof ApiError) throw error;
     throw new ApiError('Network error. Please check your connection.', 0, error);
@@ -124,7 +159,7 @@ export const fetchConversation = async (conversationId: string): Promise<Convers
       { method: 'GET' },
       'Failed to fetch conversation'
     );
-    return data.conversation;
+    return normalizeConversationDetail(data.conversation);
   } catch (error) {
     if (error instanceof ApiError) throw error;
     throw new ApiError('Network error. Please check your connection.', 0, error);

--- a/utils/profileImage.ts
+++ b/utils/profileImage.ts
@@ -15,13 +15,15 @@ function isDevLoopbackHostname(hostname: string): boolean {
 }
 
 /**
- * If the API stored an absolute URL with localhost / 127.0.0.1 / Android emulator host,
- * rewrite it to the app's current API origin so images still load on real devices and after updates.
+ * Rewrites absolute profile image URLs that point at this app's API /uploads/ path
+ * (or loopback dev hosts) to the current API_BASE so avatars load on QA/prod and real devices.
  */
-function rewriteDevLoopbackAbsoluteUrl(trimmed: string): string {
+function rewriteAbsoluteProfileUrl(trimmed: string): string {
   try {
     const parsed = new URL(trimmed);
-    if (!isDevLoopbackHostname(parsed.hostname)) return trimmed;
+    const isLoopback = isDevLoopbackHostname(parsed.hostname);
+    const isApiUpload = parsed.pathname.includes('/uploads/');
+    if (!isLoopback && !isApiUpload) return trimmed;
     const origin = API_BASE.replace(/\/$/, '');
     return `${origin}${parsed.pathname}${parsed.search}`;
   } catch {
@@ -44,7 +46,7 @@ export function getProfileImageUrl(url: string | null | undefined): string | nul
   if (trimmed.startsWith('file:')) return null;
   if (trimmed.startsWith('data:')) return trimmed;
   if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    return rewriteDevLoopbackAbsoluteUrl(trimmed);
+    return rewriteAbsoluteProfileUrl(trimmed);
   }
   const base = API_BASE.replace(/\/$/, '');
   const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;


### PR DESCRIPTION
… home

- Rewrite absolute /uploads/ and loopback hosts in getProfileImageUrl using EXPO_PUBLIC_API_URL so QA devices load avatars stored with dev or stale API hosts.
- Normalize other_user_image, supplier_image, and client_image in conversation list, detail, and create flows via coerceSupplierProfileImage.