### PR TITLE
fix(service-area): prevent fatal crash when Google Maps API key is mi…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ EXPO_PUBLIC_API_URL=https://mordobo-api-qa.onrender.com
 EXPO_PUBLIC_SUPABASE_URL=
 EXPO_PUBLIC_SUPABASE_ANON_KEY=
 
+# Google Maps (required for Service Area map on Android)
+EXPO_PUBLIC_GOOGLE_MAPS_API_KEY=
+
 # Google Sign-In (Expo / native)
 # EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=
 # EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=

--- a/components/ServiceAreaMap.native.tsx
+++ b/components/ServiceAreaMap.native.tsx
@@ -118,6 +118,17 @@ export const ServiceAreaMap = forwardRef<ServiceAreaMapHandle, ServiceAreaMapPro
   const isExpoGo = Constants.appOwnership === 'expo';
   const showAndroidKeyHint = Platform.OS === 'android' && googleMapsApiKey.length === 0 && !isExpoGo;
 
+  if (showAndroidKeyHint) {
+    return (
+      <View style={styles.mapBox} collapsable={false}>
+        <View style={styles.keyMissingFallback}>
+          <Text style={styles.keyMissingIcon}>🗺️</Text>
+          <Text style={styles.keyMissingText}>{t('providerDashboard.providerServiceArea.mapsAndroidKeyHint')}</Text>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.mapBox} collapsable={false}>
       {!mapReady && (
@@ -125,11 +136,6 @@ export const ServiceAreaMap = forwardRef<ServiceAreaMapHandle, ServiceAreaMapPro
           <ActivityIndicator size="large" color={primaryColor} />
         </View>
       )}
-      {showAndroidKeyHint ? (
-        <View style={styles.keyMissingBanner}>
-          <Text style={styles.keyMissingText}>{t('providerDashboard.providerServiceArea.mapsAndroidKeyHint')}</Text>
-        </View>
-      ) : null}
       <MapView
         ref={mapRef}
         style={styles.mapFill}
@@ -184,20 +190,21 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.15)',
     zIndex: 2,
   },
-  keyMissingBanner: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    zIndex: 3,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    backgroundColor: 'rgba(180,83,9,0.92)',
+  keyMissingFallback: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(180,83,9,0.12)',
+    paddingHorizontal: 24,
+    gap: 8,
+  },
+  keyMissingIcon: {
+    fontSize: 32,
   },
   keyMissingText: {
-    color: '#fff',
-    fontSize: 11,
+    color: '#92400e',
+    fontSize: 13,
     textAlign: 'center',
-    lineHeight: 15,
+    lineHeight: 18,
   },
 });


### PR DESCRIPTION
…ssing on Android

The Service Area screen crashed the app on Android because the MapView from react-native-maps was rendered even when EXPO_PUBLIC_GOOGLE_MAPS_API_KEY was unset, causing Google Maps SDK to throw an IllegalStateException.

- Return a fallback UI early in ServiceAreaMap.native.tsx when the API key is empty on Android instead of rendering MapView, preventing the crash.
- Document EXPO_PUBLIC_GOOGLE_MAPS_API_KEY in .env.example so it is visible to developers during project setup.